### PR TITLE
fix(auth): Update CSP to allow Google OAuth API calls

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -23,6 +23,7 @@ server {
             https://ai.google.dev
             https://generativelanguage.googleapis.com
             https://www.googleapis.com
+            https://*.googleapis.com
             https://oauth2.googleapis.com
             https://accounts.google.com
             https://*.googleusercontent.com

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,7 +24,7 @@ export default defineConfig(({ mode }) => {
           "style-src 'self' 'unsafe-inline'", // unsafe-inline needed for styled components
           "img-src 'self' data: https: blob:", // Allow images from data URIs, HTTPS, and blob URLs
           "font-src 'self' data:",
-          "connect-src 'self' https://ai.google.dev https://*.supabase.co wss://*.supabase.co https://n8n-n8n.w9jo16.easypanel.host https://project-management-docker.w9jo16.easypanel.host",
+          "connect-src 'self' https://ai.google.dev https://*.supabase.co wss://*.supabase.co https://n8n-n8n.w9jo16.easypanel.host https://project-management-docker.w9jo16.easypanel.host https://www.googleapis.com https://*.googleapis.com https://oauth2.googleapis.com https://accounts.google.com https://*.googleusercontent.com",
           "media-src 'self' blob: data:",
           "object-src 'none'",
           "frame-ancestors 'none'",


### PR DESCRIPTION
## 🎯 Resumo

Corrige o bloqueio de Content Security Policy (CSP) que impedia chamadas à API do Google durante o fluxo de autenticação OAuth.

## 🐛 Problema

O login OAuth com Google estava funcionando, mas a chamada para obter informações do usuário (`https://www.googleapis.com/oauth2/v2/userinfo`) estava sendo bloqueada pela CSP, gerando o seguinte erro no console:

```
Connecting to 'https://www.googleapis.com/oauth2/v2/userinfo' violates the following 
Content Security Policy directive: "connect-src 'self' https://ai.google.dev 
https://*.supabase.co wss://*.supabase.co https://n8n-n8n.w9jo16.easypanel.host 
https://project-management-docker.w9jo16.easypanel.host"
```

## 🔧 Solução

Atualizou a diretiva `connect-src` da CSP em ambos os ambientes (desenvolvimento e produção) para incluir os domínios necessários das APIs do Google.

### Arquivos Modificados

1. **vite.config.ts** (desenvolvimento)
   - Linha 27: Expandida a diretiva `connect-src` para incluir:
     - `https://www.googleapis.com`
     - `https://*.googleapis.com`
     - `https://oauth2.googleapis.com`
     - `https://accounts.google.com`
     - `https://*.googleusercontent.com`

2. **nginx.conf** (produção)
   - Linha 26: Adicionado padrão wildcard `https://*.googleapis.com`

## ✅ Resultado Esperado

Após o merge e deploy:
- ✅ Chamadas para `https://www.googleapis.com/oauth2/v2/userinfo` funcionarão
- ✅ Erro de CSP no console desaparecerá
- ✅ Informações do usuário Google serão obtidas corretamente
- ✅ Segurança mantida - CSP continua protegendo contra XSS

## 🧪 Plano de Teste

- [ ] Testar login OAuth com Google em desenvolvimento
- [ ] Verificar que não há erros de CSP no console
- [ ] Confirmar que informações do usuário são obtidas com sucesso
- [ ] Testar em produção após deploy

## 🔒 Nota de Segurança

Todos os domínios adicionados são APIs e serviços oficiais do Google:
- `googleapis.com` - APIs públicas do Google
- `oauth2.googleapis.com` - Autenticação OAuth 2.0
- `accounts.google.com` - Gerenciamento de contas Google
- `googleusercontent.com` - Conteúdo gerado por usuários de serviços Google

## 📊 Impacto

- **Prioridade**: 🔴 Alta
- **Breaking Changes**: Não
- **Rollback**: Fácil (revert do commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)