### PR TITLE
Fix OAuth PKCE 401 error with cookie storage

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,35 +1,120 @@
 /**
  * useAuth Hook
- * React hook for accessing authentication state
+ * React hook for accessing authentication state with PKCE support
+ *
+ * Handles:
+ * - Initial session retrieval from cookies
+ * - OAuth PKCE code exchange on callback
+ * - Auth state change subscriptions
  */
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { supabase } from '../services/supabaseClient'
 import type { User, Session } from '@supabase/supabase-js'
+
+/**
+ * Checks if the current URL contains an OAuth callback code
+ */
+function hasAuthCodeInUrl(): boolean {
+  const params = new URLSearchParams(window.location.search)
+  return params.has('code')
+}
+
+/**
+ * Cleans auth parameters from URL after processing
+ */
+function cleanAuthParamsFromUrl(): void {
+  const url = new URL(window.location.href)
+  url.searchParams.delete('code')
+  url.searchParams.delete('error')
+  url.searchParams.delete('error_description')
+  window.history.replaceState({}, '', url.pathname + url.search + url.hash)
+}
 
 export function useAuth() {
   const [user, setUser] = useState<User | null>(null)
   const [session, setSession] = useState<Session | null>(null)
   const [isLoading, setIsLoading] = useState(true)
+  const codeExchangeAttempted = useRef(false)
 
   useEffect(() => {
-    // Get initial session
-    supabase.auth.getSession().then(({ data: { session } }) => {
-      setSession(session)
-      setUser(session?.user ?? null)
-      setIsLoading(false)
-    })
+    let isMounted = true
 
-    // Listen for auth changes
+    async function initializeAuth() {
+      try {
+        // Step 1: Check if this is an OAuth callback with a code
+        // PKCE flow: The authorization server returns a 'code' that must be
+        // exchanged for tokens using the stored 'code_verifier'
+        if (hasAuthCodeInUrl() && !codeExchangeAttempted.current) {
+          codeExchangeAttempted.current = true
+          console.log('[useAuth] OAuth callback detected, exchanging code for session...')
+
+          try {
+            // exchangeCodeForSession uses the code_verifier stored in cookies
+            // to complete the PKCE exchange
+            const { data, error } = await supabase.auth.exchangeCodeForSession(
+              new URLSearchParams(window.location.search).get('code')!
+            )
+
+            if (error) {
+              console.error('[useAuth] PKCE code exchange failed:', error.message)
+              // Clean URL even on error to prevent retry loops
+              cleanAuthParamsFromUrl()
+            } else if (data.session) {
+              console.log('[useAuth] PKCE code exchange successful')
+              if (isMounted) {
+                setSession(data.session)
+                setUser(data.session.user)
+                setIsLoading(false)
+              }
+              // Clean the URL after successful exchange
+              cleanAuthParamsFromUrl()
+              return // Early return, session is set
+            }
+          } catch (exchangeError) {
+            console.error('[useAuth] Error during code exchange:', exchangeError)
+            cleanAuthParamsFromUrl()
+          }
+        }
+
+        // Step 2: Get existing session from storage (cookies)
+        const { data: { session: existingSession }, error } = await supabase.auth.getSession()
+
+        if (error) {
+          console.error('[useAuth] Error getting session:', error.message)
+        }
+
+        if (isMounted) {
+          setSession(existingSession)
+          setUser(existingSession?.user ?? null)
+          setIsLoading(false)
+        }
+      } catch (error) {
+        console.error('[useAuth] Initialization error:', error)
+        if (isMounted) {
+          setIsLoading(false)
+        }
+      }
+    }
+
+    initializeAuth()
+
+    // Listen for auth changes (sign in, sign out, token refresh)
     const {
       data: { subscription },
-    } = supabase.auth.onAuthStateChange((_event, session) => {
-      setSession(session)
-      setUser(session?.user ?? null)
-      setIsLoading(false)
+    } = supabase.auth.onAuthStateChange((event, newSession) => {
+      console.log('[useAuth] Auth state changed:', event)
+      if (isMounted) {
+        setSession(newSession)
+        setUser(newSession?.user ?? null)
+        setIsLoading(false)
+      }
     })
 
-    return () => subscription.unsubscribe()
+    return () => {
+      isMounted = false
+      subscription.unsubscribe()
+    }
   }, [])
 
   return {

--- a/src/lib/supabase/cookieStorageAdapter.ts
+++ b/src/lib/supabase/cookieStorageAdapter.ts
@@ -2,31 +2,53 @@ import type { CookieOptions } from '@supabase/ssr';
 
 /**
  * Cookie Storage Adapter for Client-Side (Browser)
- * Permite @supabase/ssr usar cookies no browser, resolvendo problemas de stateless containers
+ *
+ * This adapter properly handles:
+ * - Cookie chunking for large tokens (required for PKCE/JWT)
+ * - Cross-domain OAuth redirects
+ * - Stateless container deployments (Cloud Run)
+ *
+ * IMPORTANT: Supabase stores large JSON payloads that may exceed cookie size limits.
+ * This adapter automatically chunks values across multiple cookies.
  */
+
+const CHUNK_SIZE = 3500; // Safe size under 4096 byte cookie limit (leaving room for name + metadata)
+const CHUNK_SEPARATOR = '.';
 
 const getDefaultCookieOptions = (): Partial<CookieOptions> => {
   const isProduction = window.location.protocol === 'https:';
 
   return {
     path: '/',
-    sameSite: 'lax',      // Permite OAuth redirects
-    secure: isProduction, // true em HTTPS (produção)
-    maxAge: 60 * 60 * 24 * 7, // 7 dias
+    sameSite: 'lax',      // Required for OAuth redirects
+    secure: isProduction, // true in HTTPS (production)
+    maxAge: 60 * 60 * 24 * 7, // 7 days
   };
 };
 
 function parseCookies(): Record<string, string> {
+  if (typeof document === 'undefined') return {};
+
   return document.cookie.split('; ').reduce((acc, cookie) => {
-    const [key, value] = cookie.split('=');
-    if (key && value) {
-      acc[key] = decodeURIComponent(value);
+    const separatorIndex = cookie.indexOf('=');
+    if (separatorIndex > 0) {
+      const key = cookie.substring(0, separatorIndex);
+      const value = cookie.substring(separatorIndex + 1);
+      if (key && value) {
+        try {
+          acc[key] = decodeURIComponent(value);
+        } catch {
+          acc[key] = value;
+        }
+      }
     }
     return acc;
   }, {} as Record<string, string>);
 }
 
 function setCookie(name: string, value: string, options: Partial<CookieOptions> = {}): void {
+  if (typeof document === 'undefined') return;
+
   const opts = { ...getDefaultCookieOptions(), ...options };
 
   let cookieString = `${name}=${encodeURIComponent(value)}`;
@@ -45,21 +67,100 @@ function deleteCookie(name: string, options: Partial<CookieOptions> = {}): void 
 }
 
 /**
- * Create cookies getter/setter for @supabase/ssr
+ * Chunks a large value into multiple cookie-safe pieces
+ */
+function chunkValue(value: string): string[] {
+  const chunks: string[] = [];
+  for (let i = 0; i < value.length; i += CHUNK_SIZE) {
+    chunks.push(value.substring(i, i + CHUNK_SIZE));
+  }
+  return chunks;
+}
+
+/**
+ * Gets all chunk cookie names for a base name
+ */
+function getChunkNames(baseName: string, cookies: Record<string, string>): string[] {
+  const names: string[] = [];
+  let i = 0;
+  while (cookies[`${baseName}${CHUNK_SEPARATOR}${i}`] !== undefined) {
+    names.push(`${baseName}${CHUNK_SEPARATOR}${i}`);
+    i++;
+  }
+  return names;
+}
+
+/**
+ * Create cookies getter/setter for @supabase/ssr with chunking support
+ *
+ * This is critical for PKCE flow where:
+ * 1. code_verifier is stored before OAuth redirect
+ * 2. After callback, code_verifier is retrieved to exchange for tokens
+ * 3. Large session tokens are stored after successful auth
  */
 export function createCookieHandlers() {
   return {
-    get(name: string) {
+    /**
+     * Get a cookie value, reassembling chunks if necessary
+     */
+    get(name: string): string | undefined {
       const cookies = parseCookies();
-      return cookies[name];
+
+      // Check for single cookie first
+      if (cookies[name] !== undefined) {
+        return cookies[name];
+      }
+
+      // Check for chunked cookies
+      const chunkNames = getChunkNames(name, cookies);
+      if (chunkNames.length > 0) {
+        // Reassemble chunks
+        return chunkNames.map(chunkName => cookies[chunkName]).join('');
+      }
+
+      return undefined;
     },
 
-    set(name: string, value: string, options: CookieOptions) {
-      setCookie(name, value, options);
+    /**
+     * Set a cookie value, chunking if necessary
+     */
+    set(name: string, value: string, options: CookieOptions): void {
+      const cookies = parseCookies();
+
+      // First, remove any existing chunks for this cookie
+      const existingChunks = getChunkNames(name, cookies);
+      existingChunks.forEach(chunkName => deleteCookie(chunkName, options));
+
+      // Also remove the base cookie if it exists
+      if (cookies[name] !== undefined) {
+        deleteCookie(name, options);
+      }
+
+      // If value is small enough, store directly
+      if (value.length <= CHUNK_SIZE) {
+        setCookie(name, value, options);
+        return;
+      }
+
+      // Otherwise, chunk the value
+      const chunks = chunkValue(value);
+      chunks.forEach((chunk, index) => {
+        setCookie(`${name}${CHUNK_SEPARATOR}${index}`, chunk, options);
+      });
     },
 
-    remove(name: string, options: CookieOptions) {
+    /**
+     * Remove a cookie and all its chunks
+     */
+    remove(name: string, options: CookieOptions): void {
+      const cookies = parseCookies();
+
+      // Remove base cookie
       deleteCookie(name, options);
+
+      // Remove all chunks
+      const chunkNames = getChunkNames(name, cookies);
+      chunkNames.forEach(chunkName => deleteCookie(chunkName, options));
     },
   };
 }

--- a/src/services/supabaseClient.ts
+++ b/src/services/supabaseClient.ts
@@ -15,12 +15,18 @@ if (!supabaseUrl || !supabaseKey) {
  *
  * Changes:
  * - createClient → createBrowserClient
- * - localStorage → Cookie storage (via adapter)
- * - PKCE flow mantido (default em @supabase/ssr)
+ * - localStorage → Cookie storage (via adapter with chunking support)
+ * - PKCE flow with explicit code exchange in useAuth hook
  *
  * Benefits:
- * - Cookies persistem entre diferentes containers em Cloud Run
- * - code_verifier armazenado em cookie (acessível em callback)
+ * - Cookies persist across stateless containers (Cloud Run)
+ * - code_verifier properly stored/retrieved via chunked cookies
+ * - Explicit PKCE code exchange prevents 401 errors
+ *
+ * IMPORTANT: detectSessionInUrl is set to FALSE because:
+ * - The useAuth hook explicitly handles code exchange via exchangeCodeForSession()
+ * - This prevents race conditions and double-handling of the auth code
+ * - Gives us more control over error handling and URL cleanup
  */
 export const supabase = createBrowserClient(
     supabaseUrl || '',
@@ -30,13 +36,13 @@ export const supabase = createBrowserClient(
         cookieOptions: {
             path: '/',
             sameSite: 'lax',
-            secure: window.location.protocol === 'https:',
-            maxAge: 60 * 60 * 24 * 7, // 7 dias
+            secure: typeof window !== 'undefined' && window.location.protocol === 'https:',
+            maxAge: 60 * 60 * 24 * 7, // 7 days
         },
         auth: {
             persistSession: true,
             autoRefreshToken: true,
-            detectSessionInUrl: true,
+            detectSessionInUrl: false, // Handled explicitly in useAuth hook
             flowType: 'pkce',
         },
     }


### PR DESCRIPTION
- Cookie storage adapter now supports chunking for large tokens (session JWTs exceed single cookie 4KB limit)
- useAuth hook explicitly handles PKCE code exchange via exchangeCodeForSession() instead of relying on detectSessionInUrl
- Disabled automatic session detection to prevent race conditions
- Added proper cleanup of auth params from URL after processing

This fixes the 401 error during OAuth callback where the code_verifier stored before redirect was not being properly retrieved for the token exchange.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved OAuth authentication callback handling with better error recovery and prevention of duplicate processing.
  * Enhanced session management to prevent race conditions and ensure consistent state updates.
  * Fixed cookie storage to handle large values reliably with automatic chunking.

* **Improvements**
  * Strengthened security configuration for secure cookie handling in browser environments.
  * Enhanced error logging for improved troubleshooting during authentication flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->