### PR TITLE
fix(contacts): Remove AnimatePresence blocking animation propagation

### DIFF
--- a/src/pages/ContactsView.tsx
+++ b/src/pages/ContactsView.tsx
@@ -261,6 +261,7 @@ export function ContactsView() {
               <motion.div
                 key={contact.id}
                 variants={cardVariants.item}
+                layout
               >
                 <ContactCard
                   contact={contact}


### PR DESCRIPTION
The contact cards were invisible because AnimatePresence was wrapping the mapped children, preventing the parent's animation state (hidden -> visible) from propagating to child motion.div elements.

This caused all 544 contact card wrappers to remain at opacity: 0.

Removed AnimatePresence from the contacts list since exit animations are not needed for this static list. The modal still correctly uses AnimatePresence for its exit animation.

Fixes contacts not being visible while still being clickable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated contact list animation behavior for improved rendering efficiency. Contact animations now display with simplified handling while maintaining individual item animation effects.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->