### PR TITLE
fix(whatsapp): Use shared ContactAvatar to fix 403 profile pic errors

### DIFF
--- a/src/components/RecentContactsWidget.tsx
+++ b/src/components/RecentContactsWidget.tsx
@@ -3,70 +3,16 @@
  * Displays recent contacts in a horizontal scroll widget on Home page
  */
 
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
-import { ChevronRight, Users, User } from 'lucide-react';
+import { ChevronRight, Users } from 'lucide-react';
 import type { ContactNetwork } from '../types/memoryTypes';
 import { getUserContacts } from '../services/contactNetworkService';
 import { useAuth } from '../hooks/useAuth';
+import { ContactAvatar } from '@/components/ui';
 import { createNamespacedLogger } from '@/lib/logger';
 
 const log = createNamespacedLogger('RecentContactsWidget');
-
-// Color palette for avatar backgrounds based on name
-const AVATAR_COLORS = [
-  '#3B82F6', // blue
-  '#10B981', // emerald
-  '#8B5CF6', // violet
-  '#F59E0B', // amber
-  '#EF4444', // red
-  '#EC4899', // pink
-  '#06B6D4', // cyan
-  '#84CC16', // lime
-];
-
-function getAvatarColor(name: string): string {
-  const index = name.charCodeAt(0) % AVATAR_COLORS.length;
-  return AVATAR_COLORS[index];
-}
-
-function getInitials(name: string): string {
-  const parts = name.trim().split(' ').filter(Boolean);
-  if (parts.length >= 2) {
-    return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
-  }
-  return name.slice(0, 2).toUpperCase();
-}
-
-// Contact Avatar with fallback to initials
-function ContactAvatar({ contact }: { contact: ContactNetwork }) {
-  const [imageError, setImageError] = useState(false);
-  const avatarUrl = contact.avatar_url || contact.whatsapp_profile_pic_url;
-  const showImage = avatarUrl && !imageError;
-
-  const initials = useMemo(() => getInitials(contact.name), [contact.name]);
-  const bgColor = useMemo(() => getAvatarColor(contact.name), [contact.name]);
-
-  if (showImage) {
-    return (
-      <img
-        src={avatarUrl}
-        alt={contact.name}
-        className="w-14 h-14 rounded-full object-cover"
-        onError={() => setImageError(true)}
-      />
-    );
-  }
-
-  return (
-    <div
-      className="w-14 h-14 rounded-full flex items-center justify-center text-white font-bold text-sm"
-      style={{ backgroundColor: bgColor }}
-    >
-      {initials}
-    </div>
-  );
-}
 
 interface RecentContactsWidgetProps {
   onViewAllClick?: () => void;
@@ -187,7 +133,12 @@ export function RecentContactsWidget({ onViewAllClick, onContactClick }: RecentC
               {/* Avatar with health score badge */}
               <div className="relative">
                 <div className="ceramic-inset rounded-full p-0.5 group-hover:scale-110 transition-transform">
-                  <ContactAvatar contact={contact} />
+                  <ContactAvatar
+                    name={contact.name}
+                    whatsappProfilePicUrl={contact.whatsapp_profile_pic_url}
+                    avatarUrl={contact.avatar_url}
+                    size="lg"
+                  />
                 </div>
                 {/* Health score badge */}
                 {contact.health_score != null && (

--- a/src/components/features/ContactCard.tsx
+++ b/src/components/features/ContactCard.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 import { motion } from 'framer-motion';
 import { Phone, Mail } from 'lucide-react';
 import type { ContactNetwork } from '../../types/memoryTypes';
+import { ContactAvatar } from '@/components/ui';
 
 interface ContactCardProps {
   contact: ContactNetwork;
@@ -14,9 +15,6 @@ interface ContactCardProps {
 }
 
 export function ContactCard({ contact, onClick }: ContactCardProps) {
-  // Use WhatsApp profile pic as fallback for avatar
-  const avatarUrl = contact.avatar_url || contact.whatsapp_profile_pic_url || null;
-
   return (
     <motion.button
       onClick={() => onClick(contact)}
@@ -26,21 +24,13 @@ export function ContactCard({ contact, onClick }: ContactCardProps) {
     >
       <div className="flex items-start gap-4 mb-4">
         <div className="flex-shrink-0">
-          {avatarUrl ? (
-            <img
-              src={avatarUrl}
-              alt={contact.name}
-              className="w-14 h-14 rounded-full ceramic-inset object-cover"
-              onError={(e) => {
-                // Fallback to initials on image load error
-                e.currentTarget.style.display = 'none';
-                e.currentTarget.nextElementSibling?.classList.remove('hidden');
-              }}
-            />
-          ) : null}
-          <div className={`w-14 h-14 rounded-full ceramic-inset flex items-center justify-center bg-gradient-to-br from-green-400 to-green-600 text-white font-bold text-lg ${avatarUrl ? 'hidden' : ''}`}>
-            {contact.name?.charAt(0)?.toUpperCase() || '?'}
-          </div>
+          <ContactAvatar
+            name={contact.name}
+            whatsappProfilePicUrl={contact.whatsapp_profile_pic_url}
+            avatarUrl={contact.avatar_url}
+            size="lg"
+            className="ceramic-inset"
+          />
         </div>
 
         <div className="flex-1 min-w-0">

--- a/src/components/features/ContactDetailModal.tsx
+++ b/src/components/features/ContactDetailModal.tsx
@@ -8,6 +8,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { X, Phone, Mail, MessageSquare, Sparkles } from 'lucide-react';
 import type { ContactNetwork } from '../../types/memoryTypes';
 import { ProcessWithAicaButton } from './ProcessWithAicaButton';
+import { ContactAvatar } from '@/components/ui';
 
 interface ContactDetailModalProps {
   contact: ContactNetwork;
@@ -61,20 +62,13 @@ export function ContactDetailModal({
             {/* Header */}
             <div className="flex items-center justify-between p-6 border-b border-ceramic-text-secondary/10">
               <div className="flex items-center gap-4">
-                {(contact.avatar_url || contact.whatsapp_profile_pic_url) ? (
-                  <img
-                    src={contact.avatar_url || contact.whatsapp_profile_pic_url || ''}
-                    alt={contact.name}
-                    className="w-16 h-16 rounded-full ceramic-inset object-cover"
-                    onError={(e) => {
-                      e.currentTarget.style.display = 'none';
-                      e.currentTarget.nextElementSibling?.classList.remove('hidden');
-                    }}
-                  />
-                ) : null}
-                <div className={`w-16 h-16 rounded-full ceramic-inset flex items-center justify-center bg-gradient-to-br from-green-400 to-green-600 text-white font-bold text-xl ${(contact.avatar_url || contact.whatsapp_profile_pic_url) ? 'hidden' : ''}`}>
-                  {contact.name?.charAt(0)?.toUpperCase() || '?'}
-                </div>
+                <ContactAvatar
+                  name={contact.name}
+                  whatsappProfilePicUrl={contact.whatsapp_profile_pic_url}
+                  avatarUrl={contact.avatar_url}
+                  size="xl"
+                  className="ceramic-inset"
+                />
                 <div>
                   <h2 className="text-2xl font-bold text-ceramic-text-primary">
                     {contact.name}

--- a/src/modules/connections/views/ConnectionsWhatsAppTab.tsx
+++ b/src/modules/connections/views/ConnectionsWhatsAppTab.tsx
@@ -30,13 +30,12 @@ import {
   Sparkles,
   RefreshCw,
   Phone,
-  UserCircle,
   Clock,
   ArrowUp,
   ArrowDown,
   SortAsc,
 } from 'lucide-react';
-import { CeramicTabSelector } from '@/components/ui';
+import { CeramicTabSelector, ContactAvatar } from '@/components/ui';
 import {
   ConnectionStatusCard,
   ConsentManager,
@@ -265,29 +264,11 @@ const WhatsAppContactCard: React.FC<WhatsAppContactCardProps> = ({ contact, onCl
     >
       <div className="flex items-center gap-3">
         {/* Profile Picture or Avatar */}
-        {contact.whatsapp_profile_pic_url ? (
-          <img
-            src={contact.whatsapp_profile_pic_url}
-            alt={displayName}
-            className="w-12 h-12 rounded-full object-cover"
-            onError={(e) => {
-              // Fallback to icon on error
-              (e.target as HTMLImageElement).style.display = 'none';
-            }}
-          />
-        ) : (
-          <div
-            className={`w-12 h-12 rounded-full flex items-center justify-center ceramic-concave ${
-              isGroup ? 'bg-purple-100' : 'bg-blue-100'
-            }`}
-          >
-            {isGroup ? (
-              <Users className="w-6 h-6 text-purple-600" />
-            ) : (
-              <UserCircle className="w-6 h-6 text-blue-600" />
-            )}
-          </div>
-        )}
+        <ContactAvatar
+          name={displayName}
+          whatsappProfilePicUrl={contact.whatsapp_profile_pic_url}
+          size="lg"
+        />
 
         {/* Contact Info */}
         <div className="flex-1 min-w-0">


### PR DESCRIPTION
## Summary
- 4 components were loading WhatsApp CDN URLs (`pps.whatsapp.net`) directly, bypassing the shared `ContactAvatar` proxy — causing **403 console errors** on the Home/Vida page
- Replaced all inline `<img>` tags with the shared `ContactAvatar` component from `@/components/ui`, which routes WhatsApp URLs through the `proxy-whatsapp-image` Edge Function
- Removed ~84 lines of duplicated avatar logic (local `ContactAvatar`, `getInitials`, `getAvatarColor`, inline fallback DOM manipulation)

## Files changed
| File | Change |
|------|--------|
| `src/components/RecentContactsWidget.tsx` | Removed local `ContactAvatar` + helpers, use shared component |
| `src/components/features/ContactCard.tsx` | Replaced inline `<img>` with shared `ContactAvatar` |
| `src/components/features/ContactDetailModal.tsx` | Replaced inline `<img>` with shared `ContactAvatar` (size xl) |
| `src/modules/connections/views/ConnectionsWhatsAppTab.tsx` | Replaced inline `<img>` in `WhatsAppContactCard`, removed unused `UserCircle` import |

## Test plan
- [x] `npm run build` passes with no errors
- [x] Home/Vida page shows contact avatars without 403 errors
- [x] Contacts with no profile pic show initials fallback correctly
- [x] WhatsApp tab contact list renders avatars via shared component

🤖 Generated with [Claude Code](https://claude.com/claude-code)