### PR TITLE
fix(ui): sync timestamp + disconnected status for OAuth video

### DIFF
--- a/src/components/ui/CalendarStatusDot.tsx
+++ b/src/components/ui/CalendarStatusDot.tsx
@@ -6,6 +6,7 @@ interface CalendarStatusDotProps {
   isConnected: boolean;
   isSyncing: boolean;
   hasError?: boolean;
+  lastSyncTime?: Date | null;
   onConnect: () => void;
   onDisconnect?: () => void;
   onSync?: () => void;
@@ -15,6 +16,7 @@ export const CalendarStatusDot: React.FC<CalendarStatusDotProps> = ({
   isConnected,
   isSyncing,
   hasError = false,
+  lastSyncTime,
   onConnect,
   onDisconnect,
   onSync
@@ -91,6 +93,13 @@ export const CalendarStatusDot: React.FC<CalendarStatusDotProps> = ({
             >
               {isConnected ? (
                 <div className="space-y-2">
+                  {/* Sync status label */}
+                  {lastSyncTime && !isSyncing && (
+                    <p className="px-3 py-1 text-[10px] text-ceramic-text-secondary">
+                      Sincronizado {lastSyncTime.toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' })}
+                    </p>
+                  )}
+
                   {/* Sync Button */}
                   {onSync && (
                     <button

--- a/src/modules/google-hub/components/CalendarSection.tsx
+++ b/src/modules/google-hub/components/CalendarSection.tsx
@@ -24,6 +24,9 @@ export function CalendarSection({ isConnected, onDisconnect }: CalendarSectionPr
                 <div className="flex items-center gap-2.5 mb-3">
                     <Calendar className="w-5 h-5 text-[#EA4335]" />
                     <h2 className="text-lg font-semibold text-ceramic-text-primary">Calendar</h2>
+                    <span className="text-xs text-ceramic-text-secondary bg-ceramic-cool/60 px-2 py-0.5 rounded-full">
+                        Não conectado
+                    </span>
                 </div>
                 <p className="text-sm text-ceramic-text-secondary">
                     O Calendar é conectado automaticamente no login com Google.

--- a/src/views/AgendaView.tsx
+++ b/src/views/AgendaView.tsx
@@ -815,6 +815,7 @@ export const AgendaView: React.FC<AgendaViewProps> = ({ userId, userEmail, onLog
                         isConnected={isCalendarConnected}
                         isSyncing={isLoadingCalendar}
                         hasError={!!calendarError}
+                        lastSyncTime={lastSyncTime}
                         onConnect={handleConnectCalendar}
                         onSync={syncCalendar}
                         onDisconnect={handleDisconnectCalendar}


### PR DESCRIPTION
## Summary
Cosmetic fixes identified during OAuth video script validation (team research session).

- **CalendarStatusDot**: Shows "Sincronizado HH:MM" label in dropdown menu when calendar is connected and not syncing. Uses `lastSyncTime` from `useGoogleCalendarEvents` hook.
- **CalendarSection** (Google Hub): Shows "Não conectado" pill badge when Google Calendar is disconnected, making the state explicitly clear for the OAuth demo video.

## Context
The `docs/OAUTH_VIDEO_SCRIPT.md` references:
- Scene 3: showing a sync indicator with timestamp
- Scene 5: showing "Não conectado" status after disconnect

Both were functional but lacked explicit text labels.

## Test plan
- [ ] Open Agenda → click calendar icon → verify "Sincronizado HH:MM" appears in dropdown
- [ ] Open Google Hub → disconnect Calendar → verify "Não conectado" pill appears
- [ ] Reconnect Calendar → verify pill disappears and CheckCircle2 returns

🤖 Generated with [Claude Code](https://claude.com/claude-code)