### PR TITLE
fix(agenda): remove non-existent tags column from query

### DIFF
--- a/src/views/AgendaView.tsx
+++ b/src/views/AgendaView.tsx
@@ -492,7 +492,6 @@ export const AgendaView: React.FC<AgendaViewProps> = ({ userId, userEmail, onLog
                     task_type,
                     checklist,
                     status,
-                    tags,
                     created_at,
                     archived,
                     recurrence_rule,


### PR DESCRIPTION
## Summary
- Removed `tags` from `work_items` select query in `AgendaView.tsx` — this column does not exist on the table, causing a 400 error (`column work_items.tags does not exist`) and preventing all tasks from loading

## Test plan
- [x] `npm run build` passes
- [x] `npm run typecheck` passes
- [ ] Open Agenda page — tasks should load without console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>