### PR TITLE
fix(chat): correct table names in context sidebar queries

### DIFF
--- a/src/services/userAIContextService.ts
+++ b/src/services/userAIContextService.ts
@@ -58,7 +58,7 @@ export async function getUserAIContext(forceRefresh = false): Promise<UserAICont
       .toISOString().split('T')[0]
 
     // Run all queries in parallel
-    const [profileRes, pendingTasksRes, completedTasksRes, momentsRes, grantsRes, episodesRes, financeRes, eventsRes] = await Promise.all([
+    const [profileRes, pendingTasksRes, completedTasksRes, momentsRes, grantsRes, episodesRes, financeRes] = await Promise.all([
       supabase
         .from('profiles')
         .select('full_name')
@@ -76,7 +76,7 @@ export async function getUserAIContext(forceRefresh = false): Promise<UserAICont
         .eq('status', 'completed')
         .gte('completed_at', today),
       supabase
-        .from('moment_entries')
+        .from('moments')
         .select('content')
         .eq('user_id', userId)
         .order('created_at', { ascending: false })
@@ -96,14 +96,17 @@ export async function getUserAIContext(forceRefresh = false): Promise<UserAICont
         .select('type, amount')
         .eq('user_id', userId)
         .gte('transaction_date', monthStart),
-      supabase
-        .from('calendar_events')
-        .select('title, start_time')
-        .eq('user_id', userId)
-        .gte('start_time', new Date().toISOString())
-        .order('start_time', { ascending: true })
-        .limit(5),
     ])
+
+    // calendar_events may not exist yet — query separately with graceful fallback
+    const eventsRes = await supabase
+      .from('calendar_events')
+      .select('title, start_time')
+      .eq('user_id', userId)
+      .gte('start_time', new Date().toISOString())
+      .order('start_time', { ascending: true })
+      .limit(5)
+      .then(res => res, () => ({ data: null, error: null }))
 
     // Calculate finance summary
     let financeSummary: UserAIContext['financeSummary'] = null


### PR DESCRIPTION
## Summary
- Fix `moment_entries` → `moments` table reference (404 on remote — table doesn't exist)
- Move `calendar_events` query out of `Promise.all` with graceful fallback since the table doesn't exist on remote yet
- Eliminates two 404 console errors reported after #331 staging deploy

## Test plan
- [ ] `npm run build` passes
- [ ] No more 404 errors for `moment_entries` or `calendar_events` in console
- [ ] Context sidebar still loads correctly when expanded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced calendar event data handling to gracefully manage scenarios where event data is unavailable, preventing failures from missing sources.

* **Performance**
  * Optimized calendar event data fetching sequence for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->