### PR TITLE
feat(eraforge): Jony Ive visual polish + gameplay persistence

### DIFF
--- a/src/modules/eraforge/components/EF_AdvisorPanel.tsx
+++ b/src/modules/eraforge/components/EF_AdvisorPanel.tsx
@@ -3,10 +3,13 @@
  *
  * Displays 3 featured advisors (historian, scientist, explorer).
  * On tap: shows speech bubble with advisor hint, auto-TTS.
- * Includes loading state and haptic feedback.
+ * Uses Framer Motion for advisor pop and bubble slide-up.
+ * Frosted glass bubble design.
  */
 
 import React, { useEffect, useRef } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { springElevation } from '@/lib/animations/ceramic-motion';
 import { ADVISOR_CONFIG } from '../types/eraforge.types';
 import { EF_VoiceWave } from './EF_VoiceWave';
 import type { AdvisorId } from '../types/eraforge.types';
@@ -14,15 +17,10 @@ import type { AdvisorId } from '../types/eraforge.types';
 interface EF_AdvisorPanelProps {
   onSelectAdvisor: (advisorId: AdvisorId) => void;
   selectedAdvisor?: AdvisorId | null;
-  /** Hint text from the selected advisor */
   advisorHint?: string | null;
-  /** AI is loading the hint */
   isLoading?: boolean;
-  /** TTS is speaking the hint */
   isSpeaking?: boolean;
-  /** Stop TTS callback */
   onStopSpeaking?: () => void;
-  /** Voice supported */
   voiceSupported?: boolean;
 }
 
@@ -31,8 +29,6 @@ const FEATURED_ADVISORS: { id: AdvisorId; emoji: string }[] = [
   { id: 'scientist', emoji: '🔬' },
   { id: 'explorer', emoji: '🧭' },
 ];
-
-const fredoka = { fontFamily: "'Fredoka', 'Nunito', sans-serif" };
 
 export function EF_AdvisorPanel({
   onSelectAdvisor,
@@ -45,7 +41,6 @@ export function EF_AdvisorPanel({
 }: EF_AdvisorPanelProps) {
   const bubbleRef = useRef<HTMLDivElement>(null);
 
-  // Scroll speech bubble into view when hint appears
   useEffect(() => {
     if (advisorHint && bubbleRef.current) {
       bubbleRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
@@ -54,10 +49,7 @@ export function EF_AdvisorPanel({
 
   return (
     <div>
-      <h3
-        className="text-sm font-semibold text-ceramic-text-secondary mb-2"
-        style={fredoka}
-      >
+      <h3 className="text-sm font-semibold text-ceramic-text-secondary mb-2 font-fredoka">
         Conselheiros
       </h3>
 
@@ -68,30 +60,28 @@ export function EF_AdvisorPanel({
           const isSelected = selectedAdvisor === id;
 
           return (
-            <button
+            <motion.button
               key={id}
               onClick={() => onSelectAdvisor(id)}
               disabled={isLoading}
-              className={`flex-1 p-3 rounded-xl text-center transition-all duration-300 ${
+              whileHover={{ scale: 1.03 }}
+              whileTap={{ scale: 0.97 }}
+              animate={isSelected ? { scale: 1.05 } : { scale: 1 }}
+              transition={springElevation}
+              className={`flex-1 p-3 rounded-xl text-center transition-colors ${
                 isSelected
-                  ? 'bg-amber-100 ring-2 ring-ceramic-warning shadow-ceramic-emboss scale-[1.05]'
-                  : 'bg-ceramic-card shadow-ceramic-emboss hover:scale-[1.03] disabled:opacity-50'
+                  ? 'bg-amber-100 ring-2 ring-ceramic-warning shadow-ceramic-emboss'
+                  : 'bg-ceramic-card shadow-ceramic-emboss disabled:opacity-50'
               }`}
-              style={{
-                animation: isSelected ? 'ef-advisor-pop 0.3s ease-out' : undefined,
-              }}
             >
               <div className="text-2xl mb-1">{emoji}</div>
-              <div
-                className="text-xs font-bold text-ceramic-text-primary truncate"
-                style={fredoka}
-              >
+              <div className="text-xs font-bold text-ceramic-text-primary truncate font-fredoka">
                 {config.name}
               </div>
               <div className="text-[10px] text-ceramic-text-secondary mt-0.5 truncate">
                 {config.specialty}
               </div>
-            </button>
+            </motion.button>
           );
         })}
       </div>
@@ -107,61 +97,51 @@ export function EF_AdvisorPanel({
       )}
 
       {/* Speech bubble with advisor hint */}
-      {advisorHint && selectedAdvisor && !isLoading && (
-        <div
-          ref={bubbleRef}
-          className="mt-3 relative animate-[ef-slide-up_0.4s_ease-out]"
-        >
-          {/* Bubble arrow */}
-          <div className="absolute -top-2 left-1/2 -translate-x-1/2 w-0 h-0
-                          border-l-[8px] border-l-transparent
-                          border-r-[8px] border-r-transparent
-                          border-b-[8px] border-b-amber-50" />
+      <AnimatePresence>
+        {advisorHint && selectedAdvisor && !isLoading && (
+          <motion.div
+            ref={bubbleRef}
+            className="mt-3 relative"
+            initial={{ opacity: 0, y: 16, scale: 0.95 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 16, scale: 0.95 }}
+            transition={springElevation}
+          >
+            {/* Bubble arrow */}
+            <div className="absolute -top-2 left-1/2 -translate-x-1/2 w-0 h-0
+                            border-l-[8px] border-l-transparent
+                            border-r-[8px] border-r-transparent
+                            border-b-[8px] border-b-amber-50/80" />
 
-          {/* Bubble content */}
-          <div className="p-4 bg-amber-50 border border-amber-200 rounded-xl">
-            <div className="flex items-center gap-2 mb-2">
-              <span className="text-lg">
-                {FEATURED_ADVISORS.find((a) => a.id === selectedAdvisor)?.emoji}
-              </span>
-              <span
-                className="text-xs font-bold text-amber-800"
-                style={fredoka}
-              >
-                {ADVISOR_CONFIG[selectedAdvisor].name}
-              </span>
-            </div>
-
-            <p className="text-sm text-amber-900 leading-relaxed">
-              {advisorHint}
-            </p>
-
-            {/* Voice wave when speaking hint */}
-            {isSpeaking && (
-              <div className="mt-2">
-                <EF_VoiceWave
-                  isSpeaking={isSpeaking}
-                  onStopSpeaking={onStopSpeaking}
-                  voiceSupported={voiceSupported}
-                />
+            {/* Bubble content — frosted glass */}
+            <div className="p-4 bg-amber-50/80 backdrop-blur-sm border border-amber-200/60 rounded-xl">
+              <div className="flex items-center gap-2 mb-2">
+                <span className="text-lg">
+                  {FEATURED_ADVISORS.find((a) => a.id === selectedAdvisor)?.emoji}
+                </span>
+                <span className="text-xs font-bold text-amber-800 font-fredoka">
+                  {ADVISOR_CONFIG[selectedAdvisor].name}
+                </span>
               </div>
-            )}
-          </div>
-        </div>
-      )}
 
-      {/* Animations */}
-      <style>{`
-        @keyframes ef-advisor-pop {
-          0% { transform: scale(1); }
-          50% { transform: scale(1.1); }
-          100% { transform: scale(1.05); }
-        }
-        @keyframes ef-slide-up {
-          0% { opacity: 0; transform: translateY(16px); }
-          100% { opacity: 1; transform: translateY(0); }
-        }
-      `}</style>
+              <p className="text-sm text-amber-900 leading-relaxed">
+                {advisorHint}
+              </p>
+
+              {/* Voice wave when speaking hint */}
+              {isSpeaking && (
+                <div className="mt-2">
+                  <EF_VoiceWave
+                    isSpeaking={isSpeaking}
+                    onStopSpeaking={onStopSpeaking}
+                    voiceSupported={voiceSupported}
+                  />
+                </div>
+              )}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   );
 }

--- a/src/modules/eraforge/components/EF_GameScreen.tsx
+++ b/src/modules/eraforge/components/EF_GameScreen.tsx
@@ -5,9 +5,12 @@
  *   scenario -> ask_advice -> advisors -> decision -> consequence -> turn_complete -> (loop | day_complete)
  *
  * All data comes via props; callbacks trigger parent actions.
+ * Uses Framer Motion for phase transitions and Ceramic design tokens.
  */
 
 import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { pageTransitionVariants, staggerContainer, staggerItem, springElevation } from '@/lib/animations/ceramic-motion';
 import { EF_SceneRenderer } from './EF_SceneRenderer';
 import { EF_StatsBar } from './EF_StatsBar';
 import { EF_AdvisorPanel } from './EF_AdvisorPanel';
@@ -43,13 +46,9 @@ export interface EF_GameScreenProps {
   advisorHint: string | null;
   consequence: TurnConsequences | null;
   isLoadingAI: boolean;
-  /** TTS is currently speaking */
   isSpeaking?: boolean;
-  /** STT is currently listening */
   isListening?: boolean;
-  /** Interim transcript from STT */
   interimTranscript?: string;
-  /** Whether voice features are available */
   voiceSupported?: boolean;
   onAskAdvice: () => void;
   onSelectAdvisor: (advisorId: AdvisorId) => void;
@@ -58,16 +57,48 @@ export interface EF_GameScreenProps {
   onNextTurn: () => void;
   onEndGame: () => void;
   onPlayAgain: () => void;
-  /** Total era progress earned this session */
   eraProgressEarned?: number;
-  /** Name of the next era if advancement was triggered */
   nextEraName?: string | null;
-  /** Start STT listening */
   onStartListening?: () => void;
-  /** Stop TTS speaking */
   onStopSpeaking?: () => void;
-  /** Speak text via TTS */
   onSpeak?: (text: string) => void;
+  onSimulate?: () => void;
+}
+
+// ============================================
+// EFButton — shared button component
+// ============================================
+
+function EFButton({
+  variant = 'primary',
+  loading = false,
+  children,
+  className = '',
+  ...props
+}: {
+  variant?: 'primary' | 'secondary' | 'ghost';
+  loading?: boolean;
+  children: React.ReactNode;
+  className?: string;
+} & Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'className'>) {
+  const styles = {
+    primary: 'bg-amber-500 hover:bg-amber-600 text-white shadow-lg shadow-amber-500/30',
+    secondary: 'bg-ceramic-cool hover:bg-ceramic-cool-hover text-ceramic-text-primary',
+    ghost: 'text-ceramic-text-secondary hover:text-ceramic-text-primary bg-transparent',
+  };
+  return (
+    <motion.button
+      whileHover={{ scale: 1.02 }}
+      whileTap={{ scale: 0.97 }}
+      className={`py-3 px-4 rounded-xl font-fredoka font-bold transition-colors ${styles[variant]} ${className}`}
+      disabled={loading}
+      {...(props as any)}
+    >
+      {loading ? (
+        <div className="w-5 h-5 border-2 border-current border-t-transparent rounded-full animate-spin mx-auto" />
+      ) : children}
+    </motion.button>
+  );
 }
 
 // ============================================
@@ -99,6 +130,7 @@ export function EF_GameScreen({
   onStartListening,
   onStopSpeaking,
   onSpeak,
+  onSimulate,
 }: EF_GameScreenProps) {
   const scenario = currentTurn?.scenario;
 
@@ -135,11 +167,9 @@ export function EF_GameScreen({
   useEffect(() => {
     if (consequence && phaseRef.current === 'decision') {
       setPhase('consequence');
-      // Auto-narrate consequence narrative
       if (consequence.narrative && onSpeak) {
         onSpeak(consequence.narrative);
       }
-      // Animate stats after a short delay
       setAnimatingStats(true);
       const timer = setTimeout(() => setAnimatingStats(false), 1200);
       return () => clearTimeout(timer);
@@ -200,8 +230,6 @@ export function EF_GameScreen({
 
   // ----- Render helpers -----
 
-  const fredoka = { fontFamily: "'Fredoka', 'Nunito', sans-serif" };
-
   const renderStatDeltas = (cons: TurnConsequences) => {
     const deltas = [
       { label: 'Conhecimento', delta: cons.knowledge_delta, emoji: '📚' },
@@ -212,22 +240,31 @@ export function EF_GameScreen({
     if (deltas.length === 0) return null;
 
     return (
-      <div className="flex gap-3 mt-3">
-        {deltas.map((d) => (
-          <div
+      <motion.div
+        className="flex gap-3 mt-3"
+        variants={staggerContainer}
+        initial="hidden"
+        animate="visible"
+      >
+        {deltas.map((d, i) => (
+          <motion.div
             key={d.label}
-            className={`flex items-center gap-1 text-sm font-bold transition-all duration-700 ${
-              animatingStats ? 'scale-110' : 'scale-100'
-            } ${d.delta! > 0 ? 'text-ceramic-success' : 'text-ceramic-error'}`}
+            variants={staggerItem}
+            className={`flex items-center gap-1 text-sm font-bold ${
+              d.delta! > 0 ? 'text-ceramic-success' : 'text-ceramic-error'
+            }`}
           >
             <span>{d.emoji}</span>
-            <span>
-              {d.delta! > 0 ? '+' : ''}
-              {d.delta}
-            </span>
-          </div>
+            <motion.span
+              initial={{ scale: 1 }}
+              animate={animatingStats ? { scale: [1, 1.3, 1] } : { scale: 1 }}
+              transition={{ duration: 0.5, delay: i * 0.1 }}
+            >
+              {d.delta! > 0 ? '+' : ''}{d.delta}
+            </motion.span>
+          </motion.div>
         ))}
-      </div>
+      </motion.div>
     );
   };
 
@@ -236,7 +273,7 @@ export function EF_GameScreen({
   const renderScenarioPhase = () => {
     if (!scenario) {
       return (
-        <PhaseCard visible>
+        <PhaseCard phaseKey="scenario-loading">
           <p className="text-ceramic-text-secondary text-sm text-center py-4">
             Preparando cenário...
           </p>
@@ -245,18 +282,14 @@ export function EF_GameScreen({
     }
 
     return (
-      <PhaseCard visible={phase === 'scenario'}>
-        <h2
-          className="text-lg font-bold text-ceramic-text-primary"
-          style={fredoka}
-        >
+      <PhaseCard phaseKey="scenario">
+        <h2 className="text-lg font-bold text-ceramic-text-primary font-fredoka">
           {scenario.title || 'Aventura'}
         </h2>
         <p className="text-sm text-ceramic-text-secondary mt-2 leading-relaxed">
           {scenario.description || 'Carregando cenário...'}
         </p>
 
-        {/* Voice wave when narrating */}
         {isSpeaking && (
           <div className="mt-3">
             <EF_VoiceWave
@@ -267,25 +300,21 @@ export function EF_GameScreen({
           </div>
         )}
 
-        {/* Ask Advice button */}
         {phase === 'scenario' && !isSpeaking && (
-          <button
+          <EFButton
             onClick={handleAskAdvice}
             aria-label="Pedir conselho aos conselheiros"
-            className="mt-4 w-full py-3 rounded-xl font-bold text-white bg-amber-500
-                       hover:bg-amber-600 active:scale-[0.97] transition-all
-                       shadow-lg shadow-amber-500/30 animate-pulse"
-            style={fredoka}
+            className="mt-4 w-full animate-pulse"
           >
             Pedir Conselho!
-          </button>
+          </EFButton>
         )}
       </PhaseCard>
     );
   };
 
   const renderAdvisorPhase = () => (
-    <PhaseCard visible={phase === 'ask_advice' || phase === 'advisors'}>
+    <PhaseCard phaseKey="advisors">
       <EF_AdvisorPanel
         onSelectAdvisor={handleSelectAdvisor}
         selectedAdvisor={selectedAdvisor}
@@ -296,17 +325,14 @@ export function EF_GameScreen({
         voiceSupported={voiceSupported}
       />
 
-      {/* Choose button — visible when hint is shown */}
       {phase === 'advisors' && advisorHint && !isSpeaking && (
-        <button
+        <EFButton
           onClick={handleChooseDecision}
           aria-label="Escolher uma decisão"
-          className="mt-4 w-full py-3 rounded-xl font-bold text-white bg-amber-500
-                     hover:bg-amber-600 active:scale-[0.97] transition-all shadow-lg shadow-amber-500/30"
-          style={fredoka}
+          className="mt-4 w-full"
         >
           Escolher
-        </button>
+        </EFButton>
       )}
     </PhaseCard>
   );
@@ -315,31 +341,35 @@ export function EF_GameScreen({
     if (!scenario?.choices) return null;
 
     return (
-      <PhaseCard visible={phase === 'decision'}>
-        <h3
-          className="text-sm font-bold text-ceramic-text-primary mb-3"
-          style={fredoka}
-        >
+      <PhaseCard phaseKey="decision">
+        <h3 className="text-sm font-bold text-ceramic-text-primary mb-3 font-fredoka">
           O que você decide?
         </h3>
 
-        <div className="space-y-2">
+        <motion.div
+          className="space-y-2"
+          variants={staggerContainer}
+          initial="hidden"
+          animate="visible"
+        >
           {scenario.choices.map((choice) => (
-            <button
+            <motion.button
               key={choice.id}
+              variants={staggerItem}
+              whileHover={{ scale: 1.01 }}
+              whileTap={{ scale: 0.98 }}
               onClick={() => handleSelectChoice(choice.id)}
               disabled={isLoadingAI}
-              className="w-full text-left p-3 rounded-lg bg-ceramic-inset hover:bg-amber-50
-                         active:scale-[0.98] transition-all disabled:opacity-50"
+              className="w-full text-left p-3 rounded-lg bg-ceramic-cool shadow-ceramic-inset hover:bg-amber-50
+                         transition-colors disabled:opacity-50"
             >
               <span className="text-sm font-medium text-ceramic-text-primary">
                 {choice.text}
               </span>
-            </button>
+            </motion.button>
           ))}
-        </div>
+        </motion.div>
 
-        {/* Voice decision option */}
         <div className="mt-4 pt-3 border-t border-ceramic-border">
           <p className="text-xs text-ceramic-text-secondary mb-2 text-center">
             Ou fale sua decisão:
@@ -369,15 +399,13 @@ export function EF_GameScreen({
     if (!consequence) return null;
 
     return (
-      <PhaseCard visible={phase === 'consequence'}>
-        {/* Narrative */}
-        <div className="p-4 bg-ceramic-inset rounded-lg">
+      <PhaseCard phaseKey="consequence">
+        <div className="p-4 bg-ceramic-cool shadow-ceramic-inset rounded-lg">
           <p className="text-sm text-ceramic-text-primary leading-relaxed">
             {consequence.narrative}
           </p>
         </div>
 
-        {/* Voice wave when narrating consequence */}
         {isSpeaking && (
           <div className="mt-3">
             <EF_VoiceWave
@@ -388,13 +416,11 @@ export function EF_GameScreen({
           </div>
         )}
 
-        {/* Stat deltas */}
         {renderStatDeltas(consequence)}
 
-        {/* Historical fact bonus */}
         {consequence.historical_fact && (
-          <div className="mt-3 p-3 bg-amber-50 border border-amber-200 rounded-lg">
-            <p className="text-xs font-bold text-amber-700 mb-1" style={fredoka}>
+          <div className="mt-3 p-3 bg-amber-50/80 backdrop-blur-sm border border-amber-200/60 rounded-lg">
+            <p className="text-xs font-bold text-amber-700 mb-1 font-fredoka">
               Você sabia?
             </p>
             <p className="text-xs text-amber-800 leading-relaxed">
@@ -403,32 +429,26 @@ export function EF_GameScreen({
           </div>
         )}
 
-        {/* Next turn button */}
         {!isSpeaking && (
-          <button
+          <EFButton
             onClick={handleNextTurn}
             aria-label={turnsRemaining <= 1 ? 'Finalizar aventura' : 'Ir para o próximo turno'}
-            className="mt-4 w-full py-3 rounded-xl font-bold text-white bg-amber-500
-                       hover:bg-amber-600 active:scale-[0.97] transition-all shadow-lg shadow-amber-500/30"
-            style={fredoka}
+            className="mt-4 w-full"
           >
             {turnsRemaining <= 1
               ? 'Aventura Completa!'
               : 'Próximo Turno'}
-          </button>
+          </EFButton>
         )}
       </PhaseCard>
     );
   };
 
   const renderTurnComplete = () => (
-    <PhaseCard visible={phase === 'turn_complete'}>
+    <PhaseCard phaseKey="turn_complete">
       <div className="flex flex-col items-center py-6">
         <div className="w-8 h-8 border-3 border-amber-500 border-t-transparent rounded-full animate-spin" />
-        <p
-          className="mt-3 text-sm font-bold text-ceramic-text-primary"
-          style={fredoka}
-        >
+        <p className="mt-3 text-sm font-bold text-ceramic-text-primary font-fredoka">
           Preparando próximo turno...
         </p>
       </div>
@@ -436,10 +456,17 @@ export function EF_GameScreen({
   );
 
   const renderDayComplete = () => (
-    <PhaseCard visible={phase === 'day_complete'}>
+    <PhaseCard phaseKey="day_complete">
       <div className="flex flex-col items-center py-6 text-center">
-        <span className="text-5xl mb-3">{nextEraName ? '🏆' : '🌟'}</span>
-        <h2 className="text-xl font-bold text-ceramic-text-primary" style={fredoka}>
+        <motion.span
+          className="text-5xl mb-3"
+          initial={{ scale: 0 }}
+          animate={{ scale: 1 }}
+          transition={{ type: 'spring', stiffness: 300, damping: 20 }}
+        >
+          {nextEraName ? '🏆' : '🌟'}
+        </motion.span>
+        <h2 className="text-xl font-bold text-ceramic-text-primary font-fredoka">
           {nextEraName ? 'Nova Era Desbloqueada!' : 'Parabéns!'}
         </h2>
         <p className="text-sm text-ceramic-text-secondary mt-2 leading-relaxed max-w-xs">
@@ -448,16 +475,14 @@ export function EF_GameScreen({
             : 'Sua aventura de hoje foi incrível! Você explorou a história e tomou decisões incríveis.'}
         </p>
 
-        {/* Era progress earned */}
         {eraProgressEarned > 0 && (
           <div className="mt-3 px-4 py-2 bg-amber-50 border border-amber-200 rounded-lg">
-            <p className="text-xs font-bold text-amber-700" style={fredoka}>
+            <p className="text-xs font-bold text-amber-700 font-fredoka">
               Progresso da Era: +{eraProgressEarned}%
             </p>
           </div>
         )}
 
-        {/* Stats summary */}
         <div className="mt-4 w-full max-w-xs">
           <EF_StatsBar
             knowledge={member.knowledge}
@@ -466,22 +491,29 @@ export function EF_GameScreen({
           />
         </div>
 
-        {/* Two action buttons */}
         <div className="mt-6 w-full max-w-xs space-y-3">
-          <button
+          <EFButton
             onClick={onPlayAgain}
             aria-label={nextEraName ? `Explorar ${nextEraName}` : 'Jogar novamente'}
-            className="w-full py-3 rounded-xl font-bold text-white bg-amber-500
-                       hover:bg-amber-600 active:scale-[0.97] transition-all shadow-lg shadow-amber-500/30"
-            style={fredoka}
+            className="w-full"
           >
             {nextEraName ? `Explorar ${nextEraName}` : 'Jogar Novamente'}
-          </button>
+          </EFButton>
+          {onSimulate && (
+            <EFButton
+              variant="secondary"
+              onClick={onSimulate}
+              aria-label="Simular 14 dias"
+              className="w-full"
+            >
+              Simular 14 dias
+            </EFButton>
+          )}
           <button
             onClick={onEndGame}
             aria-label="Voltar ao início"
-            className="w-full py-2 text-sm text-ceramic-text-secondary bg-ceramic-inset
-                       rounded-lg hover:bg-ceramic-border transition-colors"
+            className="w-full py-2 text-sm text-ceramic-text-secondary bg-ceramic-cool shadow-ceramic-inset
+                       rounded-lg hover:bg-ceramic-cool-hover transition-colors"
           >
             Voltar ao Início
           </button>
@@ -493,7 +525,12 @@ export function EF_GameScreen({
   // ----- Main render -----
 
   return (
-    <div className="flex flex-col min-h-screen bg-ceramic-base">
+    <motion.div
+      className="flex flex-col min-h-screen bg-ceramic-base"
+      variants={pageTransitionVariants}
+      initial="initial"
+      animate="animate"
+    >
       {/* Top bar: stats + turns */}
       <div className="flex items-center justify-between p-4">
         <EF_StatsBar
@@ -511,56 +548,54 @@ export function EF_GameScreen({
 
       {/* Phase content */}
       <div className="flex-1 px-4 mt-4 pb-4 space-y-0">
-        {renderScenarioPhase()}
-        {(phase === 'ask_advice' || phase === 'advisors') && renderAdvisorPhase()}
-        {phase === 'decision' && renderDecisionPhase()}
-        {phase === 'consequence' && renderConsequencePhase()}
-        {phase === 'turn_complete' && renderTurnComplete()}
-        {phase === 'day_complete' && renderDayComplete()}
+        <AnimatePresence mode="wait">
+          {phase === 'scenario' && renderScenarioPhase()}
+          {(phase === 'ask_advice' || phase === 'advisors') && renderAdvisorPhase()}
+          {phase === 'decision' && renderDecisionPhase()}
+          {phase === 'consequence' && renderConsequencePhase()}
+          {phase === 'turn_complete' && renderTurnComplete()}
+          {phase === 'day_complete' && renderDayComplete()}
+        </AnimatePresence>
       </div>
 
-      {/* End Game shortcut (only during active gameplay, not day_complete) */}
+      {/* End Game shortcut */}
       {phase !== 'day_complete' && phase !== 'turn_complete' && (
         <div className="px-4 pb-6">
           <button
             onClick={onEndGame}
             aria-label="Encerrar sessão de jogo"
-            className="w-full py-2 text-sm text-ceramic-text-secondary bg-ceramic-inset
-                       rounded-lg hover:bg-ceramic-border transition-colors"
+            className="w-full py-2 text-sm text-ceramic-text-secondary bg-ceramic-cool shadow-ceramic-inset
+                       rounded-lg hover:bg-ceramic-cool-hover transition-colors"
           >
             Encerrar Sessão
           </button>
         </div>
       )}
-    </div>
+    </motion.div>
   );
 }
 
 // ============================================
-// PHASE CARD — animated wrapper
+// PHASE CARD — Framer Motion animated wrapper
 // ============================================
 
 function PhaseCard({
-  visible,
+  phaseKey,
   children,
 }: {
-  visible: boolean;
+  phaseKey: string;
   children: React.ReactNode;
 }) {
   return (
-    <div
-      aria-hidden={!visible}
-      className="p-4 bg-ceramic-card rounded-xl shadow-ceramic-emboss transition-all duration-500"
-      style={{
-        opacity: visible ? 1 : 0,
-        transform: visible ? 'translateY(0)' : 'translateY(12px)',
-        pointerEvents: visible ? 'auto' : 'none',
-        maxHeight: visible ? '2000px' : '0px',
-        overflow: 'hidden',
-        marginBottom: visible ? '0px' : '-16px',
-      }}
+    <motion.div
+      key={phaseKey}
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -8 }}
+      transition={springElevation}
+      className="p-4 bg-ceramic-card rounded-xl shadow-ceramic-emboss"
     >
       {children}
-    </div>
+    </motion.div>
   );
 }

--- a/src/modules/eraforge/components/EF_HomeScreen.tsx
+++ b/src/modules/eraforge/components/EF_HomeScreen.tsx
@@ -3,9 +3,17 @@
  *
  * Entry point for EraForge. Shows available worlds and children,
  * with inline creation forms for worlds and child profiles.
+ * Uses Framer Motion for entrance animations and card hover effects.
  */
 
 import React, { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import {
+  pageTransitionVariants,
+  staggerContainer,
+  staggerItem,
+  cardElevationVariants,
+} from '@/lib/animations/ceramic-motion';
 import { ERA_CONFIG } from '../types/eraforge.types';
 import type { World, ChildProfile, Era, WorldCreateInput, ChildProfileCreateInput } from '../types/eraforge.types';
 
@@ -66,13 +74,15 @@ export function EF_HomeScreen({
   };
 
   return (
-    <div className="p-6 space-y-8">
+    <motion.div
+      className="p-6 space-y-8"
+      variants={pageTransitionVariants}
+      initial="initial"
+      animate="animate"
+    >
       {/* Header */}
       <div className="text-center">
-        <h1
-          className="text-3xl font-bold text-ceramic-text-primary"
-          style={{ fontFamily: "'Fredoka', 'Nunito', sans-serif" }}
-        >
+        <h1 className="text-3xl font-bold text-ceramic-text-primary font-fredoka">
           EraForge
         </h1>
         <p className="text-ceramic-text-secondary mt-2">
@@ -83,10 +93,7 @@ export function EF_HomeScreen({
       {/* Children Section */}
       <div>
         <div className="flex items-center justify-between mb-3">
-          <h2
-            className="text-lg font-semibold text-ceramic-text-primary"
-            style={{ fontFamily: "'Fredoka', 'Nunito', sans-serif" }}
-          >
+          <h2 className="text-lg font-semibold text-ceramic-text-primary font-fredoka">
             Jogadores
           </h2>
           {onCreateChild && (
@@ -101,82 +108,99 @@ export function EF_HomeScreen({
         </div>
 
         {/* Child creation form */}
-        {showChildForm && (
-          <div className="mb-4 p-4 rounded-xl bg-ceramic-card shadow-ceramic-emboss space-y-3">
-            <input
-              type="text"
-              placeholder="Nome do jogador"
-              value={childName}
-              onChange={e => setChildName(e.target.value)}
-              maxLength={30}
-              className="w-full px-3 py-2 rounded-lg bg-ceramic-inset text-ceramic-text-primary placeholder:text-ceramic-text-secondary/50 border-none outline-none text-sm"
-              autoFocus
-            />
-            <div>
-              <p className="text-xs text-ceramic-text-secondary mb-1">Avatar</p>
-              <div className="flex flex-wrap gap-2">
-                {AVATAR_EMOJIS.map(emoji => (
+        <AnimatePresence>
+          {showChildForm && (
+            <motion.div
+              initial={{ opacity: 0, height: 0 }}
+              animate={{ opacity: 1, height: 'auto' }}
+              exit={{ opacity: 0, height: 0 }}
+              className="mb-4 overflow-hidden"
+            >
+              <div className="p-4 rounded-xl bg-ceramic-card shadow-ceramic-emboss space-y-3">
+                <input
+                  type="text"
+                  placeholder="Nome do jogador"
+                  value={childName}
+                  onChange={e => setChildName(e.target.value)}
+                  maxLength={30}
+                  className="w-full px-3 py-2 rounded-lg bg-ceramic-cool shadow-ceramic-inset text-ceramic-text-primary placeholder:text-ceramic-text-secondary/50 border-none outline-none text-sm"
+                  autoFocus
+                />
+                <div>
+                  <p className="text-xs text-ceramic-text-secondary mb-1">Avatar</p>
+                  <div className="flex flex-wrap gap-2">
+                    {AVATAR_EMOJIS.map(emoji => (
+                      <button
+                        key={emoji}
+                        onClick={() => setChildEmoji(emoji)}
+                        className={`w-9 h-9 rounded-lg flex items-center justify-center text-lg transition-all ${
+                          childEmoji === emoji
+                            ? 'bg-amber-100 ring-2 ring-amber-400 scale-110'
+                            : 'bg-ceramic-cool hover:bg-ceramic-cool-hover'
+                        }`}
+                      >
+                        {emoji}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+                <input
+                  type="number"
+                  placeholder="Ano de nascimento (opcional)"
+                  value={childBirthYear}
+                  onChange={e => setChildBirthYear(e.target.value)}
+                  min={2005}
+                  max={2025}
+                  className="w-full px-3 py-2 rounded-lg bg-ceramic-cool shadow-ceramic-inset text-ceramic-text-primary placeholder:text-ceramic-text-secondary/50 border-none outline-none text-sm"
+                />
+                <div className="flex gap-2">
                   <button
-                    key={emoji}
-                    onClick={() => setChildEmoji(emoji)}
-                    className={`w-9 h-9 rounded-lg flex items-center justify-center text-lg transition-all ${
-                      childEmoji === emoji
-                        ? 'bg-amber-100 ring-2 ring-amber-400 scale-110'
-                        : 'bg-ceramic-inset hover:bg-ceramic-cool'
-                    }`}
+                    onClick={() => setShowChildForm(false)}
+                    className="flex-1 py-2 text-sm text-ceramic-text-secondary bg-ceramic-cool rounded-lg hover:bg-ceramic-cool-hover transition-colors"
                   >
-                    {emoji}
+                    Cancelar
                   </button>
-                ))}
+                  <button
+                    onClick={handleSubmitChild}
+                    disabled={!childName.trim() || isCreating}
+                    className="flex-1 py-2 text-sm font-bold text-white bg-amber-500 rounded-lg hover:bg-amber-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  >
+                    {isCreating ? 'Criando...' : 'Criar Jogador'}
+                  </button>
+                </div>
               </div>
-            </div>
-            <input
-              type="number"
-              placeholder="Ano de nascimento (opcional)"
-              value={childBirthYear}
-              onChange={e => setChildBirthYear(e.target.value)}
-              min={2005}
-              max={2025}
-              className="w-full px-3 py-2 rounded-lg bg-ceramic-inset text-ceramic-text-primary placeholder:text-ceramic-text-secondary/50 border-none outline-none text-sm"
-            />
-            <div className="flex gap-2">
-              <button
-                onClick={() => setShowChildForm(false)}
-                className="flex-1 py-2 text-sm text-ceramic-text-secondary bg-ceramic-inset rounded-lg hover:bg-ceramic-cool transition-colors"
-              >
-                Cancelar
-              </button>
-              <button
-                onClick={handleSubmitChild}
-                disabled={!childName.trim() || isCreating}
-                className="flex-1 py-2 text-sm font-bold text-white bg-amber-500 rounded-lg hover:bg-amber-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-              >
-                {isCreating ? 'Criando...' : 'Criar Jogador'}
-              </button>
-            </div>
-          </div>
-        )}
+            </motion.div>
+          )}
+        </AnimatePresence>
 
         {childProfiles.length > 0 ? (
-          <div className="flex gap-3 overflow-x-auto pb-2">
+          <motion.div
+            className="flex gap-3 overflow-x-auto pb-2"
+            variants={staggerContainer}
+            initial="hidden"
+            animate="visible"
+          >
             {childProfiles.map(child => (
-              <button
+              <motion.button
                 key={child.id}
+                variants={staggerItem}
+                whileHover={{ scale: 1.05 }}
+                whileTap={{ scale: 0.97 }}
                 onClick={() => onSelectChild(child)}
                 aria-label={`Jogador: ${child.display_name}`}
-                className="flex-shrink-0 flex flex-col items-center gap-2 p-3 rounded-xl bg-ceramic-card shadow-ceramic-emboss hover:scale-105 transition-transform"
+                className="flex-shrink-0 flex flex-col items-center gap-2 p-3 rounded-xl bg-ceramic-card shadow-ceramic-emboss"
               >
-                <div className="w-12 h-12 rounded-full bg-ceramic-inset flex items-center justify-center text-2xl">
+                <div className="w-12 h-12 rounded-full bg-ceramic-cool flex items-center justify-center text-2xl">
                   {child.avatar_emoji || '👤'}
                 </div>
                 <span className="text-sm font-medium text-ceramic-text-primary whitespace-nowrap">
                   {child.display_name}
                 </span>
-              </button>
+              </motion.button>
             ))}
-          </div>
+          </motion.div>
         ) : !showChildForm ? (
-          <div className="text-center py-4 bg-ceramic-inset rounded-xl">
+          <div className="text-center py-4 bg-ceramic-cool rounded-xl">
             <p className="text-ceramic-text-secondary text-sm">
               Nenhum jogador criado ainda
             </p>
@@ -186,54 +210,58 @@ export function EF_HomeScreen({
 
       {/* Worlds Grid */}
       <div>
-        <h2
-          className="text-lg font-semibold text-ceramic-text-primary mb-3"
-          style={{ fontFamily: "'Fredoka', 'Nunito', sans-serif" }}
-        >
+        <h2 className="text-lg font-semibold text-ceramic-text-primary mb-3 font-fredoka">
           Mundos
         </h2>
 
         {loading ? (
           <div className="grid grid-cols-2 gap-4">
             {[1, 2, 3, 4].map(i => (
-              <div key={i} className="h-32 rounded-xl bg-ceramic-inset animate-pulse" />
+              <div key={i} className="h-32 rounded-xl bg-ceramic-cool animate-pulse" />
             ))}
           </div>
         ) : worlds.length > 0 ? (
-          <div className="grid grid-cols-2 gap-4">
+          <motion.div
+            className="grid grid-cols-2 gap-4"
+            variants={staggerContainer}
+            initial="hidden"
+            animate="visible"
+          >
             {worlds.map(world => {
               const eraConfig = ERA_CONFIG[world.current_era];
               const isSelected = selectedWorld?.id === world.id;
               return (
-                <button
+                <motion.button
                   key={world.id}
+                  variants={cardElevationVariants}
+                  initial="rest"
+                  whileHover="hover"
+                  whileTap="pressed"
+                  animate={isSelected ? 'selected' : 'rest'}
                   onClick={() => onSelectWorld(world)}
-                  className={`p-4 rounded-xl bg-ceramic-card shadow-ceramic-emboss text-left hover:scale-[1.02] transition-all ${
+                  className={`p-4 rounded-xl bg-ceramic-card shadow-ceramic-emboss text-left ${
                     isSelected ? 'ring-2 ring-amber-400' : ''
                   }`}
                 >
                   <div className="text-2xl mb-2">🌍</div>
-                  <h3
-                    className="text-sm font-bold text-ceramic-text-primary truncate"
-                    style={{ fontFamily: "'Fredoka', 'Nunito', sans-serif" }}
-                  >
+                  <h3 className="text-sm font-bold text-ceramic-text-primary truncate font-fredoka">
                     {world.name}
                   </h3>
                   <p className="text-xs text-ceramic-text-secondary mt-1">
                     {eraConfig.label}
                   </p>
-                  <div className="mt-2 h-1.5 bg-ceramic-inset rounded-full overflow-hidden">
+                  <div className="mt-2 h-1.5 bg-ceramic-cool rounded-full overflow-hidden">
                     <div
                       className="h-full bg-amber-400 rounded-full transition-all"
                       style={{ width: `${Math.min(100, world.era_progress)}%` }}
                     />
                   </div>
-                </button>
+                </motion.button>
               );
             })}
-          </div>
+          </motion.div>
         ) : !showWorldForm ? (
-          <div className="text-center py-8 bg-ceramic-inset rounded-xl">
+          <div className="text-center py-8 bg-ceramic-cool rounded-xl">
             <p className="text-ceramic-text-secondary text-sm">
               Nenhum mundo criado ainda
             </p>
@@ -242,66 +270,75 @@ export function EF_HomeScreen({
       </div>
 
       {/* World Creation Form */}
-      {showWorldForm ? (
-        <div className="p-4 rounded-xl bg-ceramic-card shadow-ceramic-emboss space-y-4">
-          <h3
-            className="text-base font-bold text-ceramic-text-primary"
-            style={{ fontFamily: "'Fredoka', 'Nunito', sans-serif" }}
+      <AnimatePresence mode="wait">
+        {showWorldForm ? (
+          <motion.div
+            key="world-form"
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -8 }}
+            className="p-4 rounded-xl bg-ceramic-card shadow-ceramic-emboss space-y-4"
           >
-            Novo Mundo
-          </h3>
-          <input
-            type="text"
-            placeholder="Nome do mundo (ex: Terra dos Dinossauros)"
-            value={worldName}
-            onChange={e => setWorldName(e.target.value)}
-            maxLength={50}
-            className="w-full px-3 py-2 rounded-lg bg-ceramic-inset text-ceramic-text-primary placeholder:text-ceramic-text-secondary/50 border-none outline-none text-sm"
-            autoFocus
-          />
-          <div>
-            <p className="text-xs text-ceramic-text-secondary mb-2">Era inicial</p>
-            <div className="grid grid-cols-3 gap-2">
-              {ERA_OPTIONS.map(([era, config]) => (
-                <button
-                  key={era}
-                  onClick={() => setWorldEra(era)}
-                  className={`px-2 py-2 rounded-lg text-xs text-center transition-all ${
-                    worldEra === era
-                      ? 'bg-amber-100 ring-2 ring-amber-400 text-amber-800 font-bold'
-                      : 'bg-ceramic-inset text-ceramic-text-secondary hover:bg-ceramic-cool'
-                  }`}
-                >
-                  {config.label}
-                </button>
-              ))}
+            <h3 className="text-base font-bold text-ceramic-text-primary font-fredoka">
+              Novo Mundo
+            </h3>
+            <input
+              type="text"
+              placeholder="Nome do mundo (ex: Terra dos Dinossauros)"
+              value={worldName}
+              onChange={e => setWorldName(e.target.value)}
+              maxLength={50}
+              className="w-full px-3 py-2 rounded-lg bg-ceramic-cool shadow-ceramic-inset text-ceramic-text-primary placeholder:text-ceramic-text-secondary/50 border-none outline-none text-sm"
+              autoFocus
+            />
+            <div>
+              <p className="text-xs text-ceramic-text-secondary mb-2">Era inicial</p>
+              <div className="grid grid-cols-3 gap-2">
+                {ERA_OPTIONS.map(([era, config]) => (
+                  <button
+                    key={era}
+                    onClick={() => setWorldEra(era)}
+                    className={`px-2 py-2 rounded-lg text-xs text-center transition-all ${
+                      worldEra === era
+                        ? 'bg-amber-100 ring-2 ring-amber-400 text-amber-800 font-bold'
+                        : 'bg-ceramic-cool text-ceramic-text-secondary hover:bg-ceramic-cool-hover'
+                    }`}
+                  >
+                    {config.label}
+                  </button>
+                ))}
+              </div>
             </div>
-          </div>
-          <div className="flex gap-2">
-            <button
-              onClick={() => { setShowWorldForm(false); setWorldName(''); }}
-              className="flex-1 py-2 text-sm text-ceramic-text-secondary bg-ceramic-inset rounded-lg hover:bg-ceramic-cool transition-colors"
-            >
-              Cancelar
-            </button>
-            <button
-              onClick={handleSubmitWorld}
-              disabled={!worldName.trim() || isCreating}
-              className="flex-1 py-2 text-sm font-bold text-white bg-amber-500 rounded-lg hover:bg-amber-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-            >
-              {isCreating ? 'Criando...' : 'Criar Mundo'}
-            </button>
-          </div>
-        </div>
-      ) : (
-        <button
-          onClick={() => setShowWorldForm(true)}
-          className="w-full py-3 bg-amber-500 hover:bg-amber-600 text-white font-bold rounded-xl transition-colors"
-          style={{ fontFamily: "'Fredoka', 'Nunito', sans-serif" }}
-        >
-          + Criar Mundo
-        </button>
-      )}
+            <div className="flex gap-2">
+              <button
+                onClick={() => { setShowWorldForm(false); setWorldName(''); }}
+                className="flex-1 py-2 text-sm text-ceramic-text-secondary bg-ceramic-cool rounded-lg hover:bg-ceramic-cool-hover transition-colors"
+              >
+                Cancelar
+              </button>
+              <button
+                onClick={handleSubmitWorld}
+                disabled={!worldName.trim() || isCreating}
+                className="flex-1 py-2 text-sm font-bold text-white bg-amber-500 rounded-lg hover:bg-amber-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              >
+                {isCreating ? 'Criando...' : 'Criar Mundo'}
+              </button>
+            </div>
+          </motion.div>
+        ) : (
+          <motion.button
+            key="create-btn"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            whileHover={{ scale: 1.02 }}
+            whileTap={{ scale: 0.97 }}
+            onClick={() => setShowWorldForm(true)}
+            className="w-full py-3 bg-amber-500 hover:bg-amber-600 text-white font-bold rounded-xl transition-colors font-fredoka"
+          >
+            + Criar Mundo
+          </motion.button>
+        )}
+      </AnimatePresence>
 
       {/* Hint: select world first, then child */}
       {selectedWorld && childProfiles.length > 0 && (
@@ -311,6 +348,6 @@ export function EF_HomeScreen({
           </p>
         </div>
       )}
-    </div>
+    </motion.div>
   );
 }

--- a/src/modules/eraforge/components/EF_SceneRenderer.tsx
+++ b/src/modules/eraforge/components/EF_SceneRenderer.tsx
@@ -1,13 +1,21 @@
 /**
- * EF_SceneRenderer - SVG scene placeholder
+ * EF_SceneRenderer - Era-specific illustrated SVG scenes
  *
- * Renders a visual scene with era-based gradient background.
- * Placeholder for future animated SVG scenes.
+ * Renders animated SVG scenes per era using dedicated scene components.
+ * Falls back to gradient + SvgPrimitives for eras without dedicated scenes.
+ * Wrapped in Framer Motion for page transition animations.
  */
 
 import React from 'react';
+import { motion } from 'framer-motion';
+import { pageTransitionVariants } from '@/lib/animations/ceramic-motion';
 import { ERA_CONFIG } from '../types/eraforge.types';
 import type { Era } from '../types/eraforge.types';
+import { StoneAgeScene } from './scenes/StoneAgeScene';
+import { AncientEgyptScene } from './scenes/AncientEgyptScene';
+import { ClassicalGreeceScene } from './scenes/ClassicalGreeceScene';
+import { MedievalScene } from './scenes/MedievalScene';
+import { Sun, Cloud, Mountain } from './scenes/SvgPrimitives';
 
 interface EF_SceneRendererProps {
   era: Era;
@@ -25,45 +33,58 @@ const ERA_GRADIENTS: Record<Era, { from: string; to: string }> = {
   future:                { from: '#06b6d4', to: '#0e7490' },
 };
 
+const SCENE_COMPONENTS: Partial<Record<Era, React.FC>> = {
+  stone_age: StoneAgeScene,
+  ancient_egypt: AncientEgyptScene,
+  classical_greece: ClassicalGreeceScene,
+  medieval: MedievalScene,
+};
+
 export function EF_SceneRenderer({ era }: EF_SceneRendererProps) {
   const gradient = ERA_GRADIENTS[era];
   const config = ERA_CONFIG[era];
+  const SceneComponent = SCENE_COMPONENTS[era];
 
   return (
-    <div className="relative rounded-xl overflow-hidden shadow-ceramic-emboss" style={{ height: 180 }}>
-      <svg
-        viewBox="0 0 400 180"
-        className="w-full h-full"
-        preserveAspectRatio="xMidYMid slice"
-      >
-        <defs>
-          <linearGradient id={`era-grad-${era}`} x1="0%" y1="0%" x2="100%" y2="100%">
-            <stop offset="0%" stopColor={gradient.from} />
-            <stop offset="100%" stopColor={gradient.to} />
-          </linearGradient>
-        </defs>
-        <rect width="400" height="180" fill={`url(#era-grad-${era})`} />
-        <text
-          x="200"
-          y="80"
-          textAnchor="middle"
-          fill="white"
-          fontSize="40"
-          opacity="0.4"
+    <motion.div
+      className="relative rounded-xl overflow-hidden shadow-ceramic-emboss"
+      style={{ height: 180 }}
+      variants={pageTransitionVariants}
+      initial="initial"
+      animate="animate"
+    >
+      {SceneComponent ? (
+        <SceneComponent />
+      ) : (
+        <svg
+          viewBox="0 0 400 180"
+          className="w-full h-full"
+          preserveAspectRatio="xMidYMid slice"
         >
+          <defs>
+            <linearGradient id={`era-grad-${era}`} x1="0%" y1="0%" x2="100%" y2="100%">
+              <stop offset="0%" stopColor={gradient.from} />
+              <stop offset="100%" stopColor={gradient.to} />
+            </linearGradient>
+          </defs>
+          <rect width="400" height="180" fill={`url(#era-grad-${era})`} />
+          <Sun cx={340} cy={40} r={20} />
+          <Cloud cx={80} cy={35} />
+          <Cloud cx={220} cy={50} />
+          <Mountain x={0} y={120} width={160} height={60} fill={gradient.to} />
+          <Mountain x={120} y={120} width={200} height={60} fill={gradient.from} opacity={0.6} />
+        </svg>
+      )}
+
+      {/* Frosted glass era label */}
+      <div className="absolute bottom-0 left-0 right-0 px-4 py-2 bg-white/30 backdrop-blur-sm">
+        <p className="text-white text-sm font-bold font-fredoka drop-shadow-sm">
           {config.label}
-        </text>
-        <text
-          x="200"
-          y="120"
-          textAnchor="middle"
-          fill="white"
-          fontSize="14"
-          opacity="0.6"
-        >
+        </p>
+        <p className="text-white/80 text-[10px] drop-shadow-sm">
           {config.period}
-        </text>
-      </svg>
-    </div>
+        </p>
+      </div>
+    </motion.div>
   );
 }

--- a/src/modules/eraforge/components/EF_SimulationScreen.tsx
+++ b/src/modules/eraforge/components/EF_SimulationScreen.tsx
@@ -37,14 +37,13 @@ interface EF_SimulationScreenProps {
 // CONSTANTS
 // ============================================
 
-const FREDOKA = "'Fredoka', 'Nunito', sans-serif";
 const AUTO_PLAY_DELAY_MS = 3000;
 const TOTAL_DAYS = 14;
 
 const IMPACT_COLORS: Record<string, string> = {
-  positive: 'bg-emerald-400',
-  neutral: 'bg-amber-400',
-  negative: 'bg-rose-400',
+  positive: 'bg-ceramic-success',
+  neutral: 'bg-ceramic-warning',
+  negative: 'bg-ceramic-error',
 };
 
 const IMPACT_BORDER: Record<string, string> = {
@@ -66,9 +65,9 @@ const IMPACT_LABELS: Record<string, string> = {
 };
 
 const STAT_CONFIG = [
-  { key: 'knowledge' as const, label: 'Conhecimento', emoji: '\u{1F4DA}', color: 'bg-blue-500' },
-  { key: 'cooperation' as const, label: 'Cooperação', emoji: '\u{1F91D}', color: 'bg-green-500' },
-  { key: 'courage' as const, label: 'Coragem', emoji: '\u{2694}\u{FE0F}', color: 'bg-red-500' },
+  { key: 'knowledge' as const, label: 'Conhecimento', emoji: '\u{1F4DA}', color: 'bg-ceramic-info' },
+  { key: 'cooperation' as const, label: 'Cooperação', emoji: '\u{1F91D}', color: 'bg-ceramic-success' },
+  { key: 'courage' as const, label: 'Coragem', emoji: '\u{2694}\u{FE0F}', color: 'bg-ceramic-warning' },
 ];
 
 // ============================================
@@ -121,8 +120,7 @@ function AnimatedTitle({ onComplete }: { onComplete: () => void }) {
   return (
     <div className="text-center py-4">
       <h1
-        className="text-2xl sm:text-3xl font-bold text-ceramic-text-primary"
-        style={{ fontFamily: FREDOKA }}
+        className="text-2xl sm:text-3xl font-bold text-ceramic-text-primary font-fredoka"
       >
         {text.slice(0, visibleChars)}
         <span className="animate-pulse text-amber-500">|</span>
@@ -153,14 +151,14 @@ function DayPill({
       onClick={onClick}
       aria-label={`Dia ${day}${hasEvents ? ' - tem eventos' : ''}`}
       className={[
-        'flex-shrink-0 flex flex-col items-center gap-1 px-3 py-2 rounded-xl transition-all duration-300',
+        'flex-shrink-0 flex flex-col items-center gap-1 px-3 py-2 rounded-xl transition-all duration-300 font-fredoka',
         isActive
           ? 'bg-amber-500 text-white scale-110 shadow-lg'
           : isRevealed && hasEvents
             ? 'bg-ceramic-card text-ceramic-text-primary shadow-ceramic-emboss'
             : 'bg-ceramic-cool/50 text-ceramic-text-secondary',
       ].join(' ')}
-      style={{ fontFamily: FREDOKA, minWidth: 56 }}
+      style={{ minWidth: 56 }}
     >
       <span className="text-xs font-medium">Dia</span>
       <span className="text-lg font-bold">{day}</span>
@@ -504,8 +502,7 @@ export function EF_SimulationScreen({
           {/* Header */}
           <div className="text-center">
             <h1
-              className="text-xl sm:text-2xl font-bold text-ceramic-text-primary"
-              style={{ fontFamily: FREDOKA }}
+              className="text-xl sm:text-2xl font-bold text-ceramic-text-primary font-fredoka"
             >
               Enquanto voc{'\u00EA'} esteve fora...
             </h1>
@@ -599,8 +596,7 @@ export function EF_SimulationScreen({
           {/* ---- Event Cards ---- */}
           <div className="space-y-3">
             <h2
-              className="text-base font-semibold text-ceramic-text-primary"
-              style={{ fontFamily: FREDOKA }}
+              className="text-base font-semibold text-ceramic-text-primary font-fredoka"
             >
               {'\u{1F4DC}'} Eventos da Simulação
             </h2>
@@ -616,8 +612,7 @@ export function EF_SimulationScreen({
                         <div className="flex items-center gap-2 pt-2">
                           <div className="h-px flex-1 bg-ceramic-border/50" />
                           <span
-                            className="text-[10px] font-bold text-amber-600 uppercase tracking-wider"
-                            style={{ fontFamily: FREDOKA }}
+                            className="text-[10px] font-bold text-amber-600 uppercase tracking-wider font-fredoka"
                           >
                             Dia {day}
                           </span>
@@ -648,8 +643,7 @@ export function EF_SimulationScreen({
           {allRevealed && summary && (
             <div className="p-4 bg-ceramic-card rounded-xl shadow-ceramic-emboss animate-[fadeIn_0.5s_ease-out]">
               <h2
-                className="text-sm font-semibold text-ceramic-text-primary mb-2"
-                style={{ fontFamily: FREDOKA }}
+                className="text-sm font-semibold text-ceramic-text-primary mb-2 font-fredoka"
               >
                 {'\u{1F989}'} Resumo da Sábia Coruja
               </h2>
@@ -663,8 +657,7 @@ export function EF_SimulationScreen({
           {showStats && (
             <div className="p-4 bg-ceramic-card rounded-xl shadow-ceramic-emboss space-y-4 animate-[fadeIn_0.5s_ease-out]">
               <h2
-                className="text-sm font-semibold text-ceramic-text-primary"
-                style={{ fontFamily: FREDOKA }}
+                className="text-sm font-semibold text-ceramic-text-primary font-fredoka"
               >
                 {'\u{1F4CA}'} Evolução dos Atributos
               </h2>
@@ -712,9 +705,8 @@ export function EF_SimulationScreen({
                 'w-full py-3.5 bg-amber-500 hover:bg-amber-600 active:bg-amber-700',
                 'text-white font-bold rounded-xl transition-all duration-200',
                 'shadow-lg hover:shadow-xl active:scale-[0.98]',
-                'animate-[fadeIn_0.5s_ease-out]',
+                'animate-[fadeIn_0.5s_ease-out] font-fredoka',
               ].join(' ')}
-              style={{ fontFamily: FREDOKA }}
             >
               {'\u{1F680}'} Continuar aventura!
             </button>
@@ -725,8 +717,7 @@ export function EF_SimulationScreen({
             <button
               onClick={onBack}
               aria-label="Voltar ao início"
-              className="w-full py-3 bg-amber-500 hover:bg-amber-600 text-white font-bold rounded-xl transition-colors"
-              style={{ fontFamily: FREDOKA }}
+              className="w-full py-3 bg-amber-500 hover:bg-amber-600 text-white font-bold rounded-xl transition-colors font-fredoka"
             >
               Voltar ao Início
             </button>

--- a/src/modules/eraforge/components/EF_StatsBar.tsx
+++ b/src/modules/eraforge/components/EF_StatsBar.tsx
@@ -1,11 +1,12 @@
 /**
- * EF_StatsBar - Child stats progress bars
+ * EF_StatsBar - Animated child stats progress bars
  *
- * Shows 3 progress bars for knowledge, cooperation, and courage.
- * Uses ceramic tokens for consistent styling.
+ * Shows 3 progress bars for knowledge, cooperation, and courage
+ * with Framer Motion spring animations on bar width and number pop.
  */
 
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
+import { motion, useSpring, useTransform } from 'framer-motion';
 
 interface EF_StatsBarProps {
   knowledge: number;
@@ -19,6 +20,28 @@ const STATS_CONFIG = [
   { key: 'cooperation', label: 'Cooperacao',   emoji: '🤝', color: 'bg-ceramic-success' },
   { key: 'courage',     label: 'Coragem',      emoji: '⚔️', color: 'bg-ceramic-warning' },
 ] as const;
+
+function AnimatedNumber({ value }: { value: number }) {
+  const spring = useSpring(value, { stiffness: 300, damping: 30 });
+  const display = useTransform(spring, (v) => Math.round(v));
+  const prevRef = useRef(value);
+  const isChanging = prevRef.current !== value;
+
+  useEffect(() => {
+    spring.set(value);
+    prevRef.current = value;
+  }, [value, spring]);
+
+  return (
+    <motion.span
+      className="text-xs text-ceramic-text-secondary w-6 text-right font-medium tabular-nums"
+      animate={isChanging ? { scale: [1, 1.3, 1] } : { scale: 1 }}
+      transition={{ duration: 0.4 }}
+    >
+      {display}
+    </motion.span>
+  );
+}
 
 export function EF_StatsBar({ knowledge, cooperation, courage, max = 100 }: EF_StatsBarProps) {
   const values: Record<string, number> = {
@@ -36,15 +59,14 @@ export function EF_StatsBar({ knowledge, cooperation, courage, max = 100 }: EF_S
         return (
           <div key={stat.key} className="flex items-center gap-2">
             <span className="text-xs w-4 text-center">{stat.emoji}</span>
-            <div className="flex-1 h-2 bg-ceramic-inset rounded-full overflow-hidden">
-              <div
-                className={`h-full rounded-full transition-all duration-500 ${stat.color}`}
-                style={{ width: `${pct}%` }}
+            <div className="flex-1 h-2 bg-ceramic-cool shadow-ceramic-inset rounded-full overflow-hidden">
+              <motion.div
+                className={`h-full rounded-full ${stat.color}`}
+                animate={{ width: `${pct}%` }}
+                transition={{ type: 'spring', stiffness: 300, damping: 30 }}
               />
             </div>
-            <span className="text-[10px] text-ceramic-text-secondary w-6 text-right font-medium">
-              {value}
-            </span>
+            <AnimatedNumber value={value} />
           </div>
         );
       })}

--- a/src/modules/eraforge/components/EF_TurnCounter.tsx
+++ b/src/modules/eraforge/components/EF_TurnCounter.tsx
@@ -1,37 +1,78 @@
 /**
- * EF_TurnCounter - Circular turn counter
+ * EF_TurnCounter - SVG progress ring turn counter
  *
- * Shows remaining turns in a circular badge.
+ * Shows remaining turns as an animated SVG ring with Framer Motion.
+ * Pulses when turns are low (<= 2).
  */
 
 import React from 'react';
+import { motion } from 'framer-motion';
+import { springElevation, pulseVariants } from '@/lib/animations/ceramic-motion';
 
 interface EF_TurnCounterProps {
   turnsRemaining: number;
   maxTurns?: number;
 }
 
+const RING_SIZE = 48;
+const STROKE_WIDTH = 4;
+const RADIUS = (RING_SIZE - STROKE_WIDTH) / 2;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+
 export function EF_TurnCounter({ turnsRemaining, maxTurns = 10 }: EF_TurnCounterProps) {
-  const pct = Math.min(100, (turnsRemaining / maxTurns) * 100);
+  const pct = Math.min(1, turnsRemaining / maxTurns);
+  const offset = CIRCUMFERENCE * (1 - pct);
   const isLow = turnsRemaining <= 2;
 
   return (
-    <div className="flex flex-col items-center gap-1">
-      <div
-        className={`w-12 h-12 rounded-full flex items-center justify-center shadow-ceramic-emboss ${
-          isLow ? 'bg-ceramic-error/10 ring-2 ring-ceramic-error' : 'bg-ceramic-card'
-        }`}
-      >
-        <span
-          className={`text-lg font-bold ${isLow ? 'text-ceramic-error' : 'text-ceramic-text-primary'}`}
-          style={{ fontFamily: "'Fredoka', 'Nunito', sans-serif" }}
+    <motion.div
+      className="flex flex-col items-center gap-1"
+      variants={isLow ? pulseVariants : undefined}
+      initial="initial"
+      animate={isLow ? 'pulse' : 'initial'}
+    >
+      <div className="relative" style={{ width: RING_SIZE, height: RING_SIZE }}>
+        {/* Background ring */}
+        <svg
+          width={RING_SIZE}
+          height={RING_SIZE}
+          className="absolute inset-0 -rotate-90"
         >
-          {turnsRemaining}
-        </span>
+          <circle
+            cx={RING_SIZE / 2}
+            cy={RING_SIZE / 2}
+            r={RADIUS}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={STROKE_WIDTH}
+            className="text-ceramic-border"
+          />
+          <motion.circle
+            cx={RING_SIZE / 2}
+            cy={RING_SIZE / 2}
+            r={RADIUS}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={STROKE_WIDTH}
+            strokeLinecap="round"
+            strokeDasharray={CIRCUMFERENCE}
+            animate={{ strokeDashoffset: offset }}
+            transition={springElevation}
+            className={isLow ? 'text-ceramic-error' : 'text-amber-500'}
+          />
+        </svg>
+        {/* Center number */}
+        <div className="absolute inset-0 flex items-center justify-center">
+          <span
+            className={`text-lg font-bold font-fredoka ${isLow ? 'text-ceramic-error' : 'text-ceramic-text-primary'}`}
+          >
+            {turnsRemaining}
+          </span>
+        </div>
       </div>
       <span className="text-[10px] text-ceramic-text-secondary font-medium">
         turnos
       </span>
-    </div>
+    </motion.div>
   );
 }

--- a/src/modules/eraforge/components/EF_VoiceWave.tsx
+++ b/src/modules/eraforge/components/EF_VoiceWave.tsx
@@ -2,32 +2,29 @@
  * EF_VoiceWave - Animated voice wave during recording/speaking
  *
  * Shows an animated sound wave visualization when STT is listening
- * or TTS is speaking. Includes mic/stop buttons as fallback controls.
- * Uses Ceramic design tokens with Fredoka/Nunito fonts.
+ * or TTS is speaking. Uses Framer Motion for smooth bar animations.
+ * Includes glow effects on active states.
  */
 
 import React, { useMemo } from 'react';
+import { motion } from 'framer-motion';
 
 interface EF_VoiceWaveProps {
-  /** Whether the microphone is actively listening */
   isListening?: boolean;
-  /** Whether TTS audio is playing */
   isSpeaking?: boolean;
-  /** Interim transcript text to display */
   interimTranscript?: string;
-  /** Callback to start listening */
   onListen?: () => void;
-  /** Callback to stop speaking */
   onStopSpeaking?: () => void;
-  /** Whether voice is supported */
   voiceSupported?: boolean;
-  /** Error message */
   error?: string | null;
-  /** Additional className */
   className?: string;
 }
 
 const BAR_COUNT = 5;
+
+// Heights vary per bar for frequency-like effect (center tallest)
+const BAR_MAX_HEIGHTS = [16, 22, 28, 22, 16];
+const BAR_MIN_HEIGHT = 6;
 
 export function EF_VoiceWave({
   isListening = false,
@@ -41,7 +38,6 @@ export function EF_VoiceWave({
 }: EF_VoiceWaveProps) {
   const isActive = isListening || isSpeaking;
 
-  // Generate bar animation delays
   const barDelays = useMemo(
     () => Array.from({ length: BAR_COUNT }, (_, i) => i * 0.12),
     []
@@ -49,32 +45,48 @@ export function EF_VoiceWave({
 
   if (!voiceSupported) {
     return (
-      <div className={`flex items-center gap-2 text-ceramic-text-secondary text-xs font-nunito ${className}`}>
+      <div className={`flex items-center gap-2 text-ceramic-text-secondary text-xs ${className}`}>
         <span>Voz não disponível neste navegador</span>
       </div>
     );
   }
 
+  const glowClass = isActive
+    ? isListening
+      ? 'shadow-[0_0_12px_rgba(217,119,6,0.3)]'
+      : 'shadow-[0_0_12px_rgba(123,143,162,0.3)]'
+    : '';
+
   return (
     <div className={`flex items-center gap-3 ${className}`}>
       {/* Wave visualization */}
-      <div className="flex items-center gap-0.5 h-8 min-w-[40px]">
+      <div className={`flex items-center gap-0.5 h-8 min-w-[40px] rounded-lg px-1 transition-shadow duration-300 ${glowClass}`}>
         {barDelays.map((delay, i) => (
-          <div
+          <motion.div
             key={i}
-            className={`w-1 rounded-full transition-all duration-200 ${
+            className={`w-1 rounded-full ${
               isActive
                 ? isListening
                   ? 'bg-amber-500'
                   : 'bg-ceramic-info'
                 : 'bg-ceramic-border'
             }`}
-            style={{
-              height: isActive ? undefined : '8px',
-              animation: isActive
-                ? `ef-voice-wave 0.8s ease-in-out ${delay}s infinite alternate`
-                : 'none',
+            animate={{
+              height: isActive
+                ? [BAR_MIN_HEIGHT, BAR_MAX_HEIGHTS[i], BAR_MIN_HEIGHT]
+                : BAR_MIN_HEIGHT,
             }}
+            transition={
+              isActive
+                ? {
+                    duration: 0.8,
+                    delay,
+                    repeat: Infinity,
+                    repeatType: 'reverse' as const,
+                    ease: 'easeInOut',
+                  }
+                : { duration: 0.2 }
+            }
           />
         ))}
       </div>
@@ -82,23 +94,23 @@ export function EF_VoiceWave({
       {/* Status / Transcript */}
       <div className="flex-1 min-w-0">
         {error ? (
-          <span className="text-ceramic-error text-xs font-nunito truncate block">{error}</span>
+          <span className="text-ceramic-error text-xs truncate block">{error}</span>
         ) : isListening && interimTranscript ? (
-          <span className="text-ceramic-text-primary text-sm font-nunito truncate block italic">
+          <span className="text-ceramic-text-primary text-sm truncate block italic">
             {interimTranscript}...
           </span>
         ) : isListening ? (
-          <span className="text-amber-600 text-xs font-nunito animate-pulse">
+          <span className="text-amber-600 text-xs animate-pulse">
             Ouvindo...
           </span>
         ) : isSpeaking ? (
-          <span className="text-ceramic-info text-xs font-nunito animate-pulse">
+          <span className="text-ceramic-info text-xs animate-pulse">
             Falando...
           </span>
         ) : null}
       </div>
 
-      {/* Controls — always visible as fallback */}
+      {/* Controls */}
       <div className="flex items-center gap-2 shrink-0">
         {isSpeaking ? (
           <button
@@ -127,21 +139,9 @@ export function EF_VoiceWave({
           </button>
         )}
       </div>
-
-      {/* CSS animation for wave bars */}
-      <style>{`
-        @keyframes ef-voice-wave {
-          0% { height: 6px; }
-          100% { height: 24px; }
-        }
-      `}</style>
     </div>
   );
 }
-
-// ============================================
-// INLINE ICONS (to avoid external deps)
-// ============================================
 
 function MicIcon() {
   return (

--- a/src/modules/eraforge/views/EraForgeMainView.tsx
+++ b/src/modules/eraforge/views/EraForgeMainView.tsx
@@ -12,7 +12,9 @@ import React, { useEffect, useState, useCallback, useRef } from 'react';
 import { useEraforgeGame } from '../contexts/EraforgeGameContext';
 import { EraforgeGameService } from '../services/eraforgeGameService';
 import { EraforgeAIService } from '../services/eraforgeAIService';
+import type { SimulationResult } from '../services/eraforgeAIService';
 import { useEraforgeVoiceHook } from '../hooks/useEraforgeVoice';
+import { useEraforgeTurns } from '../hooks/useEraforgeTurns';
 import { supabase } from '@/services/supabaseClient';
 import { EF_HomeScreen } from '../components/EF_HomeScreen';
 import { EF_GameScreen } from '../components/EF_GameScreen';
@@ -28,6 +30,8 @@ import type {
   TurnConsequences,
   WorldCreateInput,
   ChildProfileCreateInput,
+  SimulationEvent,
+  StatsDelta,
 } from '../types/eraforge.types';
 import { getNextEra, ERA_CONFIG } from '../types/eraforge.types';
 
@@ -38,6 +42,7 @@ const DEFAULT_TURNS = 5;
 export default function EraForgeMainView() {
   const { state, actions } = useEraforgeGame();
   const voice = useEraforgeVoiceHook();
+  const turnsPersistence = useEraforgeTurns();
 
   // Data loading state
   const [worlds, setWorlds] = useState<World[]>([]);
@@ -51,6 +56,7 @@ export default function EraForgeMainView() {
   const [isLoadingAI, setIsLoadingAI] = useState(false);
   const [turns, setTurns] = useState<Turn[]>([]);
   const [isCreating, setIsCreating] = useState(false);
+  const [simulationData, setSimulationData] = useState<SimulationResult | null>(null);
 
   // Ref to track whether we've already initiated game start for the current child
   const gameStartedRef = useRef(false);
@@ -124,6 +130,13 @@ export default function EraForgeMainView() {
         consequences: {},
         created_at: new Date().toISOString(),
       };
+
+      // Persist to DB (fire-and-forget, don't block UI)
+      turnsPersistence.createTurn({
+        world_id: state.currentWorld.id,
+        child_id: state.currentChild.id,
+        scenario: result.data.scenario,
+      }).catch(err => log.warn('Failed to persist turn:', err));
 
       return turn;
     } catch (err) {
@@ -335,6 +348,13 @@ export default function EraForgeMainView() {
           ),
         );
 
+        // Persist decision to DB (fire-and-forget)
+        if (turns.length > 0) {
+          const currentTurnId = turns[turns.length - 1].id;
+          turnsPersistence.submitDecision(currentTurnId, choiceId, consequences)
+            .catch(err => log.warn('Failed to persist decision:', err));
+        }
+
         // Narrate the consequence via TTS
         if (voice.voiceSupported && consequences.narrative) {
           voice.speak(consequences.narrative);
@@ -523,6 +543,43 @@ export default function EraForgeMainView() {
     actions.endGame();
   }, [persistGameProgress, state.currentWorld, state.currentChild, actions]);
 
+  // ------- SIMULATION HANDLER -------
+
+  const handleStartSimulation = useCallback(async () => {
+    if (!state.currentWorld || !state.currentMember) {
+      log.error('Cannot start simulation: missing world or member');
+      return;
+    }
+
+    setIsLoadingAI(true);
+    try {
+      const result = await EraforgeAIService.runSimulation(
+        state.currentWorld.id,
+        state.currentWorld.name,
+        state.currentWorld.current_era,
+        state.currentWorld.era_progress,
+        {
+          knowledge: state.currentMember.knowledge,
+          cooperation: state.currentMember.cooperation,
+          courage: state.currentMember.courage,
+        },
+      );
+
+      if (result.data) {
+        setSimulationData(result.data);
+        actions.goSimulation();
+      } else {
+        log.error('Failed to run simulation:', result.error);
+        actions.setError('Erro ao executar simulação');
+      }
+    } catch (err) {
+      log.error('Unexpected error running simulation:', err);
+      actions.setError('Erro inesperado na simulação');
+    } finally {
+      setIsLoadingAI(false);
+    }
+  }, [state.currentWorld, state.currentMember, actions]);
+
   // ------- PARENT DASHBOARD HANDLERS -------
 
   const handleVerifyPin = useCallback(async (_pin: string): Promise<boolean> => {
@@ -603,18 +660,36 @@ export default function EraForgeMainView() {
           onStartListening={voice.listen}
           onStopSpeaking={voice.stopSpeaking}
           onSpeak={voice.speak}
+          onSimulate={handleStartSimulation}
         />
       );
 
-    case 'SIMULATION':
+    case 'SIMULATION': {
+      const simStats = state.currentMember ? {
+        knowledge: state.currentMember.knowledge,
+        cooperation: state.currentMember.cooperation,
+        courage: state.currentMember.courage,
+      } : { knowledge: 50, cooperation: 50, courage: 50 };
+      const simDelta = simulationData?.stats_delta ?? {};
+      const simAfter = {
+        knowledge: simStats.knowledge + (simDelta.knowledge ?? 0),
+        cooperation: simStats.cooperation + (simDelta.cooperation ?? 0),
+        courage: simStats.courage + (simDelta.courage ?? 0),
+      };
       return (
         <EF_SimulationScreen
-          events={[]}
-          summary=""
-          statsDelta={{}}
+          events={simulationData?.events ?? []}
+          summary={simulationData?.summary ?? ''}
+          statsDelta={simDelta}
+          statsBefore={simStats}
+          statsAfter={simAfter}
           onBack={() => actions.goHome()}
+          onSpeak={voice.speak}
+          isSpeaking={voice.isSpeaking}
+          onStopSpeaking={voice.stopSpeaking}
         />
       );
+    }
 
     case 'PARENT_DASHBOARD':
       return (

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,6 +8,7 @@ export default {
         extend: {
             fontFamily: {
                 sans: ['Inter', 'system-ui', 'sans-serif'],
+                fredoka: ['Fredoka', 'Nunito', 'sans-serif'],
             },
             colors: {
                 'aurora-blue': '#6366f1',
@@ -39,12 +40,15 @@ export default {
                 'ceramic-warning-bg': '#F8F0E5',
                 'ceramic-success-bg': '#F0F3ED',
                 'ceramic-error-bg': '#F5EFED',
+                'ceramic-card': '#F0EFE9',
+                'ceramic-border': '#DDD8CF',
             },
             animation: {
                 'fade-in-up': 'fadeInUp 0.5s cubic-bezier(0.2, 0.8, 0.2, 1) forwards',
                 'scale-in': 'scaleIn 0.3s cubic-bezier(0.2, 0.8, 0.2, 1) forwards',
                 'float': 'float 8s ease-in-out infinite',
                 'pulse-slow': 'pulseSlow 3s infinite',
+                'shimmer': 'shimmer 2s ease-in-out infinite',
             },
             keyframes: {
                 fadeInUp: {
@@ -62,9 +66,14 @@ export default {
                 pulseSlow: {
                     '0%, 100%': { opacity: '1', transform: 'scale(1)' },
                     '50%': { opacity: '0.9', transform: 'scale(0.95)' },
+                },
+                shimmer: {
+                    '0%': { backgroundPosition: '200% 0' },
+                    '100%': { backgroundPosition: '-200% 0' },
                 }
             },
             boxShadow: {
+                'ceramic-emboss': '4px 4px 10px rgba(163, 158, 145, 0.15), -4px -4px 10px rgba(255, 255, 255, 0.90)',
                 'ceramic-inset': 'inset 3px 3px 6px rgba(163, 158, 145, 0.25), inset -3px -3px 6px rgba(255, 255, 255, 0.95)',
                 'ceramic-elevated': '5px 5px 10px rgba(163, 158, 145, 0.25), -5px -5px 10px rgba(255, 255, 255, 0.95)',
                 // Digital Desire - Landing Page V2 shadows


### PR DESCRIPTION
## Summary
- **Phase 0**: Add `font-fredoka`, `ceramic-card`, `ceramic-border`, `ceramic-emboss`, `shimmer` tokens to `tailwind.config.js` — fixes phantom CSS classes across ALL EraForge components
- **Phase 1**: Visual polish on 4 small components (SceneRenderer, StatsBar, TurnCounter, VoiceWave) with Framer Motion animations, SVG progress ring, era-specific scenes
- **Phase 2**: Framer Motion phase transitions on GameScreen (AnimatePresence + EFButton extraction), entrance animations on HomeScreen (stagger cards + card elevation), frosted glass AdvisorPanel bubble, Ceramic token cleanup on SimulationScreen
- **Phase 3**: CRITICAL fix — wire `useEraforgeTurns.createTurn()` and `submitDecision()` for turn persistence to DB; wire `EraforgeAIService.runSimulation()` with real data to SimulationScreen

## Files Changed (10)
| File | Change |
|------|--------|
| `tailwind.config.js` | +fredoka font, +ceramic-card/border/emboss tokens |
| `EF_SceneRenderer.tsx` | Era scene components + frosted glass label |
| `EF_StatsBar.tsx` | Framer Motion spring bars + animated numbers |
| `EF_TurnCounter.tsx` | SVG progress ring + pulse on low turns |
| `EF_VoiceWave.tsx` | Framer Motion bars replacing CSS keyframes |
| `EF_GameScreen.tsx` | EFButton, AnimatePresence PhaseCard, onSimulate |
| `EF_HomeScreen.tsx` | Page entrance + stagger + card elevation |
| `EF_AdvisorPanel.tsx` | Frosted glass bubble + Framer Motion |
| `EF_SimulationScreen.tsx` | Ceramic tokens + font-fredoka cleanup |
| `EraForgeMainView.tsx` | Turn persistence + simulation wiring |

## Test plan
- [ ] `npm run build` passes
- [ ] `npm run typecheck` — no new errors (pre-existing only)
- [ ] SceneRenderer shows era-specific scenes (stone_age, ancient_egypt, classical_greece, medieval) with frosted glass label
- [ ] GameScreen phases transition smoothly with Framer Motion
- [ ] HomeScreen has entrance animation with staggered cards
- [ ] StatsBar numbers animate on value change
- [ ] TurnCounter shows SVG progress ring, pulses when turns <= 2
- [ ] AdvisorPanel bubble uses frosted glass design
- [ ] "Simular 14 dias" button appears in day_complete phase
- [ ] After playing: turns should persist to `eraforge_turns` table

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulation feature with "Simulate 14 Days" button in game screen.
  * Implemented era-specific scene rendering with dynamic visuals.

* **UI/UX Improvements**
  * Enhanced animations throughout: advisor panel, game phases, stats bars, turn counter, and voice wave visualizer.
  * Improved visual transitions and feedback for form submissions and state changes.
  * Applied consistent typography and updated color scheme for better visual coherence.
  * Added frosted glass styling for advisor hints and refined button interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->