### PR TITLE
fix(pwa): prevent nginx from caching sw.js and index.html

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -81,11 +81,19 @@ server {
     # CACHING
     # ==========================================================================
 
+    # Service worker files — NEVER cache (must be fresh on every load)
+    location ~* ^/(sw\.js|workbox-.*)$ {
+        expires -1;
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        add_header X-Content-Type-Options "nosniff" always;
+    }
+
     # Cache para assets estáticos (JS, CSS, imagens, fontes)
+    # Excludes sw.js/workbox files (handled above)
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot|webp|avif)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";
-        
+
         # Repetir headers de segurança (add_header em location sobrescreve os do server)
         add_header X-Content-Type-Options "nosniff" always;
     }
@@ -97,6 +105,13 @@ server {
     # SPA - Redirecionar tudo para index.html
     location / {
         try_files $uri $uri/ /index.html;
+
+        # index.html must never be cached (references hashed assets + sw.js)
+        location = /index.html {
+            expires -1;
+            add_header Cache-Control "no-cache, no-store, must-revalidate";
+            add_header X-Content-Type-Options "nosniff" always;
+        }
     }
 
     # Health check para Cloud Run


### PR DESCRIPTION
## Summary
- Service worker files (`sw.js`, `workbox-*`) were cached for 1 year with `immutable`, preventing browsers from detecting SW updates
- This caused `bad-precaching-response` errors (404) for old asset hashes after deploys
- Add `no-cache` rules for `sw.js`, `workbox-*`, and `index.html`
- Static assets with hashed filenames keep the 1y immutable cache

## Root cause
nginx rule `location ~* \.(js|css|...)` matched ALL `.js` files including `sw.js`. After a deploy, the old cached `sw.js` referenced old asset hashes that no longer exist → 404.

## Test plan
- [x] `npm run build` passes
- [ ] Deploy, verify `sw.js` returns `Cache-Control: no-cache`
- [ ] Verify hashed assets still return `Cache-Control: immutable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)