### PR TITLE
fix(eraforge): improve scene visibility with larger elements and zoomed viewBox

### DIFF
--- a/src/modules/eraforge/components/EF_SceneRenderer.tsx
+++ b/src/modules/eraforge/components/EF_SceneRenderer.tsx
@@ -48,13 +48,13 @@ export function EF_SceneRenderer({ era }: EF_SceneRendererProps) {
   return (
     <motion.div
       className="relative rounded-xl overflow-hidden shadow-ceramic-emboss"
-      style={{ height: 180 }}
+      style={{ height: 240 }}
       variants={pageTransitionVariants}
       initial="initial"
       animate="animate"
     >
       <svg
-        viewBox="0 0 400 180"
+        viewBox="0 20 400 160"
         className="w-full h-full"
         preserveAspectRatio="xMidYMid slice"
       >

--- a/src/modules/eraforge/components/scenes/AncientEgyptScene.tsx
+++ b/src/modules/eraforge/components/scenes/AncientEgyptScene.tsx
@@ -32,9 +32,9 @@ export function AncientEgyptScene({ children, isAnimating }: SceneChildProps) {
       <ellipse cx={300} cy={140} rx={100} ry={18} fill="#EAB308" opacity="0.4" />
 
       {/* Pyramids */}
-      <Pyramid x={80} y={148} width={90} height={65} color="#D97706" shadowColor="#92400E" />
-      <Pyramid x={170} y={148} width={70} height={50} color="#EAB308" shadowColor="#A16207" />
-      <Pyramid x={245} y={148} width={50} height={35} color="#D97706" shadowColor="#92400E" />
+      <Pyramid x={80} y={148} width={110} height={80} color="#D97706" shadowColor="#92400E" />
+      <Pyramid x={180} y={148} width={85} height={62} color="#EAB308" shadowColor="#A16207" />
+      <Pyramid x={260} y={148} width={60} height={45} color="#D97706" shadowColor="#92400E" />
 
       {/* Sphinx silhouette */}
       <g aria-label="Esfinge" opacity="0.6">
@@ -47,9 +47,9 @@ export function AncientEgyptScene({ children, isAnimating }: SceneChildProps) {
       <Water y={148} height={14} color="#2563EB" waveColor="#60A5FA" />
 
       {/* Palm trees along Nile */}
-      <Tree x={290} y={145} height={42} leafColor="#16A34A" trunkColor="#78716C" type="palm" />
-      <Tree x={330} y={147} height={35} leafColor="#15803D" trunkColor="#92400E" type="palm" />
-      <Tree x={370} y={146} height={38} leafColor="#16A34A" trunkColor="#78716C" type="palm" />
+      <Tree x={290} y={145} height={52} leafColor="#16A34A" trunkColor="#78716C" type="palm" />
+      <Tree x={330} y={147} height={45} leafColor="#15803D" trunkColor="#92400E" type="palm" />
+      <Tree x={370} y={146} height={48} leafColor="#16A34A" trunkColor="#78716C" type="palm" />
 
       {/* Desert ground */}
       <DesertGround y={155} />
@@ -73,14 +73,14 @@ export function AncientEgyptScene({ children, isAnimating }: SceneChildProps) {
             y={125}
             emoji={child.avatar_emoji || '🏺'}
             color={child.avatar_color || '#EAB308'}
-            scale={0.65}
+            scale={0.85}
             name={child.child_id}
           />
         ))
       ) : (
         <>
-          <Character x={135} y={125} emoji="🏺" color="#EAB308" scale={0.6} />
-          <Character x={175} y={128} emoji="📜" color="#FBBF24" scale={0.55} />
+          <Character x={135} y={115} emoji="🏺" color="#EAB308" scale={0.9} />
+          <Character x={180} y={118} emoji="📜" color="#FBBF24" scale={0.8} />
         </>
       )}
     </g>

--- a/src/modules/eraforge/components/scenes/ClassicalGreeceScene.tsx
+++ b/src/modules/eraforge/components/scenes/ClassicalGreeceScene.tsx
@@ -27,16 +27,16 @@ export function ClassicalGreeceScene({ children }: SceneChildProps) {
       {/* Island/hill */}
       <ellipse cx={200} cy={130} rx={180} ry={40} fill="#86EFAC" />
 
-      {/* Temple / Parthenon */}
+      {/* Temple / Parthenon — enlarged */}
       <g aria-label="Templo">
         {/* Base */}
-        <rect x={120} y={92} width={80} height={6} fill="#E7E5E4" rx="1" />
-        <rect x={125} y={98} width={70} height={32} fill="#D6D3D1" />
+        <rect x={100} y={82} width={110} height={8} fill="#E7E5E4" rx="1" />
+        <rect x={105} y={90} width={100} height={40} fill="#D6D3D1" />
         {/* Pediment */}
-        <polygon points="118,92 160,72 202,92" fill="#E7E5E4" />
+        <polygon points="96,82 155,56 214,82" fill="#E7E5E4" />
         {/* Columns */}
-        {[130, 145, 160, 175, 190].map((cx, i) => (
-          <rect key={i} x={cx} y={92} width={5} height={38} fill="#F5F5F4" rx="2" />
+        {[110, 128, 146, 164, 182, 198].map((cx, i) => (
+          <rect key={i} x={cx} y={82} width={6} height={48} fill="#F5F5F4" rx="2" />
         ))}
       </g>
 
@@ -48,8 +48,8 @@ export function ClassicalGreeceScene({ children }: SceneChildProps) {
       </g>
 
       {/* Olive trees */}
-      <Tree x={55} y={128} height={32} leafColor="#84CC16" type="round" />
-      <Tree x={350} y={128} height={28} leafColor="#84CC16" type="round" />
+      <Tree x={55} y={128} height={42} leafColor="#84CC16" type="round" />
+      <Tree x={350} y={128} height={38} leafColor="#84CC16" type="round" />
 
       {/* Ground */}
       <rect x="0" y={130} width={400} height={50} fill="#22C55E" opacity="0.3" />
@@ -63,12 +63,12 @@ export function ClassicalGreeceScene({ children }: SceneChildProps) {
             y={108}
             emoji={child.avatar_emoji || '🏛️'}
             color={child.avatar_color || '#3B82F6'}
-            scale={0.6}
+            scale={0.85}
             name={child.child_id}
           />
         ))
       ) : (
-        <Character x={230} y={108} emoji="🏛️" color="#60A5FA" scale={0.6} />
+        <Character x={230} y={100} emoji="🏛️" color="#60A5FA" scale={0.9} />
       )}
     </g>
   );

--- a/src/modules/eraforge/components/scenes/MedievalScene.tsx
+++ b/src/modules/eraforge/components/scenes/MedievalScene.tsx
@@ -32,13 +32,13 @@ export function MedievalScene({ children, isAnimating }: SceneChildProps) {
       <ellipse cx={200} cy={135} rx={100} ry={30} fill="#4ADE80" opacity="0.5" />
       <ellipse cx={350} cy={138} rx={70} ry={22} fill="#86EFAC" opacity="0.6" />
 
-      {/* Castle */}
-      <Castle x={70} y={138} width={70} height={60} color="#A8A29E" roofColor="#991B1B" />
+      {/* Castle — enlarged */}
+      <Castle x={70} y={138} width={90} height={75} color="#A8A29E" roofColor="#991B1B" />
 
       {/* Forest edge */}
-      <Tree x={170} y={140} height={40} leafColor="#15803D" type="pine" />
-      <Tree x={195} y={142} height={35} leafColor="#16A34A" type="round" />
-      <Tree x={215} y={140} height={42} leafColor="#15803D" type="pine" />
+      <Tree x={170} y={140} height={50} leafColor="#15803D" type="pine" />
+      <Tree x={195} y={142} height={45} leafColor="#16A34A" type="round" />
+      <Tree x={215} y={140} height={52} leafColor="#15803D" type="pine" />
 
       {/* Village houses */}
       <g aria-label="Vila">
@@ -114,14 +114,14 @@ export function MedievalScene({ children, isAnimating }: SceneChildProps) {
             y={125}
             emoji={child.avatar_emoji || '🏰'}
             color={child.avatar_color || '#A8A29E'}
-            scale={0.65}
+            scale={0.85}
             name={child.child_id}
           />
         ))
       ) : (
         <>
-          <Character x={145} y={125} emoji="🏰" color="#A8A29E" scale={0.6} />
-          <Character x={240} y={128} emoji="⚔️" color="#D6D3D1" scale={0.55} />
+          <Character x={145} y={115} emoji="🏰" color="#A8A29E" scale={0.9} />
+          <Character x={240} y={118} emoji="⚔️" color="#D6D3D1" scale={0.8} />
         </>
       )}
     </g>

--- a/src/modules/eraforge/components/scenes/StoneAgeScene.tsx
+++ b/src/modules/eraforge/components/scenes/StoneAgeScene.tsx
@@ -47,12 +47,12 @@ export function StoneAgeScene({ children, isAnimating }: SceneChildProps) {
       </g>
 
       {/* Trees */}
-      <Tree x={200} y={148} height={45} leafColor="#15803D" type="round" />
-      <Tree x={270} y={150} height={35} leafColor="#16A34A" type="pine" />
-      <Tree x={340} y={148} height={40} leafColor="#15803D" type="round" />
+      <Tree x={200} y={148} height={55} leafColor="#15803D" type="round" />
+      <Tree x={270} y={150} height={45} leafColor="#16A34A" type="pine" />
+      <Tree x={340} y={148} height={50} leafColor="#15803D" type="round" />
 
       {/* Campfire */}
-      <Fire x={175} y={142} scale={0.9} />
+      <Fire x={175} y={138} scale={1.3} />
 
       {/* Ground */}
       <StoneGround y={150} />
@@ -69,14 +69,14 @@ export function StoneAgeScene({ children, isAnimating }: SceneChildProps) {
             y={125}
             emoji={child.avatar_emoji || '🦴'}
             color={child.avatar_color || '#FBBF24'}
-            scale={0.7}
+            scale={0.9}
             name={child.child_id}
           />
         ))
       ) : (
         <>
-          <Character x={110} y={125} emoji="🦴" color="#FBBF24" scale={0.65} />
-          <Character x={155} y={128} emoji="🪨" color="#F97316" scale={0.55} />
+          <Character x={110} y={118} emoji="🦴" color="#FBBF24" scale={0.9} />
+          <Character x={160} y={120} emoji="🪨" color="#F97316" scale={0.8} />
         </>
       )}
     </g>


### PR DESCRIPTION
## Summary
- Scene container height increased from 180px to 240px (33% more space)
- SVG viewBox cropped to remove empty sky area, zooming ~12% into scene elements
- Character scales increased from 0.55-0.65 to 0.8-0.9 across all 4 scenes
- Trees, fire, pyramids, temple, castle all enlarged for better mobile visibility

## Test plan
- [ ] Open EraForge on mobile viewport (~375px wide) — scene elements clearly visible
- [ ] StoneAge: cave, fire, trees, characters all prominent
- [ ] Egypt: pyramids dominate scene, palm trees visible
- [ ] Greece: temple with 6 large columns, olive trees
- [ ] Medieval: castle prominent, village houses, forest visible
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted visual layout and scaling across Ancient Egypt, Classical Greece, Medieval, and Stone Age scenes to improve visual balance and proportions.
  * Enhanced character sizing and positioning for better scene composition.
  * Enlarged key environmental elements (pyramids, temples, castles, trees) for improved visual hierarchy.
  * Refined scene container dimensions and rendering area alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->