### PR TITLE
fix(pwa): Phase 2 recovery — clean SW with safeguards

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -47,9 +47,6 @@ export default defineConfig(() => {
     plugins: [
       react(),
       VitePWA({
-        // TEMPORARY: selfDestroying nukes the broken SW + all caches for existing users.
-        // After 1-2 deploys, remove this line and set selfDestroying: false.
-        selfDestroying: true,
         registerType: 'autoUpdate',
         includeAssets: ['favicon.svg'],
         manifest: {
@@ -84,9 +81,13 @@ export default defineConfig(() => {
         },
         workbox: {
           globPatterns: ['**/*.{js,css,html,svg,png,ico,woff2}'],
+          // Exclude unhashed files from precache manifest to prevent stale entries
+          globIgnores: ['**/sw-share-target.js'],
           skipWaiting: true,
           clientsClaim: true,
           cleanupOutdatedCaches: true,
+          // Prevent Workbox navigation fallback from serving index.html for /assets/ paths
+          navigateFallbackDenylist: [/^\/assets\//, /^\/api\//],
           importScripts: ['/sw-share-target.js'],
           runtimeCaching: [
             {


### PR DESCRIPTION
## Summary
- Remove `selfDestroying: true` — the broken SW has been successfully cleaned up in production (verified via browser: 0 registrations, no controller)
- Add `navigateFallbackDenylist: [/^\/assets\//, /^\/api\//]` — prevents Workbox from ever serving `index.html` for hashed asset paths (root cause of `bad-precaching-response`)
- Add `globIgnores: ['**/sw-share-target.js']` — excludes unhashed file from precache manifest (loaded via `importScripts` instead)

## Context
Phase 1 (PRs #360, #362) deployed `selfDestroying: true` + nginx `try_files $uri =404`. Browser verification confirmed the old SW is fully cleaned up. This Phase 2 restores a properly configured Workbox SW with safeguards against the original issue.

## Test plan
- [x] `npm run build` passes (82 precache entries)
- [x] Generated `sw.js` includes `navigateFallbackDenylist` with `/assets/` and `/api/`
- [x] `sw-share-target.js` NOT in precache manifest
- [x] Browser verification: 0 SW registrations, no controller on production
- [ ] Deploy staging → verify SW registers and precaches cleanly
- [ ] Deploy production → verify no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)