### PR TITLE
feat(eraforge): add navigation header and fix screen navigation flow

### DIFF
--- a/src/modules/eraforge/components/EF_GameScreen.tsx
+++ b/src/modules/eraforge/components/EF_GameScreen.tsx
@@ -10,7 +10,8 @@
 
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { pageTransitionVariants, staggerContainer, staggerItem, springElevation } from '@/lib/animations/ceramic-motion';
+import { pageTransitionVariants, staggerContainer, staggerItem, springElevation, springPress } from '@/lib/animations/ceramic-motion';
+import { EF_NavHeader } from './EF_NavHeader';
 import { EF_SceneRenderer } from './EF_SceneRenderer';
 import { EF_StatsBar } from './EF_StatsBar';
 import { EF_AdvisorPanel } from './EF_AdvisorPanel';
@@ -63,6 +64,9 @@ export interface EF_GameScreenProps {
   onStopSpeaking?: () => void;
   onSpeak?: (text: string) => void;
   onSimulate?: () => void;
+  worldName?: string;
+  eraLabel?: string;
+  onBack?: () => void;
 }
 
 // ============================================
@@ -131,6 +135,9 @@ export function EF_GameScreen({
   onStopSpeaking,
   onSpeak,
   onSimulate,
+  worldName,
+  eraLabel,
+  onBack,
 }: EF_GameScreenProps) {
   const scenario = currentTurn?.scenario;
 
@@ -138,6 +145,7 @@ export function EF_GameScreen({
   const [phase, setPhase] = useState<GamePhase>('scenario');
   const [prevMember, setPrevMember] = useState<WorldMember>(member);
   const [animatingStats, setAnimatingStats] = useState(false);
+  const [showExitConfirm, setShowExitConfirm] = useState(false);
   const phaseRef = useRef(phase);
   phaseRef.current = phase;
 
@@ -227,6 +235,19 @@ export function EF_GameScreen({
   const handleNextTurn = useCallback(() => {
     setPhase('turn_complete');
   }, []);
+
+  const handleBackPress = useCallback(() => {
+    if (phase === 'day_complete') {
+      onEndGame();
+    } else {
+      setShowExitConfirm(true);
+    }
+  }, [phase, onEndGame]);
+
+  const handleConfirmExit = useCallback(() => {
+    setShowExitConfirm(false);
+    onEndGame();
+  }, [onEndGame]);
 
   // ----- Render helpers -----
 
@@ -524,6 +545,10 @@ export function EF_GameScreen({
 
   // ----- Main render -----
 
+  const headerSubtitle = worldName && eraLabel
+    ? `${worldName} \u2022 ${eraLabel}`
+    : worldName || eraLabel || undefined;
+
   return (
     <motion.div
       className="flex flex-col min-h-screen bg-ceramic-base"
@@ -531,6 +556,12 @@ export function EF_GameScreen({
       initial="initial"
       animate="animate"
     >
+      <EF_NavHeader
+        title="Aventura"
+        subtitle={headerSubtitle}
+        onBack={onBack ? handleBackPress : undefined}
+      />
+
       {/* Top bar: stats + turns */}
       <div className="flex items-center justify-between p-4">
         <EF_StatsBar
@@ -558,19 +589,61 @@ export function EF_GameScreen({
         </AnimatePresence>
       </div>
 
-      {/* End Game shortcut */}
-      {phase !== 'day_complete' && phase !== 'turn_complete' && (
-        <div className="px-4 pb-6">
-          <button
-            onClick={onEndGame}
-            aria-label="Encerrar sessão de jogo"
-            className="w-full py-2 text-sm text-ceramic-text-secondary bg-ceramic-cool shadow-ceramic-inset
-                       rounded-lg hover:bg-ceramic-cool-hover transition-colors"
+      {/* Exit confirmation dialog */}
+      <AnimatePresence>
+        {showExitConfirm && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="fixed inset-0 z-50 flex items-center justify-center p-6"
           >
-            Encerrar Sessão
-          </button>
-        </div>
-      )}
+            {/* Backdrop */}
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              className="absolute inset-0 bg-black/30 backdrop-blur-sm"
+              onClick={() => setShowExitConfirm(false)}
+            />
+
+            {/* Dialog */}
+            <motion.div
+              initial={{ opacity: 0, scale: 0.92, y: 8 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.92, y: 8 }}
+              transition={{ type: 'spring', stiffness: 400, damping: 30 }}
+              className="relative w-full max-w-xs p-5 bg-white/80 backdrop-blur-md rounded-2xl shadow-ceramic-elevated text-center"
+            >
+              <h3 className="text-base font-bold text-ceramic-text-primary font-fredoka">
+                Sair da aventura?
+              </h3>
+              <p className="text-sm text-ceramic-text-secondary mt-2 leading-relaxed">
+                O progresso do turno atual sera perdido.
+              </p>
+              <div className="flex gap-3 mt-5">
+                <motion.button
+                  whileTap={{ scale: 0.95 }}
+                  transition={springPress}
+                  onClick={() => setShowExitConfirm(false)}
+                  className="flex-1 py-2.5 text-sm font-medium text-ceramic-text-secondary bg-ceramic-cool rounded-xl hover:bg-ceramic-cool-hover transition-colors"
+                >
+                  Cancelar
+                </motion.button>
+                <motion.button
+                  whileTap={{ scale: 0.95 }}
+                  transition={springPress}
+                  onClick={handleConfirmExit}
+                  className="flex-1 py-2.5 text-sm font-bold text-white bg-ceramic-error rounded-xl hover:opacity-90 transition-opacity"
+                >
+                  Sair
+                </motion.button>
+              </div>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </motion.div>
   );
 }

--- a/src/modules/eraforge/components/EF_HomeScreen.tsx
+++ b/src/modules/eraforge/components/EF_HomeScreen.tsx
@@ -14,6 +14,7 @@ import {
   staggerItem,
   cardElevationVariants,
 } from '@/lib/animations/ceramic-motion';
+import { EF_NavHeader } from './EF_NavHeader';
 import { ERA_CONFIG } from '../types/eraforge.types';
 import type { World, ChildProfile, Era, WorldCreateInput, ChildProfileCreateInput } from '../types/eraforge.types';
 
@@ -31,6 +32,8 @@ interface EF_HomeScreenProps {
   onCreateChild?: (input: ChildProfileCreateInput) => Promise<void>;
   loading?: boolean;
   isCreating?: boolean;
+  onBack?: () => void;
+  onParentDashboard?: () => void;
 }
 
 export function EF_HomeScreen({
@@ -43,6 +46,8 @@ export function EF_HomeScreen({
   onCreateChild,
   loading = false,
   isCreating = false,
+  onBack,
+  onParentDashboard,
 }: EF_HomeScreenProps) {
   const [showWorldForm, setShowWorldForm] = useState(false);
   const [showChildForm, setShowChildForm] = useState(false);
@@ -74,21 +79,23 @@ export function EF_HomeScreen({
   };
 
   return (
-    <motion.div
-      className="p-6 space-y-8"
-      variants={pageTransitionVariants}
-      initial="initial"
-      animate="animate"
-    >
-      {/* Header */}
-      <div className="text-center">
-        <h1 className="text-3xl font-bold text-ceramic-text-primary font-fredoka">
-          EraForge
-        </h1>
-        <p className="text-ceramic-text-secondary mt-2">
-          Escolha um mundo para explorar
-        </p>
-      </div>
+    <div className="flex flex-col min-h-screen bg-ceramic-base">
+      <EF_NavHeader
+        title="EraForge"
+        onBack={onBack}
+        onParentDashboard={onParentDashboard}
+        showParentAccess={!!onParentDashboard}
+      />
+      <motion.div
+        className="p-6 space-y-8 flex-1"
+        variants={pageTransitionVariants}
+        initial="initial"
+        animate="animate"
+      >
+      {/* Subtitle */}
+      <p className="text-ceramic-text-secondary text-center -mt-2">
+        Escolha um mundo para explorar
+      </p>
 
       {/* Children Section */}
       <div>
@@ -349,5 +356,6 @@ export function EF_HomeScreen({
         </div>
       )}
     </motion.div>
+    </div>
   );
 }

--- a/src/modules/eraforge/components/EF_NavHeader.tsx
+++ b/src/modules/eraforge/components/EF_NavHeader.tsx
@@ -1,0 +1,115 @@
+/**
+ * EF_NavHeader - Shared navigation header for all EraForge screens
+ *
+ * Frosted glass bar with back arrow, title, optional subtitle,
+ * and optional parent dashboard access icon.
+ * Uses Framer Motion for smooth entrance and tactile press feedback.
+ */
+
+import React from 'react';
+import { motion } from 'framer-motion';
+import { springPress } from '@/lib/animations/ceramic-motion';
+
+export interface EF_NavHeaderProps {
+  title: string;
+  subtitle?: string;
+  onBack?: () => void;
+  onParentDashboard?: () => void;
+  showParentAccess?: boolean;
+}
+
+export function EF_NavHeader({
+  title,
+  subtitle,
+  onBack,
+  onParentDashboard,
+  showParentAccess = false,
+}: EF_NavHeaderProps) {
+  return (
+    <motion.header
+      initial={{ opacity: 0, y: -8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3, ease: [0.4, 0, 0.2, 1] }}
+      className="sticky top-0 z-30 flex items-center h-14 px-3 bg-white/60 backdrop-blur-md border-b border-ceramic-border/40"
+    >
+      {/* Left: back button */}
+      <div className="w-10 flex-shrink-0">
+        {onBack && (
+          <motion.button
+            whileTap={{ scale: 0.85 }}
+            transition={springPress}
+            onClick={onBack}
+            aria-label="Voltar"
+            className="w-9 h-9 flex items-center justify-center rounded-full hover:bg-ceramic-cool/60 transition-colors"
+          >
+            <svg
+              width="20"
+              height="20"
+              viewBox="0 0 20 20"
+              fill="none"
+              className="text-ceramic-text-primary"
+            >
+              <path
+                d="M12.5 15L7.5 10L12.5 5"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </motion.button>
+        )}
+      </div>
+
+      {/* Center: title + subtitle */}
+      <div className="flex-1 min-w-0 text-center">
+        <h1 className="text-base font-bold text-ceramic-text-primary font-fredoka leading-tight truncate">
+          {title}
+        </h1>
+        {subtitle && (
+          <p className="text-[11px] text-ceramic-text-secondary leading-tight truncate mt-0.5">
+            {subtitle}
+          </p>
+        )}
+      </div>
+
+      {/* Right: parent dashboard icon */}
+      <div className="w-10 flex-shrink-0 flex justify-end">
+        {showParentAccess && onParentDashboard && (
+          <motion.button
+            whileTap={{ scale: 0.85 }}
+            transition={springPress}
+            onClick={onParentDashboard}
+            aria-label="Painel dos Pais"
+            className="w-9 h-9 flex items-center justify-center rounded-full hover:bg-ceramic-cool/60 transition-colors"
+          >
+            <svg
+              width="18"
+              height="18"
+              viewBox="0 0 18 18"
+              fill="none"
+              className="text-ceramic-text-secondary"
+            >
+              <rect
+                x="3"
+                y="7"
+                width="12"
+                height="9"
+                rx="2"
+                stroke="currentColor"
+                strokeWidth="1.5"
+              />
+              <path
+                d="M6 7V5a3 3 0 116 0v2"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+              />
+              <circle cx="9" cy="12" r="1.25" fill="currentColor" />
+            </svg>
+          </motion.button>
+        )}
+      </div>
+    </motion.header>
+  );
+}

--- a/src/modules/eraforge/components/EF_ParentDashboard.tsx
+++ b/src/modules/eraforge/components/EF_ParentDashboard.tsx
@@ -7,6 +7,7 @@
  */
 
 import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { EF_NavHeader } from './EF_NavHeader';
 import type { ChildProfile, ParentalSettings, WorldMember } from '../types/eraforge.types';
 
 // ─── Emoji Picker Grid ────────────────────────────────────
@@ -320,15 +321,12 @@ export function EF_ParentDashboard({
   // DASHBOARD (after PIN verified)
   // ═══════════════════════════════════════════════════════════
   return (
-    <div className="p-6 space-y-6 bg-ceramic-base min-h-screen">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <h1
-          className="text-2xl font-bold text-ceramic-text-primary"
-          style={fredokaFont}
-        >
-          Painel dos Pais
-        </h1>
+    <div className="bg-ceramic-base min-h-screen">
+      <EF_NavHeader title="Painel dos Pais" onBack={onBack} />
+
+      <div className="p-6 space-y-6">
+      {/* Lock button */}
+      <div className="flex justify-end">
         <button
           onClick={() => {
             setIsVerified(false);
@@ -752,6 +750,7 @@ export function EF_ParentDashboard({
           </div>
         </div>
       )}
+      </div>
     </div>
   );
 }

--- a/src/modules/eraforge/components/EF_SimulationScreen.tsx
+++ b/src/modules/eraforge/components/EF_SimulationScreen.tsx
@@ -12,6 +12,7 @@
  */
 
 import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import { EF_NavHeader } from './EF_NavHeader';
 import type { SimulationEvent, StatsDelta, Era } from '../types/eraforge.types';
 import { ERA_LABELS } from '../types/eraforge.types';
 
@@ -492,6 +493,8 @@ export function EF_SimulationScreen({
 
   return (
     <div className="flex flex-col min-h-full pb-6">
+      <EF_NavHeader title="Simulação" onBack={onBack} />
+
       {/* ---- Animated Title ---- */}
       {!titleDone ? (
         <div className="flex-1 flex items-center justify-center p-6">

--- a/src/modules/eraforge/views/EraForgeMainView.tsx
+++ b/src/modules/eraforge/views/EraForgeMainView.tsx
@@ -39,10 +39,25 @@ const log = createNamespacedLogger('EraForgeMainView');
 
 const DEFAULT_TURNS = 5;
 
-export default function EraForgeMainView() {
+interface EraForgeMainViewProps {
+  onExitToApp?: () => void;
+}
+
+export default function EraForgeMainView({ onExitToApp }: EraForgeMainViewProps = {}) {
   const { state, actions } = useEraforgeGame();
   const voice = useEraforgeVoiceHook();
   const turnsPersistence = useEraforgeTurns();
+
+  // ------- NAV HANDLERS -------
+
+  const handleExitToApp = useCallback(async () => {
+    actions.endGame();
+    onExitToApp?.();
+  }, [actions, onExitToApp]);
+
+  const handleGoParentDashboard = useCallback(() => {
+    actions.goParentDashboard();
+  }, [actions]);
 
   // Data loading state
   const [worlds, setWorlds] = useState<World[]>([]);
@@ -626,6 +641,8 @@ export default function EraForgeMainView() {
           onCreateChild={handleCreateChild}
           loading={loading}
           isCreating={isCreating}
+          onBack={handleExitToApp}
+          onParentDashboard={handleGoParentDashboard}
         />
       );
 
@@ -661,6 +678,9 @@ export default function EraForgeMainView() {
           onStopSpeaking={voice.stopSpeaking}
           onSpeak={voice.speak}
           onSimulate={handleStartSimulation}
+          worldName={state.currentWorld.name}
+          eraLabel={ERA_CONFIG[state.currentWorld.current_era]?.label}
+          onBack={handleEndGame}
         />
       );
 

--- a/src/router/AppRouter.tsx
+++ b/src/router/AppRouter.tsx
@@ -547,7 +547,7 @@ export function AppRouter() {
                   <ErrorBoundary fallback={<ModuleErrorFallback moduleName="EraForge" />}>
                      <EraforgeGameProvider>
                         <EraforgeVoiceProvider>
-                           <EraForgeMainView />
+                           <EraForgeMainView onExitToApp={() => setCurrentView('vida')} />
                         </EraforgeVoiceProvider>
                      </EraforgeGameProvider>
                   </ErrorBoundary>
@@ -743,7 +743,7 @@ export function AppRouter() {
                <Route path="/flux/parq/:athleteId" element={<ProtectedRoute><ErrorBoundary fallback={<ModuleErrorFallback moduleName="Flux" />}><FluxProvider><ParQFormView /></FluxProvider></ErrorBoundary></ProtectedRoute>} />
 
                {/* EraForge Module - Historical simulation game */}
-               <Route path="/eraforge" element={<ProtectedRoute><ErrorBoundary fallback={<ModuleErrorFallback moduleName="EraForge" />}><EraForgeAccessGuard><EraforgeGameProvider><EraforgeVoiceProvider><EraForgeMainView /></EraforgeVoiceProvider></EraforgeGameProvider></EraForgeAccessGuard></ErrorBoundary></ProtectedRoute>} />
+               <Route path="/eraforge" element={<ProtectedRoute><ErrorBoundary fallback={<ModuleErrorFallback moduleName="EraForge" />}><EraForgeAccessGuard><EraforgeGameProvider><EraforgeVoiceProvider><EraForgeMainView onExitToApp={() => navigate('/')} /></EraforgeVoiceProvider></EraforgeGameProvider></EraForgeAccessGuard></ErrorBoundary></ProtectedRoute>} />
 
                {/* Athlete Portal - Read-only training view (no FluxProvider needed, athlete context) */}
                <Route path="/meu-treino" element={<ProtectedRoute><ErrorBoundary fallback={<ModuleErrorFallback moduleName="Meu Treino" />}><AthletePortalView /></ErrorBoundary></ProtectedRoute>} />


### PR DESCRIPTION
## Summary
- Created `EF_NavHeader` — frosted glass navigation header (Ceramic/Jony Ive style) with back button, title/subtitle, and parent dashboard lock icon
- Integrated header into all EraForge screens (HomeScreen, GameScreen, SimulationScreen, ParentDashboard)
- Added mid-game exit confirmation dialog with AnimatePresence + spring animation
- Wired `onExitToApp` callback through MainView → AppRouter so users can return to the main app
- Removed redundant bottom "Encerrar Sessão" button (replaced by header back)

## Navigation fixes
- **HomeScreen**: back arrow exits to main app, lock icon opens parent dashboard
- **GameScreen**: back arrow shows confirmation dialog during active turn, exits directly when day complete
- **SimulationScreen**: back arrow returns to game
- **ParentDashboard**: back arrow returns to home

## Test plan
- [ ] `npm run build` passes
- [ ] `npm run typecheck` — no new errors (pre-existing only)
- [ ] Navigate Home → Game → back (shows confirmation) → confirm exit → returns to Home
- [ ] Navigate Home → Parent Dashboard → back → returns to Home
- [ ] Exit to main app from HomeScreen back arrow
- [ ] Mid-game exit dialog animates smoothly (spring, frosted glass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent navigation header across game screens with back button and contextual information (world name, era label)
  * Implemented exit confirmation dialog when leaving gameplay to prevent accidental exits
  * Integrated parent dashboard navigation option in home and applicable screens
  * Enhanced navigation flow with proper exit handling and view transitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->