### PR TITLE
fix(ui): add auto-retry to ErrorBoundary and fix null module renders

### DIFF
--- a/src/components/ui/ErrorBoundary.tsx
+++ b/src/components/ui/ErrorBoundary.tsx
@@ -22,55 +22,94 @@ interface Props {
   children: ReactNode;
   fallback?: ReactNode;
   onError?: (error: Error, errorInfo: ErrorInfo) => void;
+  /** Delay in ms before auto-retry (0 = disabled) */
+  autoRetryMs?: number;
+  /** Max auto-retry attempts before showing manual fallback */
+  maxRetries?: number;
 }
 
 interface State {
   hasError: boolean;
   error: Error | null;
   errorInfo: ErrorInfo | null;
+  isAutoRetrying: boolean;
 }
 
 export class ErrorBoundary extends Component<Props, State> {
+  private _retryCount = 0;
+  private _autoRetryTimer: ReturnType<typeof setTimeout> | null = null;
+
   constructor(props: Props) {
     super(props);
     this.state = {
       hasError: false,
       error: null,
       errorInfo: null,
+      isAutoRetrying: false,
     };
   }
 
   static getDerivedStateFromError(error: Error): Partial<State> {
-    // Atualiza o state para mostrar o fallback UI
     return { hasError: true, error };
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    // Log do erro para monitoramento
     log.error('ErrorBoundary caught an error:', error, errorInfo);
 
-    this.setState({
-      error,
-      errorInfo,
-    });
+    this.setState({ error, errorInfo });
 
-    // Callback customizado para logging externo (Sentry, etc)
     if (this.props.onError) {
       this.props.onError(error, errorInfo);
     }
+
+    // Auto-retry logic
+    const { autoRetryMs = 0, maxRetries = 3 } = this.props;
+    if (autoRetryMs > 0 && this._retryCount < maxRetries) {
+      this.setState({ isAutoRetrying: true });
+      this._autoRetryTimer = setTimeout(() => {
+        this._retryCount++;
+        log.debug(`Auto-retry attempt ${this._retryCount}/${maxRetries}`);
+        this.setState({
+          hasError: false,
+          error: null,
+          errorInfo: null,
+          isAutoRetrying: false,
+        });
+      }, autoRetryMs);
+    }
   }
 
+  componentWillUnmount() {
+    if (this._autoRetryTimer) {
+      clearTimeout(this._autoRetryTimer);
+    }
+  }
+
+  /** Manual reset — clears retry counter so auto-retry cycle restarts */
   handleReset = () => {
+    if (this._autoRetryTimer) clearTimeout(this._autoRetryTimer);
+    this._retryCount = 0;
     this.setState({
       hasError: false,
       error: null,
       errorInfo: null,
+      isAutoRetrying: false,
     });
   };
 
   render() {
     if (this.state.hasError) {
-      // Renderizar fallback customizado ou default
+      // Clone fallback element to inject retry props
+      if (this.props.fallback && React.isValidElement(this.props.fallback)) {
+        return React.cloneElement(this.props.fallback as React.ReactElement<any>, {
+          onReset: this.handleReset,
+          retryCount: this._retryCount,
+          isAutoRetrying: this.state.isAutoRetrying,
+          maxRetries: this.props.maxRetries ?? 3,
+          error: this.state.error,
+        });
+      }
+
       if (this.props.fallback) {
         return this.props.fallback;
       }
@@ -118,34 +157,89 @@ export class ErrorBoundary extends Component<Props, State> {
  * FALLBACK COMPONENTS - Reusable UI para diferentes contextos
  */
 
-export const ModuleErrorFallback: React.FC<{ moduleName: string; onReset?: () => void }> = ({
+/** Detects chunk/dynamic import errors that require a full page reload */
+function isChunkLoadError(error?: Error | null): boolean {
+  if (!error) return false;
+  const msg = error.message || '';
+  return (
+    error.name === 'ChunkLoadError' ||
+    msg.includes('Loading chunk') ||
+    msg.includes('Failed to fetch dynamically imported module') ||
+    msg.includes('Importing a module script failed')
+  );
+}
+
+export const ModuleErrorFallback: React.FC<{
+  moduleName: string;
+  onReset?: () => void;
+  retryCount?: number;
+  isAutoRetrying?: boolean;
+  maxRetries?: number;
+  error?: Error | null;
+}> = ({
   moduleName,
   onReset,
-}) => (
-  <div className="flex flex-col items-center justify-center min-h-[300px] p-8">
-    <div className="text-center max-w-md">
-      <div className="w-12 h-12 mx-auto mb-4 rounded-full bg-ceramic-error-bg flex items-center justify-center">
-        <svg className="w-6 h-6 text-ceramic-error" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-          <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-        </svg>
+  retryCount = 0,
+  isAutoRetrying = false,
+  maxRetries = 3,
+  error,
+}) => {
+  // During auto-retry: show loading spinner
+  if (isAutoRetrying) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[300px] p-8">
+        <div className="text-center max-w-md">
+          <div className="w-12 h-12 mx-auto mb-4">
+            <div className="w-12 h-12 border-4 border-ceramic-accent border-t-transparent rounded-full animate-spin" />
+          </div>
+          <p className="text-ceramic-text-secondary text-sm">
+            Recarregando {moduleName}... ({retryCount + 1}/{maxRetries})
+          </p>
+        </div>
       </div>
-      <h3 className="text-lg font-semibold text-ceramic-text-primary mb-2">
-        Erro ao carregar {moduleName}
-      </h3>
-      <p className="text-ceramic-text-secondary mb-4">
-        Não foi possível carregar este módulo. Outros módulos continuam disponíveis no menu lateral.
-      </p>
-      {onReset && (
-        <button
-          onClick={onReset}
-          className="px-6 py-2 ceramic-button-secondary rounded-lg transition"
-        >
-          Tentar novamente
-        </button>
-      )}
+    );
+  }
+
+  const chunkError = isChunkLoadError(error);
+
+  // All retries exhausted: show manual fallback
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[300px] p-8">
+      <div className="text-center max-w-md">
+        <div className="w-12 h-12 mx-auto mb-4 rounded-full bg-ceramic-error-bg flex items-center justify-center">
+          <svg className="w-6 h-6 text-ceramic-error" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+          </svg>
+        </div>
+        <h3 className="text-lg font-semibold text-ceramic-text-primary mb-2">
+          Erro ao carregar {moduleName}
+        </h3>
+        <p className="text-ceramic-text-secondary mb-4">
+          {chunkError
+            ? 'Uma atualização foi detectada. Recarregue a página para continuar.'
+            : 'Não foi possível carregar este módulo. Outros módulos continuam disponíveis no menu lateral.'}
+        </p>
+        <div className="flex gap-3 justify-center">
+          {chunkError ? (
+            <button
+              onClick={() => window.location.reload()}
+              className="px-6 py-2 bg-amber-500 hover:bg-amber-600 text-white rounded-lg transition"
+            >
+              Recarregar página
+            </button>
+          ) : onReset ? (
+            <button
+              onClick={onReset}
+              className="px-6 py-2 ceramic-button-secondary rounded-lg transition"
+            >
+              Tentar novamente
+            </button>
+          ) : null}
+        </div>
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export const DataFetchErrorFallback: React.FC<{ onRetry?: () => void }> = ({ onRetry }) => (
   <div className="flex flex-col items-center justify-center p-6 ceramic-tray border border-ceramic-accent/20 rounded-lg">

--- a/src/router/AppRouter.tsx
+++ b/src/router/AppRouter.tsx
@@ -401,7 +401,7 @@ export function AppRouter() {
             onSelectArchetype={handleSelectArchetype}
             onCreateAssociation={handleCreateAssociation}
          />
-      ) : null
+      ) : <CeramicLoadingState variant="page" />
    );
 
    // ==================== MEU DIA (AGENDA) VIEW ====================
@@ -412,7 +412,7 @@ export function AppRouter() {
             userEmail={userEmail || undefined}
             onLogout={() => supabase.auth.signOut()}
          />
-      ) : null
+      ) : <CeramicLoadingState variant="page" />
    );
 
    // ==================== ASSOCIATION DETAIL VIEW ====================
@@ -492,7 +492,7 @@ export function AppRouter() {
             userId={userId}
             onBack={() => setCurrentView('vida')}
          />
-      ) : null
+      ) : <CeramicLoadingState variant="page" />
    );
 
    // ==================== JOURNEY VIEW ====================
@@ -533,22 +533,22 @@ export function AppRouter() {
          <div className="bg-ceramic-base min-h-screen font-sans text-ceramic-text-primary">
             <AnimatePresence mode="wait">
             {currentView === 'vida' && <motion.div key="vida" variants={pageTransitionVariants} initial="initial" animate="animate" exit="exit">{renderVida()}</motion.div>}
-            {currentView === 'agenda' && <motion.div key="agenda" variants={pageTransitionVariants} initial="initial" animate="animate" exit="exit"><ErrorBoundary fallback={<ModuleErrorFallback moduleName="Agenda" />}>{renderAgenda()}</ErrorBoundary></motion.div>}
-            {currentView === 'connections' && <motion.div key="connections" variants={pageTransitionVariants} initial="initial" animate="animate" exit="exit"><ErrorBoundary fallback={<ModuleErrorFallback moduleName="Connections" />}>{renderConnections()}</ErrorBoundary></motion.div>}
-            {currentView === 'studio' && <motion.div key="studio" variants={pageTransitionVariants} initial="initial" animate="animate" exit="exit"><ErrorBoundary fallback={<ModuleErrorFallback moduleName="Studio" />}>{renderStudio()}</ErrorBoundary></motion.div>}
+            {currentView === 'agenda' && <motion.div key="agenda" variants={pageTransitionVariants} initial="initial" animate="animate" exit="exit"><ErrorBoundary autoRetryMs={2000} maxRetries={3} fallback={<ModuleErrorFallback moduleName="Agenda" />}>{renderAgenda()}</ErrorBoundary></motion.div>}
+            {currentView === 'connections' && <motion.div key="connections" variants={pageTransitionVariants} initial="initial" animate="animate" exit="exit"><ErrorBoundary autoRetryMs={2000} maxRetries={3} fallback={<ModuleErrorFallback moduleName="Connections" />}>{renderConnections()}</ErrorBoundary></motion.div>}
+            {currentView === 'studio' && <motion.div key="studio" variants={pageTransitionVariants} initial="initial" animate="animate" exit="exit"><ErrorBoundary autoRetryMs={2000} maxRetries={3} fallback={<ModuleErrorFallback moduleName="Studio" />}>{renderStudio()}</ErrorBoundary></motion.div>}
             {currentView === 'association_detail' && <motion.div key="association_detail" variants={pageTransitionVariants} initial="initial" animate="animate" exit="exit">{renderAssociationDetail()}</motion.div>}
-            {currentView === 'finance' && <motion.div key="finance" variants={pageTransitionVariants} initial="initial" animate="animate" exit="exit"><ErrorBoundary fallback={<ModuleErrorFallback moduleName="Finance" />}>{renderFinance()}</ErrorBoundary></motion.div>}
-            {currentView === 'journey' && <motion.div key="journey" variants={pageTransitionVariants} initial="initial" animate="animate" exit="exit"><ErrorBoundary fallback={<ModuleErrorFallback moduleName="Journey" />}>{renderJourney()}</ErrorBoundary></motion.div>}
+            {currentView === 'finance' && <motion.div key="finance" variants={pageTransitionVariants} initial="initial" animate="animate" exit="exit"><ErrorBoundary autoRetryMs={2000} maxRetries={3} fallback={<ModuleErrorFallback moduleName="Finance" />}>{renderFinance()}</ErrorBoundary></motion.div>}
+            {currentView === 'journey' && <motion.div key="journey" variants={pageTransitionVariants} initial="initial" animate="animate" exit="exit"><ErrorBoundary autoRetryMs={2000} maxRetries={3} fallback={<ModuleErrorFallback moduleName="Journey" />}>{renderJourney()}</ErrorBoundary></motion.div>}
             {currentView === 'grants' && (
                <motion.div key="grants" variants={pageTransitionVariants} initial="initial" animate="animate" exit="exit">
-                  <ErrorBoundary fallback={<ModuleErrorFallback moduleName="Grants" />}>
+                  <ErrorBoundary autoRetryMs={2000} maxRetries={3} fallback={<ModuleErrorFallback moduleName="Grants" />}>
                      <GrantsModuleView onBack={() => setCurrentView('vida')} />
                   </ErrorBoundary>
                </motion.div>
             )}
             {currentView === 'eraforge' && (
                <motion.div key="eraforge" variants={pageTransitionVariants} initial="initial" animate="animate" exit="exit">
-                  <ErrorBoundary fallback={<ModuleErrorFallback moduleName="EraForge" />}>
+                  <ErrorBoundary autoRetryMs={2000} maxRetries={3} fallback={<ModuleErrorFallback moduleName="EraForge" />}>
                      <EraforgeGameProvider>
                         <EraforgeVoiceProvider>
                            <EraForgeMainView onExitToApp={() => setCurrentView('vida')} />
@@ -686,8 +686,8 @@ export function AppRouter() {
                />
 
                {/* Connections Module Routes - Simplified 2-level navigation */}
-               <Route path="/connections" element={<ProtectedRoute><ErrorBoundary fallback={<ModuleErrorFallback moduleName="Connections" />}><ConnectionsLayout><ConnectionsPage /></ConnectionsLayout></ErrorBoundary></ProtectedRoute>} />
-               <Route path="/connections/:spaceId" element={<ProtectedRoute><ErrorBoundary fallback={<ModuleErrorFallback moduleName="Connections" />}><SpaceDetailView /></ErrorBoundary></ProtectedRoute>} />
+               <Route path="/connections" element={<ProtectedRoute><ErrorBoundary autoRetryMs={2000} maxRetries={3} fallback={<ModuleErrorFallback moduleName="Connections" />}><ConnectionsLayout><ConnectionsPage /></ConnectionsLayout></ErrorBoundary></ProtectedRoute>} />
+               <Route path="/connections/:spaceId" element={<ProtectedRoute><ErrorBoundary autoRetryMs={2000} maxRetries={3} fallback={<ModuleErrorFallback moduleName="Connections" />}><SpaceDetailView /></ErrorBoundary></ProtectedRoute>} />
                {/* Legacy redirects: old /connections/:archetype/:spaceId → new /connections/:spaceId */}
                <Route path="/connections/:archetype/:spaceId" element={<LegacySpaceRedirect />} />
                <Route path="/connections/:archetype/:spaceId/:section" element={<LegacySpaceRedirect />} />
@@ -698,7 +698,7 @@ export function AppRouter() {
                   path="/studio"
                   element={
                      <ProtectedRoute>
-                        <ErrorBoundary fallback={<ModuleErrorFallback moduleName="Studio" />}>
+                        <ErrorBoundary autoRetryMs={2000} maxRetries={3} fallback={<ModuleErrorFallback moduleName="Studio" />}>
                            <StudioProvider>
                               <StudioMainView />
                            </StudioProvider>
@@ -712,7 +712,7 @@ export function AppRouter() {
                   path="/studio/calendar"
                   element={
                      <ProtectedRoute>
-                        <ErrorBoundary fallback={<ModuleErrorFallback moduleName="Studio" />}>
+                        <ErrorBoundary autoRetryMs={2000} maxRetries={3} fallback={<ModuleErrorFallback moduleName="Studio" />}>
                            <ContentCalendarPage />
                         </ErrorBoundary>
                      </ProtectedRoute>
@@ -722,7 +722,7 @@ export function AppRouter() {
                   path="/studio/analytics"
                   element={
                      <ProtectedRoute>
-                        <ErrorBoundary fallback={<ModuleErrorFallback moduleName="Studio" />}>
+                        <ErrorBoundary autoRetryMs={2000} maxRetries={3} fallback={<ModuleErrorFallback moduleName="Studio" />}>
                            <StudioAnalyticsPage />
                         </ErrorBoundary>
                      </ProtectedRoute>
@@ -730,40 +730,40 @@ export function AppRouter() {
                />
 
                {/* Flux Module Routes - Protected */}
-               <Route path="/flux" element={<ProtectedRoute><ErrorBoundary fallback={<ModuleErrorFallback moduleName="Flux" />}><FluxProvider><FluxDashboard /></FluxProvider></ErrorBoundary></ProtectedRoute>} />
-               <Route path="/flux/athlete/:athleteId" element={<ProtectedRoute><ErrorBoundary fallback={<ModuleErrorFallback moduleName="Flux" />}><FluxProvider><FluxAthleteDetailView /></FluxProvider></ErrorBoundary></ProtectedRoute>} />
-               <Route path="/flux/canvas" element={<ProtectedRoute><ErrorBoundary fallback={<ModuleErrorFallback moduleName="Flux" />}><FluxProvider><FluxCanvasEditorView /></FluxProvider></ErrorBoundary></ProtectedRoute>} />
-               <Route path="/flux/canvas/:athleteId/:blockId?" element={<ProtectedRoute><ErrorBoundary fallback={<ModuleErrorFallback moduleName="Flux" />}><FluxProvider><FluxCanvasEditorView /></FluxProvider></ErrorBoundary></ProtectedRoute>} />
-               <Route path="/flux/alerts" element={<ProtectedRoute><ErrorBoundary fallback={<ModuleErrorFallback moduleName="Flux" />}><FluxProvider><FluxAlertsView /></FluxProvider></ErrorBoundary></ProtectedRoute>} />
+               <Route path="/flux" element={<ProtectedRoute><ErrorBoundary autoRetryMs={2000} maxRetries={3} fallback={<ModuleErrorFallback moduleName="Flux" />}><FluxProvider><FluxDashboard /></FluxProvider></ErrorBoundary></ProtectedRoute>} />
+               <Route path="/flux/athlete/:athleteId" element={<ProtectedRoute><ErrorBoundary autoRetryMs={2000} maxRetries={3} fallback={<ModuleErrorFallback moduleName="Flux" />}><FluxProvider><FluxAthleteDetailView /></FluxProvider></ErrorBoundary></ProtectedRoute>} />
+               <Route path="/flux/canvas" element={<ProtectedRoute><ErrorBoundary autoRetryMs={2000} maxRetries={3} fallback={<ModuleErrorFallback moduleName="Flux" />}><FluxProvider><FluxCanvasEditorView /></FluxProvider></ErrorBoundary></ProtectedRoute>} />
+               <Route path="/flux/canvas/:athleteId/:blockId?" element={<ProtectedRoute><ErrorBoundary autoRetryMs={2000} maxRetries={3} fallback={<ModuleErrorFallback moduleName="Flux" />}><FluxProvider><FluxCanvasEditorView /></FluxProvider></ErrorBoundary></ProtectedRoute>} />
+               <Route path="/flux/alerts" element={<ProtectedRoute><ErrorBoundary autoRetryMs={2000} maxRetries={3} fallback={<ModuleErrorFallback moduleName="Flux" />}><FluxProvider><FluxAlertsView /></FluxProvider></ErrorBoundary></ProtectedRoute>} />
 
                {/* Flow Module Routes (Intelligent Prescription) - Protected */}
-               <Route path="/flux/templates" element={<ProtectedRoute><ErrorBoundary fallback={<ModuleErrorFallback moduleName="Flux" />}><FluxProvider><TemplateLibraryView /></FluxProvider></ErrorBoundary></ProtectedRoute>} />
-               <Route path="/flux/templates/new" element={<ProtectedRoute><ErrorBoundary fallback={<ModuleErrorFallback moduleName="Flux" />}><FluxProvider><TemplateLibraryView /></FluxProvider></ErrorBoundary></ProtectedRoute>} />
-               <Route path="/flux/templates/:templateId/edit" element={<ProtectedRoute><ErrorBoundary fallback={<ModuleErrorFallback moduleName="Flux" />}><FluxProvider><TemplateLibraryView /></FluxProvider></ErrorBoundary></ProtectedRoute>} />
-               <Route path="/flux/microcycle/:microcycleId" element={<ProtectedRoute><ErrorBoundary fallback={<ModuleErrorFallback moduleName="Flux" />}><FluxProvider><MicrocycleEditorView /></FluxProvider></ErrorBoundary></ProtectedRoute>} />
-               <Route path="/flux/leveling" element={<ProtectedRoute><ErrorBoundary fallback={<ModuleErrorFallback moduleName="Flux" />}><FluxProvider><LevelingEngineView /></FluxProvider></ErrorBoundary></ProtectedRoute>} />
-               <Route path="/flux/intensity/:athleteId?" element={<ProtectedRoute><ErrorBoundary fallback={<ModuleErrorFallback moduleName="Flux" />}><FluxProvider><IntensityCalculatorView /></FluxProvider></ErrorBoundary></ProtectedRoute>} />
-               <Route path="/flux/crm" element={<ProtectedRoute><ErrorBoundary fallback={<ModuleErrorFallback moduleName="Flux" />}><FluxProvider><CRMCommandCenterView /></FluxProvider></ErrorBoundary></ProtectedRoute>} />
-               <Route path="/flux/parq/:athleteId" element={<ProtectedRoute><ErrorBoundary fallback={<ModuleErrorFallback moduleName="Flux" />}><FluxProvider><ParQFormView /></FluxProvider></ErrorBoundary></ProtectedRoute>} />
+               <Route path="/flux/templates" element={<ProtectedRoute><ErrorBoundary autoRetryMs={2000} maxRetries={3} fallback={<ModuleErrorFallback moduleName="Flux" />}><FluxProvider><TemplateLibraryView /></FluxProvider></ErrorBoundary></ProtectedRoute>} />
+               <Route path="/flux/templates/new" element={<ProtectedRoute><ErrorBoundary autoRetryMs={2000} maxRetries={3} fallback={<ModuleErrorFallback moduleName="Flux" />}><FluxProvider><TemplateLibraryView /></FluxProvider></ErrorBoundary></ProtectedRoute>} />
+               <Route path="/flux/templates/:templateId/edit" element={<ProtectedRoute><ErrorBoundary autoRetryMs={2000} maxRetries={3} fallback={<ModuleErrorFallback moduleName="Flux" />}><FluxProvider><TemplateLibraryView /></FluxProvider></ErrorBoundary></ProtectedRoute>} />
+               <Route path="/flux/microcycle/:microcycleId" element={<ProtectedRoute><ErrorBoundary autoRetryMs={2000} maxRetries={3} fallback={<ModuleErrorFallback moduleName="Flux" />}><FluxProvider><MicrocycleEditorView /></FluxProvider></ErrorBoundary></ProtectedRoute>} />
+               <Route path="/flux/leveling" element={<ProtectedRoute><ErrorBoundary autoRetryMs={2000} maxRetries={3} fallback={<ModuleErrorFallback moduleName="Flux" />}><FluxProvider><LevelingEngineView /></FluxProvider></ErrorBoundary></ProtectedRoute>} />
+               <Route path="/flux/intensity/:athleteId?" element={<ProtectedRoute><ErrorBoundary autoRetryMs={2000} maxRetries={3} fallback={<ModuleErrorFallback moduleName="Flux" />}><FluxProvider><IntensityCalculatorView /></FluxProvider></ErrorBoundary></ProtectedRoute>} />
+               <Route path="/flux/crm" element={<ProtectedRoute><ErrorBoundary autoRetryMs={2000} maxRetries={3} fallback={<ModuleErrorFallback moduleName="Flux" />}><FluxProvider><CRMCommandCenterView /></FluxProvider></ErrorBoundary></ProtectedRoute>} />
+               <Route path="/flux/parq/:athleteId" element={<ProtectedRoute><ErrorBoundary autoRetryMs={2000} maxRetries={3} fallback={<ModuleErrorFallback moduleName="Flux" />}><FluxProvider><ParQFormView /></FluxProvider></ErrorBoundary></ProtectedRoute>} />
 
                {/* EraForge Module - Historical simulation game */}
-               <Route path="/eraforge" element={<ProtectedRoute><ErrorBoundary fallback={<ModuleErrorFallback moduleName="EraForge" />}><EraForgeAccessGuard><EraforgeGameProvider><EraforgeVoiceProvider><EraForgeMainView onExitToApp={() => navigate('/')} /></EraforgeVoiceProvider></EraforgeGameProvider></EraForgeAccessGuard></ErrorBoundary></ProtectedRoute>} />
+               <Route path="/eraforge" element={<ProtectedRoute><ErrorBoundary autoRetryMs={2000} maxRetries={3} fallback={<ModuleErrorFallback moduleName="EraForge" />}><EraForgeAccessGuard><EraforgeGameProvider><EraforgeVoiceProvider><EraForgeMainView onExitToApp={() => navigate('/')} /></EraforgeVoiceProvider></EraforgeGameProvider></EraForgeAccessGuard></ErrorBoundary></ProtectedRoute>} />
 
                {/* Athlete Portal - Read-only training view (no FluxProvider needed, athlete context) */}
-               <Route path="/meu-treino" element={<ProtectedRoute><ErrorBoundary fallback={<ModuleErrorFallback moduleName="Meu Treino" />}><AthletePortalView /></ErrorBoundary></ProtectedRoute>} />
+               <Route path="/meu-treino" element={<ProtectedRoute><ErrorBoundary autoRetryMs={2000} maxRetries={3} fallback={<ModuleErrorFallback moduleName="Meu Treino" />}><AthletePortalView /></ErrorBoundary></ProtectedRoute>} />
 
                {/* Guest Portal - Read-only episode view for podcast guests */}
-               <Route path="/meu-episodio" element={<ProtectedRoute><ErrorBoundary fallback={<ModuleErrorFallback moduleName="Meu Episodio" />}><GuestPortalView /></ErrorBoundary></ProtectedRoute>} />
+               <Route path="/meu-episodio" element={<ProtectedRoute><ErrorBoundary autoRetryMs={2000} maxRetries={3} fallback={<ModuleErrorFallback moduleName="Meu Episodio" />}><GuestPortalView /></ErrorBoundary></ProtectedRoute>} />
 
                {/* Platform Contacts - Unified contact management */}
-               <Route path="/contatos" element={<ProtectedRoute><ErrorBoundary fallback={<ModuleErrorFallback moduleName="Contatos" />}><ContactsPage /></ErrorBoundary></ProtectedRoute>} />
+               <Route path="/contatos" element={<ProtectedRoute><ErrorBoundary autoRetryMs={2000} maxRetries={3} fallback={<ModuleErrorFallback moduleName="Contatos" />}><ContactsPage /></ErrorBoundary></ProtectedRoute>} />
 
                {/* Contacts Module Routes - Protected */}
                <Route
                   path="/contacts"
                   element={
                      <ProtectedRoute>
-                        <ErrorBoundary fallback={<ModuleErrorFallback moduleName="Contacts" />}>
+                        <ErrorBoundary autoRetryMs={2000} maxRetries={3} fallback={<ModuleErrorFallback moduleName="Contacts" />}>
                            <ConnectionsLayout>
                               <ContactsView />
                            </ConnectionsLayout>
@@ -830,8 +830,8 @@ export function AppRouter() {
                />
 
                {/* Life RPG Module - Entity personas as RPG characters */}
-               <Route path="/liferpg" element={<ProtectedRoute><ErrorBoundary fallback={<ModuleErrorFallback moduleName="Life RPG" />}><LifeRPGMainView /></ErrorBoundary></ProtectedRoute>} />
-               <Route path="/liferpg/:personaId" element={<ProtectedRoute><ErrorBoundary fallback={<ModuleErrorFallback moduleName="Life RPG" />}><LifeRPGDetailView /></ErrorBoundary></ProtectedRoute>} />
+               <Route path="/liferpg" element={<ProtectedRoute><ErrorBoundary autoRetryMs={2000} maxRetries={3} fallback={<ModuleErrorFallback moduleName="Life RPG" />}><LifeRPGMainView /></ErrorBoundary></ProtectedRoute>} />
+               <Route path="/liferpg/:personaId" element={<ProtectedRoute><ErrorBoundary autoRetryMs={2000} maxRetries={3} fallback={<ModuleErrorFallback moduleName="Life RPG" />}><LifeRPGDetailView /></ErrorBoundary></ProtectedRoute>} />
 
                {/* Main App - Authenticated users (root path only, ViewState-driven) */}
                <Route


### PR DESCRIPTION
## Summary
- **ErrorBoundary** now supports `autoRetryMs` and `maxRetries` props — auto-retries 3x with 2s delay before showing fallback
- **ModuleErrorFallback** shows spinner during retry, detects chunk load errors (suggests page reload), and provides manual retry button
- **AppRouter** render functions (`renderAgenda`, `renderVida`, `renderFinance`) show `CeramicLoadingState` instead of returning `null` when `userId` is briefly undefined

## Problem
Modules (especially Agenda) would intermittently show a static error screen saying "Outros módulos continuam disponíveis no menu lateral" with no auto-recovery. Two root causes:
1. `renderAgenda()` returned `null` when `userId` was transiently `undefined` (unlike Journey which always renders)
2. `ErrorBoundary` had no retry mechanism — any caught error was permanent until manual page refresh

## Test plan
- [ ] `npm run build` passes
- [ ] `npm run typecheck` passes
- [ ] Navigate to Agenda rapidly — should show loading state, not blank screen
- [ ] Simulate chunk load error — should auto-retry 3x then show "Recarregar página"
- [ ] Click "Tentar novamente" — resets retry counter and tries again

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented automatic error recovery with configurable retry timing and maximum attempt limits
  * Enhanced error displays with retry progress indicators providing real-time feedback during recovery
  * Improved chunk loading failure handling with dedicated page reload option
  * Standardized loading states across authenticated sections for consistent user experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->