### PR TITLE
fix(ui): auto-reload on chunk load error instead of showing error screen

### DIFF
--- a/src/components/ui/ErrorBoundary.tsx
+++ b/src/components/ui/ErrorBoundary.tsx
@@ -62,9 +62,21 @@ export class ErrorBoundary extends Component<Props, State> {
       this.props.onError(error, errorInfo);
     }
 
-    // Skip auto-retry for chunk load errors — only a full page reload can fix stale 404s
+    // Auto-reload for chunk load errors — stale 404s can only be fixed by a full page reload
     if (isChunkLoadError(error)) {
-      log.debug('Chunk load error detected, skipping auto-retry (requires page reload)');
+      const RELOAD_KEY = 'aica_chunk_reload_ts';
+      const lastReload = Number(sessionStorage.getItem(RELOAD_KEY) || '0');
+      const now = Date.now();
+
+      // Guard: only auto-reload if last reload was >10s ago (prevents infinite loop)
+      if (now - lastReload > 10_000) {
+        log.debug('Chunk load error detected, auto-reloading page to fetch fresh assets');
+        sessionStorage.setItem(RELOAD_KEY, String(now));
+        window.location.reload();
+        return;
+      }
+
+      log.debug('Chunk load error detected but recent reload already attempted, showing manual fallback');
       return;
     }
 


### PR DESCRIPTION
## Summary
- When deploys generate new hashed chunk filenames, users with cached old references get 404s on dynamic imports
- Previously the ErrorBoundary showed a manual "Recarregar página" button requiring user action
- Now it **auto-reloads the page** to fetch fresh assets transparently
- A 10-second `sessionStorage` guard prevents infinite reload loops (if reload doesn't fix it, shows manual fallback)

## Test plan
- [x] `npm run build` passes
- [ ] Deploy new version → open app with stale cache → should auto-reload and load normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for certain loading errors; the app now automatically reloads when encountering these errors while including safeguards to prevent infinite reload loops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->