### PR TITLE
fix(ui): revert root route to Home.tsx and fix ModulePulse 400 errors

### DIFF
--- a/src/components/features/ModulePulse/useModulePulseData.ts
+++ b/src/components/features/ModulePulse/useModulePulseData.ts
@@ -62,12 +62,12 @@ export function useModulePulseData() {
 
       // Fire all queries in parallel
       const [fluxRes, journeyRes, financeRes, atlasRes, studioRes] = await Promise.all([
-        // Flux: workout_slots this week
+        // Flux: workout_slots created this week
         supabase
           .from('workout_slots')
           .select('*', { head: true, count: 'exact' })
-          .gte('slot_date', weekStartStr.split('T')[0])
-          .lte('slot_date', now.toISOString().split('T')[0]),
+          .eq('user_id', user.id)
+          .gte('created_at', weekStartStr),
 
         // Journey: moments today
         supabase
@@ -81,7 +81,7 @@ export function useModulePulseData() {
           .from('finance_transactions')
           .select('*', { head: true, count: 'exact' })
           .eq('user_id', user.id)
-          .gte('date', monthStart.split('T')[0]),
+          .gte('transaction_date', monthStart.split('T')[0]),
 
         // Atlas: open work_items
         supabase

--- a/src/router/AppRouter.tsx
+++ b/src/router/AppRouter.tsx
@@ -834,16 +834,16 @@ export function AppRouter() {
                <Route path="/liferpg" element={<ProtectedRoute><ErrorBoundary autoRetryMs={2000} maxRetries={3} fallback={<ModuleErrorFallback moduleName="Life RPG" />}><LifeRPGMainView /></ErrorBoundary></ProtectedRoute>} />
                <Route path="/liferpg/:personaId" element={<ProtectedRoute><ErrorBoundary autoRetryMs={2000} maxRetries={3} fallback={<ModuleErrorFallback moduleName="Life RPG" />}><LifeRPGDetailView /></ErrorBoundary></ProtectedRoute>} />
 
-               {/* Vida Page - Central hub (new default home) */}
+               {/* Home - ViewState-driven main app */}
                <Route
                   path="/"
-                  element={<ProtectedRoute><ErrorBoundary autoRetryMs={2000} maxRetries={3} fallback={<ModuleErrorFallback moduleName="Vida" />}><VidaPage /></ErrorBoundary></ProtectedRoute>}
+                  element={<ProtectedRoute>{renderMainApp()}</ProtectedRoute>}
                />
 
-               {/* Legacy Home - ViewState-driven, kept for backward compat */}
+               {/* Vida Page - Central hub (WIP, future default) */}
                <Route
-                  path="/home-legacy"
-                  element={<ProtectedRoute>{renderMainApp()}</ProtectedRoute>}
+                  path="/vida"
+                  element={<ProtectedRoute><ErrorBoundary autoRetryMs={2000} maxRetries={3} fallback={<ModuleErrorFallback moduleName="Vida" />}><VidaPage /></ErrorBoundary></ProtectedRoute>}
                />
 
                {/* 404 Not Found - Catch all unknown routes */}


### PR DESCRIPTION
## Summary
- Reverts `/` route back to Home.tsx (quality original restaurada)
- Moves VidaPage to `/vida` (WIP para iteracao futura)
- Fixes 400 Bad Request on `workout_slots` (`slot_date` → `created_at` + adds `user_id` filter)
- Fixes 400 Bad Request on `finance_transactions` (`date` → `transaction_date`)

Closes #374

## Test plan
- [ ] `npm run build` passes
- [ ] `/` loads Home.tsx with all rich module cards
- [ ] `/vida` loads VidaPage (preserved for future)
- [ ] No 400 errors in console from ModulePulse queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated data query filters to align with current database schema and user filtering requirements.

* **Refactor**
  * Reorganized application routing structure to improve navigation logic and view composition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->