### PR TITLE
feat(ui): add Modules + Invites to settings menu, remove Google Hub

### DIFF
--- a/src/components/coming-soon/ModuleCard.tsx
+++ b/src/components/coming-soon/ModuleCard.tsx
@@ -21,7 +21,6 @@ interface ModuleCardProps {
   onJoinWaitlist?: () => Promise<boolean>;
   onLeaveWaitlist?: () => Promise<boolean>;
   onNavigate?: () => void;
-  onOpenAIPreview?: () => void;
 }
 
 export function ModuleCard({
@@ -30,7 +29,6 @@ export function ModuleCard({
   onJoinWaitlist,
   onLeaveWaitlist,
   onNavigate,
-  onOpenAIPreview,
 }: ModuleCardProps) {
   const colorPrimary = module.color_primary || '#F59E0B';
 
@@ -147,18 +145,6 @@ export function ModuleCard({
           <p className="text-xs text-ceramic-text-secondary leading-relaxed">
             {module.teaser_headline}
           </p>
-        )}
-
-        {/* AI preview button */}
-        {module.ai_preview_enabled && onOpenAIPreview && (
-          <button
-            onClick={onOpenAIPreview}
-            className="w-full flex items-center justify-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-all hover:scale-[1.02]"
-            style={{ backgroundColor: `${colorPrimary}10`, color: colorPrimary }}
-          >
-            <Sparkles className="w-3 h-3" />
-            Experimentar com IA
-          </button>
         )}
 
         {/* Waitlist */}

--- a/src/components/coming-soon/ModuleHubPage.tsx
+++ b/src/components/coming-soon/ModuleHubPage.tsx
@@ -9,13 +9,12 @@
  */
 
 import React, { useState, useMemo } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion } from 'framer-motion';
 import { ArrowLeft, Grid3X3, Zap, Clock, Layers } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
-import { useModuleRegistry, type ModuleRegistryEntry } from '@/hooks/useModuleRegistry';
+import { useModuleRegistry } from '@/hooks/useModuleRegistry';
 import { PageShell, CeramicLoadingState } from '@/components/ui';
 import { ModuleCard } from './ModuleCard';
-import { AIChatPreview } from './AIChatPreview';
 
 type FilterMode = 'all' | 'active' | 'coming-soon' | 'category';
 
@@ -61,8 +60,6 @@ export function ModuleHubPage() {
   } = useModuleRegistry();
 
   const [filter, setFilter] = useState<FilterMode>('all');
-  const [aiPreviewModule, setAiPreviewModule] = useState<ModuleRegistryEntry | null>(null);
-
   // Filter logic
   const filteredModules = useMemo(() => {
     switch (filter) {
@@ -162,9 +159,6 @@ export function ModuleHubPage() {
                         onJoinWaitlist={() => joinWaitlist(m.id)}
                         onLeaveWaitlist={() => leaveWaitlist(m.id)}
                         onNavigate={m.status === 'live' ? () => handleNavigateToModule(m.id) : undefined}
-                        onOpenAIPreview={
-                          m.ai_preview_enabled ? () => setAiPreviewModule(m) : undefined
-                        }
                       />
                     </motion.div>
                   ))}
@@ -187,9 +181,6 @@ export function ModuleHubPage() {
                   onJoinWaitlist={() => joinWaitlist(m.id)}
                   onLeaveWaitlist={() => leaveWaitlist(m.id)}
                   onNavigate={m.status === 'live' ? () => handleNavigateToModule(m.id) : undefined}
-                  onOpenAIPreview={
-                    m.ai_preview_enabled ? () => setAiPreviewModule(m) : undefined
-                  }
                 />
               </motion.div>
             ))}
@@ -203,18 +194,6 @@ export function ModuleHubPage() {
         )}
       </div>
 
-      {/* AI Chat Preview Modal */}
-      <AnimatePresence>
-        {aiPreviewModule && (
-          <AIChatPreview
-            module={aiPreviewModule}
-            isOnWaitlist={isOnWaitlist(aiPreviewModule.id)}
-            onJoinWaitlist={() => joinWaitlist(aiPreviewModule.id)}
-            onLeaveWaitlist={() => leaveWaitlist(aiPreviewModule.id)}
-            onClose={() => setAiPreviewModule(null)}
-          />
-        )}
-      </AnimatePresence>
     </PageShell>
   );
 }

--- a/src/components/layout/SettingsMenu.tsx
+++ b/src/components/layout/SettingsMenu.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useMemo } from 'react';
-import { Settings, LogOut, DollarSign, FileSearch, Crown } from 'lucide-react';
+import { Settings, LogOut, DollarSign, FileSearch, Crown, LayoutGrid, Ticket } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { supabase } from '@/services/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
@@ -213,6 +213,38 @@ export const SettingsMenu: React.FC<SettingsMenuProps> = ({
                             </div>
                             <span className="font-bold text-sm transition-colors">
                                 File Search Analytics
+                            </span>
+                        </button>
+
+                        {/* Module Hub Button */}
+                        <button
+                            onClick={() => {
+                                navigate('/modules');
+                                setIsOpen(false);
+                            }}
+                            className="w-full flex items-center gap-3 px-4 py-3 rounded-xl text-ceramic-text-primary hover:bg-white/40 transition-all group mb-1"
+                        >
+                            <div className="w-8 h-8 rounded-full ceramic-inset flex items-center justify-center group-hover:scale-110 transition-transform">
+                                <LayoutGrid className="w-4 h-4 text-ceramic-text-secondary group-hover:text-purple-500" />
+                            </div>
+                            <span className="font-bold text-sm transition-colors">
+                                Modulos
+                            </span>
+                        </button>
+
+                        {/* Invites Button */}
+                        <button
+                            onClick={() => {
+                                navigate('/invites');
+                                setIsOpen(false);
+                            }}
+                            className="w-full flex items-center gap-3 px-4 py-3 rounded-xl text-ceramic-text-primary hover:bg-white/40 transition-all group mb-1"
+                        >
+                            <div className="w-8 h-8 rounded-full ceramic-inset flex items-center justify-center group-hover:scale-110 transition-transform">
+                                <Ticket className="w-4 h-4 text-ceramic-text-secondary group-hover:text-amber-500" />
+                            </div>
+                            <span className="font-bold text-sm transition-colors">
+                                Convites
                             </span>
                         </button>
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { Wallet, Heart, Building2, BookOpen, Scale, Mic, Briefcase, Globe, Compass, type LucideIcon } from 'lucide-react';
+import { Wallet, Heart, Building2, BookOpen, Scale, Mic, Briefcase, Ticket, Compass, type LucideIcon } from 'lucide-react';
 import { HeaderGlobal, ProfileDrawer, ModuleCard, ExploreMoreSection, CreditBalanceWidget, InviteShareCard, InviteModal } from '../components';
 import { FinanceCard } from '../modules/finance/components/FinanceCard';
 import { GrantsCard } from '../modules/grants/components/GrantsCard';
@@ -343,35 +343,35 @@ export default function Home({
                   </motion.div>
                </motion.div>
 
-               {/* Google Hub — compact inline card */}
+               {/* Convites — compact inline card */}
                <motion.div
                   variants={cardVariants}
                   initial="hidden"
                   animate="visible"
                   custom={cardIndex++}
-                  onClick={() => navigate('/google-hub')}
+                  onClick={() => navigate('/invites')}
                   className="cursor-pointer"
                >
                   <motion.div
                      className="ceramic-card relative overflow-hidden p-3 min-h-[100px] flex flex-col group"
                      style={{
-                        background: 'linear-gradient(135deg, #F0EFE9 0%, #E8F0FE 100%)'
+                        background: 'linear-gradient(135deg, #F0EFE9 0%, #FEF3C7 100%)'
                      }}
                      variants={cardElevationVariants}
                      initial="rest"
                      whileHover="hover"
                      whileTap="pressed"
                   >
-                     <Globe className="absolute -right-2 -bottom-2 w-20 h-20 text-[#4285F4] opacity-10" />
+                     <Ticket className="absolute -right-2 -bottom-2 w-20 h-20 text-amber-500 opacity-10" />
                      <div className="relative z-10 flex flex-col h-full">
                         <div className="flex items-center gap-2 mb-2">
                            <div className="ceramic-inset p-1.5">
-                              <Globe className="w-4 h-4 text-[#4285F4]" />
+                              <Ticket className="w-4 h-4 text-amber-500" />
                            </div>
-                           <span className="text-xs font-bold text-ceramic-text-secondary uppercase tracking-wider">Google</span>
+                           <span className="text-xs font-bold text-ceramic-text-secondary uppercase tracking-wider">Convites</span>
                         </div>
                         <p className="text-xs text-ceramic-text-secondary line-clamp-1">
-                           Gmail, Drive & Calendar
+                           Gerencie seus convites
                         </p>
                      </div>
                   </motion.div>

--- a/src/pages/InvitesPage.tsx
+++ b/src/pages/InvitesPage.tsx
@@ -1,0 +1,252 @@
+/**
+ * InvitesPage — Dedicated page for managing invites
+ * Quick view for coaches to see pending invites and invite history.
+ * Wraps InviteModal content in a full page with PageShell.
+ */
+
+import { useState, useEffect } from 'react';
+import { motion } from 'framer-motion';
+import {
+  Ticket,
+  Copy,
+  Share2,
+  Check,
+  Clock,
+  UserPlus,
+  Gift,
+  Loader2,
+  Trash2,
+  Link2,
+} from 'lucide-react';
+import { QRCodeSVG } from 'qrcode.react';
+import { PageShell } from '@/components/ui';
+import { useInviteSystem } from '@/hooks/useInviteSystem';
+import type { EnrichedReferral } from '@/services/inviteSystemService';
+import { staggerContainer, staggerItem } from '@/lib/animations/ceramic-motion';
+
+function StatusBadge({ status, isActive }: { status: EnrichedReferral['status']; isActive: boolean }) {
+  if (status === 'accepted') {
+    return (
+      <span className={`text-[10px] font-bold px-2 py-0.5 rounded-full ${
+        isActive ? 'bg-ceramic-success/10 text-ceramic-success' : 'bg-ceramic-cool text-ceramic-text-secondary'
+      }`}>
+        {isActive ? 'Ativo' : 'Inativo'}
+      </span>
+    );
+  }
+  if (status === 'pending') {
+    return (
+      <span className="text-[10px] font-bold px-2 py-0.5 rounded-full bg-ceramic-warning/10 text-ceramic-warning">
+        Pendente
+      </span>
+    );
+  }
+  return (
+    <span className="text-[10px] font-bold px-2 py-0.5 rounded-full bg-ceramic-cool text-ceramic-text-secondary">
+      Expirado
+    </span>
+  );
+}
+
+export default function InvitesPage() {
+  const {
+    stats,
+    enrichedReferrals,
+    conversionRate,
+    loading,
+    generating,
+    revoking,
+    currentUrl,
+    currentCode,
+    hasInvites,
+    availableCount,
+    generateInvite,
+    copyLink,
+    shareLink,
+    refreshDashboard,
+    revokeInvite,
+  } = useInviteSystem();
+
+  const [copied, setCopied] = useState(false);
+  const [copiedCode, setCopiedCode] = useState(false);
+
+  useEffect(() => { refreshDashboard(); }, [refreshDashboard]);
+
+  useEffect(() => {
+    if (copied) { const t = setTimeout(() => setCopied(false), 2000); return () => clearTimeout(t); }
+  }, [copied]);
+
+  useEffect(() => {
+    if (copiedCode) { const t = setTimeout(() => setCopiedCode(false), 2000); return () => clearTimeout(t); }
+  }, [copiedCode]);
+
+  const handleCopy = async () => { if (await copyLink()) setCopied(true); };
+  const handleCopyCode = async () => {
+    if (!currentCode) return;
+    try { await navigator.clipboard.writeText(currentCode); setCopiedCode(true); } catch { setCopiedCode(true); }
+  };
+  const handleRevoke = async (id: string) => { if (await revokeInvite(id)) refreshDashboard(); };
+  const copyInviteUrl = async (token: string) => {
+    const url = `${window.location.origin}/invite/${token}`;
+    try { await navigator.clipboard.writeText(url); setCopied(true); } catch { setCopied(true); }
+  };
+
+  const formatCode = (code: string) => code.length === 8 ? `${code.slice(0, 4)}-${code.slice(4)}` : code;
+  const getDaysRemaining = (expiresAt: string) => Math.max(0, Math.ceil((new Date(expiresAt).getTime() - Date.now()) / 86400000));
+
+  const pendingCount = enrichedReferrals.filter(r => r.status === 'pending').length;
+  const acceptedCount = enrichedReferrals.filter(r => r.status === 'accepted').length;
+
+  if (loading) {
+    return (
+      <PageShell title="Convites">
+        <div className="flex items-center justify-center py-20">
+          <Loader2 className="w-6 h-6 animate-spin text-ceramic-text-secondary" />
+        </div>
+      </PageShell>
+    );
+  }
+
+  return (
+    <PageShell title="Convites">
+      <div className="max-w-lg mx-auto px-4 py-6 pb-24 space-y-6">
+        {/* Stats */}
+        <div className="grid grid-cols-4 gap-2">
+          {[
+            { value: stats?.available ?? 0, label: 'Disponiveis', color: 'text-ceramic-accent' },
+            { value: stats?.total_sent ?? 0, label: 'Enviados', color: 'text-ceramic-text-primary' },
+            { value: stats?.total_accepted ?? 0, label: 'Aceitos', color: 'text-ceramic-success' },
+            { value: conversionRate > 0 ? `${Math.round(conversionRate * 100)}%` : '--', label: 'Conversao', color: 'text-ceramic-info' },
+          ].map(({ value, label, color }) => (
+            <div key={label} className="ceramic-inset p-3 text-center rounded-xl">
+              <div className={`text-xl font-bold ${color}`}>{value}</div>
+              <div className="text-[10px] text-ceramic-text-secondary">{label}</div>
+            </div>
+          ))}
+        </div>
+
+        {/* QR + Actions */}
+        {hasInvites && currentUrl ? (
+          <div className="ceramic-card p-5 rounded-2xl space-y-4">
+            <div className="flex gap-4 items-start">
+              <QRCodeSVG value={currentUrl} size={112} bgColor="#F5F4EF" fgColor="#44403C" level="M" />
+              <div className="flex-1 min-w-0 space-y-3">
+                {currentCode && (
+                  <div>
+                    <div className="text-[10px] text-ceramic-text-secondary font-medium mb-1">Codigo</div>
+                    <div className="flex items-center gap-2">
+                      <span className="text-lg font-mono font-bold text-ceramic-text-primary tracking-wider">{formatCode(currentCode)}</span>
+                      <button onClick={handleCopyCode} className="p-1 rounded hover:bg-ceramic-cool transition-colors">
+                        {copiedCode ? <Check className="w-3.5 h-3.5 text-ceramic-success" /> : <Copy className="w-3.5 h-3.5 text-ceramic-text-secondary" />}
+                      </button>
+                    </div>
+                  </div>
+                )}
+                <div>
+                  <div className="text-[10px] text-ceramic-text-secondary font-medium mb-1">Link</div>
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs text-ceramic-text-secondary font-mono truncate">{currentUrl.replace(/^https?:\/\//, '').slice(0, 28)}...</span>
+                    <button onClick={handleCopy} className="p-1 rounded hover:bg-ceramic-cool transition-colors">
+                      {copied ? <Check className="w-3.5 h-3.5 text-ceramic-success" /> : <Link2 className="w-3.5 h-3.5 text-ceramic-text-secondary" />}
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <button onClick={shareLink} className="w-full p-3 flex items-center justify-center gap-2 bg-amber-500 hover:bg-amber-600 text-white font-bold text-sm rounded-xl transition-all hover:scale-[1.02] active:scale-[0.98]">
+              <Share2 className="w-4 h-4" /> Compartilhar convite
+            </button>
+          </div>
+        ) : hasInvites ? (
+          <button onClick={generateInvite} disabled={generating} className="w-full ceramic-card p-4 flex items-center justify-center gap-2 text-ceramic-accent hover:scale-[1.02] active:scale-[0.98] transition-transform disabled:opacity-50 rounded-2xl">
+            {generating ? <Loader2 className="w-5 h-5 animate-spin" /> : <Gift className="w-5 h-5" />}
+            <span className="font-bold">Gerar Convite</span>
+          </button>
+        ) : (
+          <div className="ceramic-inset p-6 rounded-2xl text-center">
+            <div className="text-4xl mb-2">📭</div>
+            <div className="text-ceramic-text-primary font-bold mb-1">Sem convites disponiveis</div>
+            <div className="text-sm text-ceramic-text-secondary">Voce ganha +2 convites quando alguem aceita!</div>
+          </div>
+        )}
+
+        {/* Pending section (highlighted) */}
+        {pendingCount > 0 && (
+          <div>
+            <div className="flex items-center gap-2 mb-3">
+              <Clock className="w-4 h-4 text-ceramic-warning" />
+              <h3 className="text-sm font-bold text-ceramic-text-primary">Aguardando aceite</h3>
+              <span className="text-[10px] font-bold px-1.5 py-0.5 rounded-full bg-ceramic-warning/10 text-ceramic-warning">{pendingCount}</span>
+            </div>
+            <motion.div variants={staggerContainer} initial="hidden" animate="visible" className="space-y-2">
+              {enrichedReferrals.filter(r => r.status === 'pending').map((ref) => (
+                <motion.div key={ref.id} variants={staggerItem} className="ceramic-card p-3 rounded-xl flex items-center gap-3">
+                  <div className="w-8 h-8 rounded-full bg-ceramic-warning/10 flex items-center justify-center flex-shrink-0">
+                    <Clock className="w-4 h-4 text-ceramic-warning" />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      {ref.invite_code && <span className="text-xs font-mono font-bold text-ceramic-text-primary">{formatCode(ref.invite_code)}</span>}
+                      <StatusBadge status="pending" isActive={false} />
+                    </div>
+                    <div className="text-[10px] text-ceramic-text-secondary">{getDaysRemaining(ref.expires_at)} dias restantes</div>
+                  </div>
+                  <div className="flex items-center gap-1 flex-shrink-0">
+                    <button onClick={() => copyInviteUrl(ref.invite_token)} className="p-1.5 rounded-lg hover:bg-ceramic-cool transition-colors" title="Copiar link">
+                      <Copy className="w-3.5 h-3.5 text-ceramic-text-secondary" />
+                    </button>
+                    <button onClick={() => handleRevoke(ref.id)} disabled={revoking === ref.id} className="p-1.5 rounded-lg hover:bg-ceramic-error/5 transition-colors disabled:opacity-50" title="Revogar">
+                      {revoking === ref.id ? <Loader2 className="w-3.5 h-3.5 text-ceramic-error animate-spin" /> : <Trash2 className="w-3.5 h-3.5 text-ceramic-error" />}
+                    </button>
+                  </div>
+                </motion.div>
+              ))}
+            </motion.div>
+          </div>
+        )}
+
+        {/* Accepted section */}
+        {acceptedCount > 0 && (
+          <div>
+            <div className="flex items-center gap-2 mb-3">
+              <UserPlus className="w-4 h-4 text-ceramic-success" />
+              <h3 className="text-sm font-bold text-ceramic-text-primary">Aceitos</h3>
+              <span className="text-[10px] font-bold px-1.5 py-0.5 rounded-full bg-ceramic-success/10 text-ceramic-success">{acceptedCount}</span>
+            </div>
+            <motion.div variants={staggerContainer} initial="hidden" animate="visible" className="space-y-2">
+              {enrichedReferrals.filter(r => r.status === 'accepted').map((ref) => (
+                <motion.div key={ref.id} variants={staggerItem} className="ceramic-card p-3 rounded-xl flex items-center gap-3">
+                  {ref.invitee_avatar ? (
+                    <img src={ref.invitee_avatar} alt={ref.invitee_name ?? ''} className="w-8 h-8 rounded-full object-cover" />
+                  ) : (
+                    <div className="w-8 h-8 rounded-full bg-ceramic-success/10 flex items-center justify-center flex-shrink-0">
+                      <UserPlus className="w-4 h-4 text-ceramic-success" />
+                    </div>
+                  )}
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-bold text-ceramic-text-primary truncate">{ref.invitee_name ?? 'Usuario'}</span>
+                      <StatusBadge status="accepted" isActive={ref.is_active} />
+                    </div>
+                    <div className="text-[10px] text-ceramic-text-secondary">
+                      Aceito {new Date(ref.accepted_at!).toLocaleDateString('pt-BR')}
+                    </div>
+                  </div>
+                  <div className="text-xs font-bold text-ceramic-success flex-shrink-0">+{ref.xp_awarded} XP</div>
+                </motion.div>
+              ))}
+            </motion.div>
+          </div>
+        )}
+
+        {/* Empty state */}
+        {enrichedReferrals.length === 0 && (
+          <div className="ceramic-inset p-8 rounded-2xl text-center">
+            <Ticket className="w-8 h-8 text-ceramic-text-secondary mx-auto mb-3" />
+            <div className="text-sm text-ceramic-text-secondary">Nenhum convite enviado ainda</div>
+          </div>
+        )}
+      </div>
+    </PageShell>
+  );
+}

--- a/src/router/AppRouter.tsx
+++ b/src/router/AppRouter.tsx
@@ -92,8 +92,8 @@ const PricingPage = lazy(() => import('../modules/billing').then(m => ({ default
 const UsageDashboardPage = lazy(() => import('../modules/billing').then(m => ({ default: m.UsageDashboardPage })));
 const ManageSubscriptionPage = lazy(() => import('../modules/billing').then(m => ({ default: m.ManageSubscriptionPage })));
 
-// Google Hub Module - Gmail + Drive integration
-const GoogleHubPage = lazy(() => import('../modules/google-hub').then(m => ({ default: m.GoogleHubPage })));
+// Invites Dashboard - Manage sent invites
+const InvitesPage = lazy(() => import('../pages/InvitesPage'));
 
 // Module Hub - Coming Soon system (CS-004)
 const ModuleHubPage = lazy(() => import('../components/coming-soon/ModuleHubPage').then(m => ({ default: m.ModuleHubPage })));
@@ -804,10 +804,10 @@ export function AppRouter() {
                   element={<ProtectedRoute><ProfilePage /></ProtectedRoute>}
                />
 
-               {/* Google Hub - Protected */}
+               {/* Invites Dashboard - Protected */}
                <Route
-                  path="/google-hub"
-                  element={<ProtectedRoute><GoogleHubPage /></ProtectedRoute>}
+                  path="/invites"
+                  element={<ProtectedRoute><InvitesPage /></ProtectedRoute>}
                />
 
                {/* Billing Module Routes - Protected */}


### PR DESCRIPTION
## Summary
- **SettingsMenu**: Added "Modulos" (/modules) and "Convites" (/invites) menu items
- **InvitesPage**: New dedicated page for coaches to quickly see pending invites, QR codes, and accepted referrals
- **Home**: Replaced Google Hub card with Convites card (Google Hub loses purpose after Gmail/Drive scope removal)
- **AppRouter**: Removed `/google-hub` route, added `/invites` route
- **ModuleCard**: Removed "Experimentar com IA" button and cleaned up AI Preview modal from ModuleHubPage

## Closes
- Partially addresses navigation gaps identified during CS-001 to CS-005 audit

## Test plan
- [ ] `npm run build` passes
- [ ] `npm run typecheck` passes
- [ ] Settings menu shows: Meu Plano, Custos de IA, File Search Analytics, Modulos, Convites, Sair
- [ ] `/modules` page renders with filter tabs and module cards (no AI preview button)
- [ ] `/invites` page renders with stats, QR code, pending/accepted sections
- [ ] Home page shows Convites card instead of Google Hub
- [ ] Google Calendar disconnect still works in Agenda view

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Invites page with invite management, statistics, QR code generation, and share functionality
  * Added Module Hub and Invites shortcuts to settings menu
  * Updated homepage with new Invites card

* **Removed Features**
  * Removed AI preview feature from module cards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->