### PR TITLE
feat(flux): alert indicators + liberar treino (#389, #381)

### DIFF
--- a/src/modules/flux/components/AlertBadge.tsx
+++ b/src/modules/flux/components/AlertBadge.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import type { AlertBadgeProps } from '../types';
 import { SEVERITY_COLORS } from '../types';
-import { AlertCircle, Heart, Frown, UserX, MessageSquare } from 'lucide-react';
+import { AlertCircle, Heart, Frown, UserX, MessageSquare, FileText, DollarSign } from 'lucide-react';
 
 export function AlertBadge({ alert, compact = false, onClick }: AlertBadgeProps) {
   // Icon mapping by alert type
@@ -20,6 +20,10 @@ export function AlertBadge({ alert, compact = false, onClick }: AlertBadgeProps)
         return Frown;
       case 'absence':
         return UserX;
+      case 'documents':
+        return FileText;
+      case 'financial':
+        return DollarSign;
       case 'feedback_received':
         return MessageSquare;
       default:

--- a/src/modules/flux/components/AthleteCard.tsx
+++ b/src/modules/flux/components/AthleteCard.tsx
@@ -141,6 +141,24 @@ export function AthleteCard({
             <h3 className="text-base font-bold text-ceramic-text-primary truncate flex items-center gap-1.5">
               {athlete.name}
               <ConnectionStatusDot status={athlete.invitation_status} />
+              {/* Status Indicators — #389 */}
+              {athlete.financial_status && athlete.financial_status !== 'ok' && (
+                <span
+                  className="w-2.5 h-2.5 rounded-full bg-red-500 animate-pulse flex-shrink-0"
+                  title={athlete.financial_status === 'overdue' ? 'Pagamento em atraso' : 'Pagamento pendente'}
+                />
+              )}
+              {athlete.parq_clearance_status &&
+               ['pending', 'blocked', 'expired'].includes(athlete.parq_clearance_status) && (
+                <span
+                  className="w-2.5 h-2.5 rounded-full bg-blue-500 animate-pulse flex-shrink-0"
+                  title={
+                    athlete.parq_clearance_status === 'blocked' ? 'Liberacao medica necessaria' :
+                    athlete.parq_clearance_status === 'expired' ? 'Documentos expirados' :
+                    'Documentos pendentes'
+                  }
+                />
+              )}
             </h3>
             <div className="mt-1 flex items-center gap-2">
               <LevelBadge level={athlete.level} size="sm" />

--- a/src/modules/flux/hooks/useAlerts.ts
+++ b/src/modules/flux/hooks/useAlerts.ts
@@ -124,6 +124,43 @@ export function useAlerts(): UseAlertsReturn {
               created_at: new Date().toISOString(),
             });
           }
+
+          // Document-pending alert: athlete has PAR-Q pending/blocked/expired
+          if (athlete.parq_clearance_status &&
+              ['pending', 'blocked', 'expired'].includes(athlete.parq_clearance_status)) {
+            computed.push({
+              id: `doc-${athlete.id}`,
+              user_id: user.id,
+              athlete_id: athlete.id,
+              feedback_id: '',
+              alert_type: 'documents',
+              severity: athlete.parq_clearance_status === 'blocked' ? 'critical' : 'medium',
+              keywords_detected: ['documentos', 'saúde'],
+              message_preview: athlete.parq_clearance_status === 'expired'
+                ? `${athlete.name}: Documentos de saúde expirados`
+                : athlete.parq_clearance_status === 'blocked'
+                ? `${athlete.name}: Liberação médica necessária`
+                : `${athlete.name}: Documentos de saúde pendentes`,
+              created_at: new Date().toISOString(),
+            });
+          }
+
+          // Financial-pending alert: athlete has overdue/pending payment
+          if (athlete.financial_status && athlete.financial_status !== 'ok') {
+            computed.push({
+              id: `fin-${athlete.id}`,
+              user_id: user.id,
+              athlete_id: athlete.id,
+              feedback_id: '',
+              alert_type: 'financial',
+              severity: athlete.financial_status === 'overdue' ? 'high' : 'medium',
+              keywords_detected: ['financeiro', 'pagamento'],
+              message_preview: athlete.financial_status === 'overdue'
+                ? `${athlete.name}: Pagamento em atraso`
+                : `${athlete.name}: Pagamento pendente`,
+              created_at: new Date().toISOString(),
+            });
+          }
         }
       }
 
@@ -250,7 +287,7 @@ export function useAlerts(): UseAlertsReturn {
   // Acknowledge an alert
   const acknowledge = useCallback(async (alertId: string) => {
     // Only DB alerts can be acknowledged (derived alerts are transient)
-    if (alertId.startsWith('derived-')) return;
+    if (alertId.startsWith('derived-') || alertId.startsWith('doc-') || alertId.startsWith('fin-')) return;
 
     const { error: updateError } = await supabase
       .from('alerts')

--- a/src/modules/flux/mockData.ts
+++ b/src/modules/flux/mockData.ts
@@ -200,7 +200,7 @@ export const MOCK_ATHLETES_WITH_METRICS: AthleteWithMetrics[] = MOCK_ATHLETES.ma
 // GENERATE ALERTS FOR ATHLETES WITH ISSUES
 // ============================================
 
-const ALERT_TYPES: AlertType[] = ['health', 'motivation', 'absence', 'documents', 'custom'];
+const ALERT_TYPES: AlertType[] = ['health', 'motivation', 'absence', 'documents', 'financial', 'custom'];
 const ALERT_SEVERITIES: AlertSeverity[] = ['critical', 'high', 'medium', 'low'];
 const SEVERITY_WEIGHTS = [10, 20, 40, 30]; // 10% critical, 20% high, etc.
 
@@ -229,6 +229,11 @@ const ALERT_MESSAGES: Record<AlertType, string[]> = {
     'Exame cardiologico pendente - nunca apresentado.',
     'Documentacao incompleta para treino.',
   ],
+  financial: [
+    'Pagamento da mensalidade em atraso.',
+    'Pendencia financeira - 2 meses sem pagamento.',
+    'Pagamento pendente para renovacao do plano.',
+  ],
   custom: [
     'Preciso conversar sobre ajustes no treino.',
     'Mudanca de horario nos treinos.',
@@ -246,6 +251,7 @@ const CRITICAL_KEYWORDS: Record<AlertType, string[]> = {
   motivation: ['desistir', 'desanimado', 'dificil'],
   absence: ['faltei', 'perdi', 'nao consegui'],
   documents: ['vencido', 'pendente', 'incompleta'],
+  financial: ['atraso', 'pagamento', 'pendencia'],
   custom: ['pausar', 'conversar'],
   feedback_received: ['feedback', 'evolucao', 'resultado'],
 };

--- a/src/modules/flux/types/flux.ts
+++ b/src/modules/flux/types/flux.ts
@@ -50,7 +50,7 @@ export type PlanStatus = 'pending' | 'sent' | 'acknowledged';
 /**
  * Alert types by category
  */
-export type AlertType = 'health' | 'motivation' | 'absence' | 'documents' | 'feedback_received' | 'custom';
+export type AlertType = 'health' | 'motivation' | 'absence' | 'documents' | 'financial' | 'feedback_received' | 'custom';
 
 /**
  * Alert severity levels
@@ -105,6 +105,9 @@ export interface Athlete {
   requires_clearance_cert?: boolean; // Physical activity clearance certificate required
   allow_parq_onboarding?: boolean; // Allow athlete to complete PAR-Q questionnaire
   parq_clearance_status?: 'pending' | 'cleared' | 'cleared_with_restrictions' | 'blocked' | 'expired';
+
+  // Financial status (coach-managed)
+  financial_status?: 'ok' | 'pending' | 'overdue';
 
   // Performance thresholds (for load calculation)
   ftp?: number; // Functional Threshold Power (watts) - cycling

--- a/src/modules/flux/views/AthleteDetailView.tsx
+++ b/src/modules/flux/views/AthleteDetailView.tsx
@@ -10,6 +10,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { useFlux } from '../context/FluxContext';
 import { AthleteService } from '../services/athleteService';
 import { ParQService } from '../services/parqService';
+import { MicrocycleService } from '../services/microcycleService';
 import { useAthleteDocuments } from '../hooks/useAthleteDocuments';
 import { supabase } from '@/services/supabaseClient';
 import type { Athlete, Alert } from '../types';
@@ -36,6 +37,7 @@ import {
   Ruler,
   Calculator,
   Save,
+  CheckCircle,
 } from 'lucide-react';
 
 const AVATAR_COLORS = [
@@ -71,6 +73,8 @@ export default function AthleteDetailView() {
   const [latestParQ, setLatestParQ] = useState<ParQResponse | null>(null);
   const [parqLoading, setParqLoading] = useState(false);
   const [feedbacks, setFeedbacks] = useState<SlotFeedback[]>([]);
+  const [activeMicrocycle, setActiveMicrocycle] = useState<{ id: string; status: string; name?: string } | null>(null);
+  const [activatingMicrocycle, setActivatingMicrocycle] = useState(false);
   const alerts: Alert[] = [];
   const activeBlock = null;
 
@@ -170,6 +174,20 @@ export default function AthleteDetailView() {
     };
 
     loadFeedbacks();
+    return () => { cancelled = true; };
+  }, [athleteId]);
+
+  // Load active/draft microcycle for "Liberar Treino" button (#381)
+  useEffect(() => {
+    if (!athleteId) return;
+    let cancelled = false;
+
+    MicrocycleService.getActiveMicrocycle(athleteId).then(({ data }) => {
+      if (!cancelled && data) {
+        setActiveMicrocycle({ id: data.id, status: data.status, name: data.name });
+      }
+    });
+
     return () => { cancelled = true; };
   }, [athleteId]);
 
@@ -344,8 +362,26 @@ export default function AthleteDetailView() {
                   className="w-full text-2xl font-black text-ceramic-text-primary bg-transparent border-b-2 border-ceramic-accent focus:outline-none mb-2"
                 />
               ) : (
-                <h1 className="text-2xl font-black text-ceramic-text-primary mb-2">
+                <h1 className="text-2xl font-black text-ceramic-text-primary mb-2 flex items-center gap-2">
                   {athlete.name}
+                  {/* Status Indicators — #389 */}
+                  {athlete.financial_status && athlete.financial_status !== 'ok' && (
+                    <span
+                      className="w-3 h-3 rounded-full bg-red-500 animate-pulse flex-shrink-0"
+                      title={athlete.financial_status === 'overdue' ? 'Pagamento em atraso' : 'Pagamento pendente'}
+                    />
+                  )}
+                  {athlete.parq_clearance_status &&
+                   ['pending', 'blocked', 'expired'].includes(athlete.parq_clearance_status) && (
+                    <span
+                      className="w-3 h-3 rounded-full bg-blue-500 animate-pulse flex-shrink-0"
+                      title={
+                        athlete.parq_clearance_status === 'blocked' ? 'Liberacao medica necessaria' :
+                        athlete.parq_clearance_status === 'expired' ? 'Documentos expirados' :
+                        'Documentos pendentes'
+                      }
+                    />
+                  )}
                 </h1>
               )}
               <LevelBadge level={athlete.level} size="md" />
@@ -756,6 +792,47 @@ export default function AthleteDetailView() {
               </div>
             </div>
           </button>
+
+          {/* Liberar Treino — #381 */}
+          {activeMicrocycle?.status === 'draft' && (
+            <button
+              onClick={async () => {
+                setActivatingMicrocycle(true);
+                try {
+                  const { error } = await MicrocycleService.activateMicrocycle(activeMicrocycle.id);
+                  if (!error) {
+                    setActiveMicrocycle(prev => prev ? { ...prev, status: 'active' } : null);
+                  } else {
+                    console.error('[AthleteDetail] Error activating microcycle:', error);
+                  }
+                } finally {
+                  setActivatingMicrocycle(false);
+                }
+              }}
+              disabled={activatingMicrocycle}
+              className="ceramic-card p-4 hover:scale-[1.02] transition-all group text-left disabled:opacity-50"
+            >
+              <div className="flex items-start gap-3">
+                <div className="w-10 h-10 rounded-full bg-ceramic-success/10 flex items-center justify-center group-hover:bg-ceramic-success/20 transition-colors flex-shrink-0">
+                  {activatingMicrocycle ? (
+                    <Loader2 className="w-5 h-5 text-ceramic-success animate-spin" />
+                  ) : (
+                    <CheckCircle className="w-5 h-5 text-ceramic-success" />
+                  )}
+                </div>
+                <div>
+                  <p className="text-sm font-bold text-ceramic-text-primary">Liberar Treino</p>
+                  <p className="text-xs text-ceramic-text-secondary">Ativar microciclo para o atleta</p>
+                </div>
+              </div>
+            </button>
+          )}
+          {activeMicrocycle?.status === 'active' && (
+            <div className="flex items-center gap-2 px-4 py-3 bg-ceramic-success/10 rounded-xl">
+              <CheckCircle className="w-4 h-4 text-ceramic-success" />
+              <span className="text-xs font-bold text-ceramic-success">Treino Liberado</span>
+            </div>
+          )}
         </div>
       </div>
 

--- a/src/modules/flux/views/AthletePortalView.tsx
+++ b/src/modules/flux/views/AthletePortalView.tsx
@@ -33,6 +33,8 @@ import {
   LayoutGrid,
   List,
   MessageSquare,
+  CheckCircle,
+  FileText,
 } from 'lucide-react';
 
 const log = createNamespacedLogger('AthletePortalView');
@@ -382,6 +384,47 @@ export default function AthletePortalView() {
         <motion.section className="px-5 mb-4" custom={1} initial="hidden" animate="visible" variants={sectionVariants}>
           <ProgressTimeline weeks={weeks} currentWeek={micro.current_week || 1} microcycleName={micro.name} status={micro.status} selectedWeek={selectedWeek} onWeekSelect={setSelectedWeek} />
         </motion.section>
+      )}
+
+      {/* Microcycle Status Badge — #381: PENDENTE / LIBERADO */}
+      {micro && micro.status === 'draft' && (
+        <motion.div className="px-5 mb-3" custom={1.5} initial="hidden" animate="visible" variants={sectionVariants}>
+          <div className="flex items-center gap-2 px-3 py-2 bg-amber-500/10 border border-amber-500/20 rounded-xl">
+            <Clock className="w-4 h-4 text-amber-600 flex-shrink-0" />
+            <span className="text-sm font-bold text-amber-700">Treino Pendente</span>
+            <span className="text-xs text-amber-600">Aguardando liberacao do coach</span>
+          </div>
+        </motion.div>
+      )}
+      {micro && micro.status === 'active' && (
+        <motion.div className="px-5 mb-3" custom={1.5} initial="hidden" animate="visible" variants={sectionVariants}>
+          <div className="flex items-center gap-2 px-3 py-2 bg-ceramic-success/10 border border-ceramic-success/20 rounded-xl">
+            <CheckCircle className="w-4 h-4 text-ceramic-success flex-shrink-0" />
+            <span className="text-sm font-bold text-ceramic-success">Treino Liberado</span>
+          </div>
+        </motion.div>
+      )}
+
+      {/* Document Pending Banner — #381 */}
+      {profile.parq_clearance_status &&
+       ['pending', 'blocked', 'expired'].includes(profile.parq_clearance_status) && (
+        <motion.div className="px-5 mb-3" custom={1.6} initial="hidden" animate="visible" variants={sectionVariants}>
+          <div className="flex items-center gap-3 px-4 py-3 bg-blue-50 border border-blue-200 rounded-xl">
+            <div className="w-8 h-8 rounded-full bg-blue-500/10 flex items-center justify-center flex-shrink-0">
+              <FileText className="w-4 h-4 text-blue-600" />
+            </div>
+            <div className="flex-1">
+              <p className="text-sm font-bold text-blue-800">Documentos Pendentes</p>
+              <p className="text-xs text-blue-600">
+                {profile.parq_clearance_status === 'expired'
+                  ? 'Seus documentos de saude expiraram'
+                  : profile.parq_clearance_status === 'blocked'
+                  ? 'Liberacao medica necessaria'
+                  : 'Complete seus documentos de saude'}
+              </p>
+            </div>
+          </div>
+        </motion.div>
       )}
 
       {/* Week viewing indicator */}

--- a/supabase/migrations/20260224230000_athlete_financial_status.sql
+++ b/supabase/migrations/20260224230000_athlete_financial_status.sql
@@ -1,0 +1,10 @@
+-- Add financial_status column to athletes
+-- Coach-managed field to track athlete payment status
+-- Used by frontend derived alerts in useAlerts.ts
+
+ALTER TABLE public.athletes
+  ADD COLUMN IF NOT EXISTS financial_status TEXT DEFAULT 'ok'
+  CHECK (financial_status IN ('ok', 'pending', 'overdue'));
+
+-- Comment for documentation
+COMMENT ON COLUMN public.athletes.financial_status IS 'Coach-managed financial status: ok=paid, pending=payment due, overdue=payment late';


### PR DESCRIPTION
## Summary

- **2 issues resolvidas** do módulo Flux (Sprint 4)
- Alertas semânticos com indicadores visuais coloridos (vermelho/azul)
- Workflow "Liberar Treino" para coach ativar microciclo do atleta

## Issues

### #389 — Alertas com cores semânticas
- **Vermelho** (red dot animado) = Pendência financeira (`financial_status: 'pending' | 'overdue'`)
- **Azul** (blue dot animado) = Pendência documentos de saúde (`parq_clearance_status: 'pending' | 'blocked' | 'expired'`)
- Visíveis no AthleteCard (dashboard) e AthleteDetailView (detalhe)

### #381 — Liberar Treino + Pendência de documentação
- **"Liberar Treino"** botão na view de detalhe do atleta (coach)
  - Só aparece quando microciclo está em `draft`
  - Chama `MicrocycleService.activateMicrocycle()` para draft→active
  - Mostra badge "Treino Liberado" após ativação
- **Badge PENDENTE/LIBERADO** no portal do atleta (`/meu-treino`)
  - Amber = "Treino Pendente — Aguardando liberação do coach"
  - Green = "Treino Liberado"
- **Banner de documentos pendentes** no portal do atleta
  - Mensagens contextuais: expirados, bloqueados, pendentes

## Arquivos Modificados (8)
- `flux.ts` — `'financial'` no AlertType + `financial_status` na interface Athlete
- `useAlerts.ts` — triggers derivados para doc-pending e financial-pending
- `AlertBadge.tsx` — ícones FileText (docs) e DollarSign (financial)
- `AthleteCard.tsx` — dots vermelho/azul animados
- `AthleteDetailView.tsx` — indicators + botão Liberar Treino
- `AthletePortalView.tsx` — badge PENDENTE/LIBERADO + banner docs
- `mockData.ts` — mensagens e keywords para tipo financial
- `20260224230000_athlete_financial_status.sql` — nova coluna

## Test plan
- [ ] `npm run build` passa
- [ ] `npm run typecheck` passa (0 erros no Flux)
- [ ] Dashboard: dots vermelho/azul visíveis em atletas com pendências
- [ ] Detalhe atleta: botão "Liberar Treino" aparece para microciclo draft
- [ ] Detalhe atleta: badge "Treino Liberado" após clicar
- [ ] Portal `/meu-treino`: badge PENDENTE (amber) quando draft
- [ ] Portal: badge LIBERADO (green) quando active
- [ ] Portal: banner azul "Documentos Pendentes" quando parq pending
- [ ] Migration: `financial_status` column criada na tabela athletes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added financial status tracking and alerts for overdue or pending athlete payments
  * Added PAR-Q document clearance status indicators with corresponding alerts
  * Added workout microcycle management with draft-to-active status workflow
  * Extended alert system with new financial and document-type alert categories
  * Added status banners and visual indicators across athlete profiles and portal

<!-- end of auto-generated comment: release notes by coderabbit.ai -->