### PR TITLE
fix(flux): remove module agent chats, canvas button, rename labels (#387, #391, #392, #394)

### DIFF
--- a/src/modules/finance/views/FinanceDashboard.tsx
+++ b/src/modules/finance/views/FinanceDashboard.tsx
@@ -31,8 +31,6 @@ import { exportToCSV } from '../services/exportService';
 import { statementService } from '../services/statementService';
 import { useFinanceFileSearch } from '../hooks/useFinanceFileSearch';
 import type { FinanceSummary, BurnRateData, CategoryBreakdown, FinanceStatement, BudgetAlert, FinanceTransaction } from '../types';
-import { ModuleAgentChat, ModuleAgentFAB, getModuleAgentConfig } from '@/components/features/ModuleAgentChat';
-import { useModuleAgent } from '@/hooks/useModuleAgent';
 
 // =====================================================
 // Types
@@ -119,9 +117,6 @@ export const FinanceDashboard: React.FC<FinanceDashboardProps> = ({
     documents,
     clearSearchResults,
   } = useFinanceFileSearch({ userId, autoLoad: true });
-
-  const financeAgentConfig = getModuleAgentConfig('finance')!;
-  const { isAgentOpen, openAgent, closeAgent } = useModuleAgent();
 
   const hasIndexedStatements = documents.length > 0;
 
@@ -563,19 +558,6 @@ export const FinanceDashboard: React.FC<FinanceDashboardProps> = ({
         {/* Sub-view Content */}
         {renderSubView()}
 
-        {/* Module Agent FAB + Chat Overlay */}
-        <ModuleAgentFAB onClick={openAgent} accentBg={financeAgentConfig.accentBg} label="Agente Finance" />
-        <ModuleAgentChat
-          isOpen={isAgentOpen}
-          onClose={closeAgent}
-          module={financeAgentConfig.module}
-          displayName={financeAgentConfig.displayName}
-          accentColor={financeAgentConfig.accentColor}
-          accentBg={financeAgentConfig.accentBg}
-          suggestedPrompts={financeAgentConfig.suggestedPrompts}
-          welcomeMessage={financeAgentConfig.welcomeMessage}
-          placeholder={financeAgentConfig.placeholder}
-        />
       </div>
     );
   }
@@ -1274,19 +1256,6 @@ export const FinanceDashboard: React.FC<FinanceDashboardProps> = ({
 
       </main>
 
-      {/* Module Agent FAB + Chat Overlay */}
-      <ModuleAgentFAB onClick={openAgent} accentBg={financeAgentConfig.accentBg} label="Agente Finance" />
-      <ModuleAgentChat
-        isOpen={isAgentOpen}
-        onClose={closeAgent}
-        module={financeAgentConfig.module}
-        displayName={financeAgentConfig.displayName}
-        accentColor={financeAgentConfig.accentColor}
-        accentBg={financeAgentConfig.accentBg}
-        suggestedPrompts={financeAgentConfig.suggestedPrompts}
-        welcomeMessage={financeAgentConfig.welcomeMessage}
-        placeholder={financeAgentConfig.placeholder}
-      />
     </div>
   );
 };

--- a/src/modules/flux/components/canvas/CanvasEditorDrawer.tsx
+++ b/src/modules/flux/components/canvas/CanvasEditorDrawer.tsx
@@ -173,7 +173,7 @@ export const CanvasEditorDrawer: React.FC<CanvasEditorDrawerProps> = ({
             </div>
             <div>
               <p className="text-xs text-ceramic-text-secondary font-medium uppercase tracking-wider mb-0.5">
-                Canvas de Prescricao
+                Prescrição
               </p>
               <h1 className="text-2xl font-black text-ceramic-text-primary">
                 {athlete?.name}

--- a/src/modules/flux/views/AthletePortalView.tsx
+++ b/src/modules/flux/views/AthletePortalView.tsx
@@ -337,7 +337,7 @@ export default function AthletePortalView() {
                 <List className="w-3.5 h-3.5" />Lista
               </button>
               <button onClick={() => handleViewModeChange('canvas')} className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-bold transition-all ${viewMode === 'canvas' ? 'bg-white text-ceramic-text-primary shadow-sm' : 'text-ceramic-text-secondary hover:text-ceramic-text-primary'}`}>
-                <LayoutGrid className="w-3.5 h-3.5" />Canvas
+                <LayoutGrid className="w-3.5 h-3.5" />Grade
               </button>
             </div>
           )}

--- a/src/modules/flux/views/FluxDashboard.tsx
+++ b/src/modules/flux/views/FluxDashboard.tsx
@@ -24,8 +24,6 @@ import DeleteConfirmationModal from '../components/DeleteConfirmationModal';
 import type { Athlete } from '../types';
 import { useWorkoutTemplates } from '../hooks/useWorkoutTemplates';
 import { ArrowLeft, Users, TrendingUp, Plus, Filter, GraduationCap, ArrowUpDown, ArrowUp, ArrowDown, Search, CheckCircle, X } from 'lucide-react';
-import { ModuleAgentChat, ModuleAgentFAB, getModuleAgentConfig } from '@/components/features/ModuleAgentChat';
-import { useModuleAgent } from '@/hooks/useModuleAgent';
 import { ErrorBoundary, ModuleErrorFallback } from '@/components/ui/ErrorBoundary';
 import { useFluxGamification } from '../hooks/useFluxGamification';
 
@@ -77,12 +75,9 @@ const ModalityTab: React.FC<{
   );
 };
 
-const fluxAgentConfig = getModuleAgentConfig('flux')!;
-
 export default function FluxDashboard() {
   const navigate = useNavigate();
   const { actions } = useFlux();
-  const { isAgentOpen, openAgent, closeAgent } = useModuleAgent();
 
   // Fetch real athletes with adherence from Supabase
   const { athletes: allAthletes, isLoading, error, refresh } = useAthletes();
@@ -527,27 +522,10 @@ export default function FluxDashboard() {
           </button>
 
           <button
-            onClick={() => navigate('/flux/crm')}
+            onClick={() => navigate('/meu-treino')}
             className="ceramic-card p-3 hover:scale-[1.02] transition-all group"
           >
             <div className="flex flex-col items-center gap-2">
-              <div className="ceramic-inset p-2 group-hover:bg-white/50 transition-colors">
-                <span className="text-xl">📋</span>
-              </div>
-              <p className="text-xs font-bold text-ceramic-text-primary text-center">Canvas</p>
-              {allAthletes.length > 0 && (
-                <span className="text-[10px] text-ceramic-text-secondary">
-                  {allAthletes.length} atleta{allAthletes.length !== 1 ? 's' : ''}
-                </span>
-              )}
-            </div>
-          </button>
-
-          <button
-            onClick={() => navigate('/meu-treino')}
-            className="ceramic-card p-3 hover:scale-[1.02] transition-all group col-span-2"
-          >
-            <div className="flex items-center justify-center gap-3">
               <div className="ceramic-inset p-2 group-hover:bg-white/50 transition-colors">
                 <span className="text-xl">🏃</span>
               </div>
@@ -878,19 +856,6 @@ export default function FluxDashboard() {
         </div>
       )}
 
-      {/* Module Agent */}
-      <ModuleAgentFAB onClick={openAgent} accentBg={fluxAgentConfig.accentBg} label="Agente Flux" />
-      <ModuleAgentChat
-        isOpen={isAgentOpen}
-        onClose={closeAgent}
-        module={fluxAgentConfig.module}
-        displayName={fluxAgentConfig.displayName}
-        accentColor={fluxAgentConfig.accentColor}
-        accentBg={fluxAgentConfig.accentBg}
-        suggestedPrompts={fluxAgentConfig.suggestedPrompts}
-        welcomeMessage={fluxAgentConfig.welcomeMessage}
-        placeholder={fluxAgentConfig.placeholder}
-      />
     </div>
     </ErrorBoundary>
   );

--- a/src/modules/grants/views/GrantsModuleView.tsx
+++ b/src/modules/grants/views/GrantsModuleView.tsx
@@ -5,8 +5,6 @@
 
 import { useTourAutoStart } from '@/hooks/useTourAutoStart';
 import React, { useState, useEffect } from 'react';
-import { ModuleAgentChat, ModuleAgentFAB, getModuleAgentConfig } from '@/components/features/ModuleAgentChat';
-import { useModuleAgent } from '@/hooks/useModuleAgent';
 import { ArrowLeft, Archive, ArchiveRestore, Trash2, MoreVertical, Building2 } from 'lucide-react';
 import { EditalSetupWizard } from '../components/EditalSetupWizard';
 import { EditalDetailView } from '../components/EditalDetailView';
@@ -67,12 +65,9 @@ interface GrantsModuleViewProps {
 }
 
 /* data-tour markers: grants-header, opportunities-list, opportunity-filter, edital-parser, opportunity-detail, saved-opportunities, application-tracking, ai-briefing */
-const grantsAgentConfig = getModuleAgentConfig('captacao')!;
-
 export const GrantsModuleView: React.FC<GrantsModuleViewProps> = ({ onBack }) => {
   // Auto-start tour on first visit (Phase 2 - Organic Onboarding)
   useTourAutoStart('grants-first-visit');
-  const { isAgentOpen, openAgent, closeAgent } = useModuleAgent();
 
   // View state
   const [currentView, setCurrentView] = useState<ModuleView>('dashboard');
@@ -999,19 +994,6 @@ export const GrantsModuleView: React.FC<GrantsModuleViewProps> = ({ onBack }) =>
         </div>
       )}
 
-      {/* Module Agent */}
-      <ModuleAgentFAB onClick={openAgent} accentBg={grantsAgentConfig.accentBg} label="Agente Captacao" />
-      <ModuleAgentChat
-        isOpen={isAgentOpen}
-        onClose={closeAgent}
-        module={grantsAgentConfig.module}
-        displayName={grantsAgentConfig.displayName}
-        accentColor={grantsAgentConfig.accentColor}
-        accentBg={grantsAgentConfig.accentBg}
-        suggestedPrompts={grantsAgentConfig.suggestedPrompts}
-        welcomeMessage={grantsAgentConfig.welcomeMessage}
-        placeholder={grantsAgentConfig.placeholder}
-      />
     </>
   );
 };

--- a/src/modules/journey/views/JourneyFullScreen.tsx
+++ b/src/modules/journey/views/JourneyFullScreen.tsx
@@ -16,8 +16,6 @@ import { WeeklySummaryCard } from '../components/insights/WeeklySummaryCard'
 import { DailyQuestionCard } from '../components/insights/DailyQuestionCard'
 import { PatternDashboard } from '../components/insights/PatternDashboard'
 import { LifeCouncilCard, PatternsSummary } from '@/components/features'
-import { ModuleAgentChat, ModuleAgentFAB, getModuleAgentConfig } from '@/components/features/ModuleAgentChat'
-import { useModuleAgent } from '@/hooks/useModuleAgent'
 import { useLifeCouncil } from '@/hooks/useLifeCouncil'
 import { useUserPatterns } from '@/hooks/useUserPatterns'
 
@@ -142,11 +140,8 @@ interface JourneyFullScreenProps {
   onBack?: () => void;
 }
 
-const journeyAgentConfig = getModuleAgentConfig('journey')!;
-
 export function JourneyFullScreen({ onBack }: JourneyFullScreenProps) {
   useTourAutoStart('journey-first-visit');
-  const { isAgentOpen, openAgent, closeAgent } = useModuleAgent();
 
   // Debug: Log when component mounts
   React.useEffect(() => {
@@ -772,19 +767,6 @@ export function JourneyFullScreen({ onBack }: JourneyFullScreenProps) {
         )}
       </AnimatePresence>
 
-      {/* Module Agent */}
-      <ModuleAgentFAB onClick={openAgent} accentBg={journeyAgentConfig.accentBg} label="Agente Journey" />
-      <ModuleAgentChat
-        isOpen={isAgentOpen}
-        onClose={closeAgent}
-        module={journeyAgentConfig.module}
-        displayName={journeyAgentConfig.displayName}
-        accentColor={journeyAgentConfig.accentColor}
-        accentBg={journeyAgentConfig.accentBg}
-        suggestedPrompts={journeyAgentConfig.suggestedPrompts}
-        welcomeMessage={journeyAgentConfig.welcomeMessage}
-        placeholder={journeyAgentConfig.placeholder}
-      />
     </div>
   )
 }

--- a/src/modules/studio/views/StudioMainView.tsx
+++ b/src/modules/studio/views/StudioMainView.tsx
@@ -11,8 +11,6 @@
 
 import { useTourAutoStart } from '@/hooks/useTourAutoStart';
 import React, { useEffect, useCallback, useRef } from 'react';
-import { ModuleAgentChat, ModuleAgentFAB, getModuleAgentConfig } from '@/components/features/ModuleAgentChat';
-import { useModuleAgent } from '@/hooks/useModuleAgent';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useStudio } from '../context/StudioContext';
 import { useAuth } from '../../../hooks/useAuth';
@@ -98,12 +96,9 @@ function ErrorScreen({ error, onRetry }: { error: string; onRetry: () => void })
  * Manages view state and renders appropriate component based on mode
  */
 /* data-tour markers: studio-header, studio-shows-list, create-show-button, wizard-button, guest-management, episode-production, studio-library, workspace-view */
-const studioAgentConfig = getModuleAgentConfig('studio')!;
-
 export default function StudioMainView() {
 
   useTourAutoStart('studio-first-visit');  const { state, actions } = useStudio();
-  const { isAgentOpen, openAgent, closeAgent } = useModuleAgent();
   const { user } = useAuth();
 
   // Track previous mode for slide direction
@@ -352,19 +347,6 @@ export default function StudioMainView() {
         </motion.div>
       </AnimatePresence>
 
-      {/* Module Agent */}
-      <ModuleAgentFAB onClick={openAgent} accentBg={studioAgentConfig.accentBg} label="Agente Studio" />
-      <ModuleAgentChat
-        isOpen={isAgentOpen}
-        onClose={closeAgent}
-        module={studioAgentConfig.module}
-        displayName={studioAgentConfig.displayName}
-        accentColor={studioAgentConfig.accentColor}
-        accentBg={studioAgentConfig.accentBg}
-        suggestedPrompts={studioAgentConfig.suggestedPrompts}
-        welcomeMessage={studioAgentConfig.welcomeMessage}
-        placeholder={studioAgentConfig.placeholder}
-      />
     </>
   );
 }

--- a/src/pages/ConnectionsPage.tsx
+++ b/src/pages/ConnectionsPage.tsx
@@ -2,17 +2,12 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ConnectionsView } from '../modules/connections/views/ConnectionsView';
 import { CreateSpaceDrawer } from '../modules/connections/components/CreateSpaceDrawer';
-import { ModuleAgentChat, ModuleAgentFAB, getModuleAgentConfig } from '../components/features/ModuleAgentChat';
-import { useModuleAgent } from '../hooks/useModuleAgent';
 import { useAuth } from '../hooks/useAuth';
 import type { ConnectionSpace, ArchetypeType } from '../modules/connections/types';
-
-const connectionsAgentConfig = getModuleAgentConfig('connections')!;
 
 export function ConnectionsPage() {
   const { user } = useAuth();
   const navigate = useNavigate();
-  const { isAgentOpen, openAgent, closeAgent } = useModuleAgent();
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [selectedArchetype, setSelectedArchetype] = useState<ArchetypeType | undefined>(undefined);
 
@@ -62,19 +57,6 @@ export function ConnectionsPage() {
         initialArchetype={selectedArchetype}
       />
 
-      {/* Module Agent */}
-      <ModuleAgentFAB onClick={openAgent} accentBg={connectionsAgentConfig.accentBg} label="Agente Connections" />
-      <ModuleAgentChat
-        isOpen={isAgentOpen}
-        onClose={closeAgent}
-        module={connectionsAgentConfig.module}
-        displayName={connectionsAgentConfig.displayName}
-        accentColor={connectionsAgentConfig.accentColor}
-        accentBg={connectionsAgentConfig.accentBg}
-        suggestedPrompts={connectionsAgentConfig.suggestedPrompts}
-        welcomeMessage={connectionsAgentConfig.welcomeMessage}
-        placeholder={connectionsAgentConfig.placeholder}
-      />
     </>
   );
 }

--- a/src/router/AppRouter.tsx
+++ b/src/router/AppRouter.tsx
@@ -630,7 +630,8 @@ export function AppRouter() {
             )}
 
             {/* Aica Chat FAB - Floating button for quick AI access */}
-            {isAuthenticated && <AicaChatFAB position="bottom-left" bottomOffset={shouldShowGlobalNav ? 80 : 16} />}
+            {/* Hidden on Vida page where VidaChatHero provides inline chat entry (#391) */}
+            {isAuthenticated && currentView !== 'vida-new' && <AicaChatFAB position="bottom-left" bottomOffset={shouldShowGlobalNav ? 80 : 16} />}
 
             {/* Notification Toast Container */}
             <NotificationContainer />

--- a/src/views/AgendaView.tsx
+++ b/src/views/AgendaView.tsx
@@ -25,8 +25,6 @@ const log = createNamespacedLogger('AgendaView');
 import { PriorityMatrix, DailyTimeline, HeaderGlobal, CalendarStatusDot, NextEventHero, AgendaTimeline, TaskCreationQuickAdd, AgendaModeToggle, TaskListView, TaskKanbanView, TaskFilterBar } from '../components';
 import { NextTwoDaysView, detectEventCategory, calculateTimeUntil } from '../components';
 import { CompletedTasksSection } from '../components/domain/CompletedTasksSection';
-import { ModuleAgentChat, ModuleAgentFAB, getModuleAgentConfig } from '../components/features/ModuleAgentChat';
-import { useModuleAgent } from '../hooks/useModuleAgent';
 import { useTaskCompletion } from '../hooks/useTaskCompletion';
 import { useTaskFilters } from '../hooks/useTaskFilters';
 import type { AgendaMode } from '../components/domain/AgendaModeToggle';
@@ -46,8 +44,6 @@ interface AgendaViewProps {
     onLogout: () => void;
 }
 
-const agendaAgentConfig = getModuleAgentConfig('agenda')!;
-
 /** Extract HH:MM from either "HH:MM", "HH:MM:SS" or full timestamptz string */
 const extractTimeHHMM = (ts: string): string | null => {
     try {
@@ -63,7 +59,6 @@ const extractTimeHHMM = (ts: string): string | null => {
 
 export const AgendaView: React.FC<AgendaViewProps> = ({ userId, userEmail, onLogout }) => {
     useTourAutoStart('atlas-first-visit');
-    const { isAgentOpen, openAgent, closeAgent } = useModuleAgent();
     const isDesktop = useIsDesktop();
     const [mobileMode, setMobileMode] = useState<AgendaMode>('agenda');
 
@@ -1035,19 +1030,6 @@ export const AgendaView: React.FC<AgendaViewProps> = ({ userId, userEmail, onLog
                 </DragOverlay>
             </DndContext>
 
-            {/* Module Agent */}
-            <ModuleAgentFAB onClick={openAgent} accentBg={agendaAgentConfig.accentBg} label="Agente Agenda" />
-            <ModuleAgentChat
-                isOpen={isAgentOpen}
-                onClose={closeAgent}
-                module={agendaAgentConfig.module}
-                displayName={agendaAgentConfig.displayName}
-                accentColor={agendaAgentConfig.accentColor}
-                accentBg={agendaAgentConfig.accentBg}
-                suggestedPrompts={agendaAgentConfig.suggestedPrompts}
-                welcomeMessage={agendaAgentConfig.welcomeMessage}
-                placeholder={agendaAgentConfig.placeholder}
-            />
         </div>
     );
 };


### PR DESCRIPTION
## Summary
- **#387**: Rename canvas labels — "Canvas de Prescricao" → "Prescrição", "Canvas" toggle → "Grade"
- **#389**: Verified alert colors (red=financial, blue=health) — already correct from previous sprint
- **#394**: Remove redundant "Canvas" quick-access button from FluxDashboard (workflow now: Athlete → Prescrever Treino)
- **#392**: Remove ModuleAgentFAB + ModuleAgentChat from all 7 modules (Agenda, Connections, Studio, Finance, Flux, Journey, Grants)
- **#391**: Hide global AicaChatFAB on Vida page where VidaChatHero inline bar already provides chat entry

## Changes
- 10 files modified, 160 lines removed, 5 added
- Zero new TypeScript errors (412 pre-existing, 412 after)
- Build passes in 20s

## Test plan
- [ ] `npm run build` passes
- [ ] `npm run typecheck` — no new errors
- [ ] Verify FluxDashboard shows Biblioteca + Meus Treinos (no Canvas button)
- [ ] Verify Canvas editor header shows "Prescrição" (not "Canvas de Prescricao")
- [ ] Verify /meu-treino toggle shows "Grade" (not "Canvas")
- [ ] Verify no module agent FAB buttons appear on any module page
- [ ] Verify Vida page (/vida) does NOT show floating chat FAB
- [ ] Verify other pages still show the global AicaChatFAB

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed Module Agent chat interface from Finance, Flux, Grants, Journey, Studio, Connections, and Agenda modules, streamlining the user experience across these sections.
  * Updated UI labels and navigation paths in the Flux module for improved clarity.
  * Simplified canvas editor and athlete portal displays with updated terminology.

* **Bug Fixes**
  * Fixed chat floating action button visibility on the Vida page to prevent interface conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->