### PR TITLE
fix(vida,journey): Sprint E — CP scoring, Life Council, chat UX, FAB positioning (#399, #413, #416, #417, #391)

### DIFF
--- a/src/components/features/AicaChatFAB/AicaChatFAB.css
+++ b/src/components/features/AicaChatFAB/AicaChatFAB.css
@@ -315,6 +315,63 @@
   font-weight: 400;
 }
 
+/* Empty state with quick actions */
+.aica-fab-empty-state {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  padding: 16px;
+}
+
+.aica-fab-empty-state__greeting {
+  margin: 0;
+  font-size: 15px;
+  color: rgba(0, 0, 0, 0.4);
+  font-weight: 500;
+}
+
+.aica-fab-quick-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+  max-width: 260px;
+}
+
+.aica-fab-quick-action {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border-radius: 14px;
+  border: 1px solid rgba(245, 158, 11, 0.2);
+  background: rgba(245, 158, 11, 0.06);
+  color: #b45309;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  text-align: left;
+}
+
+.aica-fab-quick-action:hover {
+  background: rgba(245, 158, 11, 0.14);
+  border-color: rgba(245, 158, 11, 0.4);
+  transform: translateY(-1px);
+}
+
+.aica-fab-quick-action:active {
+  transform: translateY(0);
+}
+
+.aica-fab-quick-action svg {
+  flex-shrink: 0;
+  color: #f59e0b;
+}
+
 /* Message bubbles */
 .aica-fab-message {
   max-width: 85%;
@@ -873,6 +930,25 @@
 
   .aica-fab-empty p {
     color: rgba(255, 255, 255, 0.3);
+  }
+
+  .aica-fab-empty-state__greeting {
+    color: rgba(255, 255, 255, 0.4);
+  }
+
+  .aica-fab-quick-action {
+    border-color: rgba(245, 158, 11, 0.2);
+    background: rgba(245, 158, 11, 0.1);
+    color: #fbbf24;
+  }
+
+  .aica-fab-quick-action:hover {
+    background: rgba(245, 158, 11, 0.2);
+    border-color: rgba(245, 158, 11, 0.35);
+  }
+
+  .aica-fab-quick-action svg {
+    color: #fbbf24;
   }
 
   .aica-fab-message--assistant {

--- a/src/components/features/AicaChatFAB/AicaChatFAB.tsx
+++ b/src/components/features/AicaChatFAB/AicaChatFAB.tsx
@@ -7,7 +7,7 @@
  */
 
 import { useState, useEffect, useRef, useCallback } from 'react'
-import { MessageCircle, X, Send, Loader2, Plus, Clock, ChevronLeft, Archive, Zap, Maximize2, Minimize2 } from 'lucide-react'
+import { MessageCircle, X, Send, Loader2, Plus, Clock, ChevronLeft, Archive, Zap, Maximize2, Minimize2, PenLine, Brain } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { cn } from '@/lib/utils'
 import { useChatSession } from '@/hooks/useChatSession'
@@ -24,11 +24,14 @@ import './AicaChatFAB.css'
 interface AicaChatFABProps {
   position?: 'bottom-right' | 'bottom-left'
   bottomOffset?: number
+  /** When true, hides the FAB circle button but keeps the drawer functional (openable via CustomEvent). Used on /vida where VidaChatHero replaces the FAB button. */
+  hideButton?: boolean
 }
 
 export function AicaChatFAB({
   position = 'bottom-right',
   bottomOffset = 80,
+  hideButton = false,
 }: AicaChatFABProps) {
   const [isOpen, setIsOpen] = useState(false)
   const [isExpanded, setIsExpanded] = useState(false)
@@ -60,18 +63,37 @@ export function AicaChatFAB({
 
   const { context: chatContext, isLoading: contextLoading } = useChatContextData(isExpanded)
 
+  // Ref to hold pending message from external event (VidaChatHero)
+  const pendingMessageRef = useRef<string | null>(null)
+
   // Listen for external open requests (e.g. from VidaChatHero)
   useEffect(() => {
     const handleExternalOpen = (e: Event) => {
       const detail = (e as CustomEvent).detail
       setIsOpen(true)
       if (detail?.message) {
+        // Store the message to be auto-sent once the drawer is open
+        pendingMessageRef.current = detail.message
         setInput(detail.message)
       }
     }
     window.addEventListener('aica-chat-open', handleExternalOpen)
     return () => window.removeEventListener('aica-chat-open', handleExternalOpen)
   }, [])
+
+  // Auto-send pending message once the drawer is open and not loading
+  useEffect(() => {
+    if (isOpen && pendingMessageRef.current && !isLoading) {
+      const message = pendingMessageRef.current
+      pendingMessageRef.current = null
+      // Small delay to let the drawer animation finish and input render
+      const timer = setTimeout(() => {
+        setInput('')
+        sendMessage(message)
+      }, 500)
+      return () => clearTimeout(timer)
+    }
+  }, [isOpen, isLoading, sendMessage])
 
   // Escape cascade: sessions → expanded → close
   useEffect(() => {
@@ -290,8 +312,40 @@ export function AicaChatFAB({
               {/* Messages */}
               <div className="aica-fab-messages">
                 {messages.length === 0 && !isLoading && (
-                  <div className="aica-fab-empty">
-                    <p>Ola! Como posso ajudar?</p>
+                  <div className="aica-fab-empty-state">
+                    <p className="aica-fab-empty-state__greeting">Ola! Como posso ajudar?</p>
+                    <div className="aica-fab-quick-actions">
+                      <button
+                        className="aica-fab-quick-action"
+                        onClick={() => {
+                          setInput('')
+                          sendMessage('Quero registrar um momento agora')
+                        }}
+                      >
+                        <PenLine size={13} />
+                        <span>Registrar momento</span>
+                      </button>
+                      <button
+                        className="aica-fab-quick-action"
+                        onClick={() => {
+                          setInput('')
+                          sendMessage('Me faca a pergunta do dia')
+                        }}
+                      >
+                        <MessageCircle size={13} />
+                        <span>Pergunta do dia</span>
+                      </button>
+                      <button
+                        className="aica-fab-quick-action"
+                        onClick={() => {
+                          setInput('')
+                          sendMessage('Quais sao meus padroes comportamentais recentes?')
+                        }}
+                      >
+                        <Brain size={13} />
+                        <span>Meus padroes</span>
+                      </button>
+                    </div>
                   </div>
                 )}
 
@@ -394,19 +448,21 @@ export function AicaChatFAB({
         )}
       </div>
 
-      {/* FAB Button */}
-      <button
-        className={cn(
-          'aica-fab-button',
-          isOpen && 'aica-fab-button--hidden',
-          position === 'bottom-left' && 'aica-fab-button--left'
-        )}
-        onClick={() => setIsOpen(true)}
-        style={{ '--fab-bottom-offset': `${bottomOffset}px` } as React.CSSProperties}
-        aria-label="Abrir chat com Aica"
-      >
-        <MessageCircle size={24} />
-      </button>
+      {/* FAB Button — hidden when hideButton=true (e.g. /vida where VidaChatHero replaces it) */}
+      {!hideButton && (
+        <button
+          className={cn(
+            'aica-fab-button',
+            isOpen && 'aica-fab-button--hidden',
+            position === 'bottom-left' && 'aica-fab-button--left'
+          )}
+          onClick={() => setIsOpen(true)}
+          style={{ '--fab-bottom-offset': `${bottomOffset}px` } as React.CSSProperties}
+          aria-label="Abrir chat com Aica"
+        >
+          <MessageCircle size={24} />
+        </button>
+      )}
     </>
   )
 }

--- a/src/components/features/VidaChatHero/VidaChatHero.tsx
+++ b/src/components/features/VidaChatHero/VidaChatHero.tsx
@@ -16,6 +16,8 @@ export function VidaChatHero() {
    const inputRef = useRef<HTMLInputElement>(null);
 
    const openChat = (message?: string) => {
+      // Blur the hero input so mobile keyboard dismisses and FAB input can take over
+      inputRef.current?.blur();
       window.dispatchEvent(
          new CustomEvent('aica-chat-open', { detail: { message } })
       );

--- a/src/modules/journey/hooks/useDailyQuestionAI.ts
+++ b/src/modules/journey/hooks/useDailyQuestionAI.ts
@@ -117,11 +117,19 @@ export function useDailyQuestionAI() {
         // Save response based on question source
         let result: AnswerQuestionResult
 
-        if (state.source === 'ai') {
-          // Save response in logs
-          await saveDailyResponse(user.id, state.question.id, responseText, 'ai')
+        // Check if question_id is a real DB UUID (journey questions from daily_questions table)
+        const isRealDBQuestion = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(state.question.id)
 
-          // Heuristic CP scoring (no Gemini call to control costs)
+        if (isRealDBQuestion) {
+          // Real DB question — save via questionService (Gemini quality eval + CP)
+          result = await saveQuestionResponse(user.id, {
+            question_id: state.question.id,
+            response_text: responseText,
+          })
+        } else {
+          // AI/template/pool question with synthetic ID — use heuristic CP scoring
+          await saveDailyResponse(user.id, state.question.id, responseText, state.source as 'ai' | 'journey' | 'pool')
+
           const wordCount = responseText.trim().split(/\s+/).length
           let cpEarned = 3
           if (wordCount >= 10) cpEarned = 5
@@ -139,12 +147,12 @@ export function useDailyQuestionAI() {
             })
             leveledUp = awardData?.leveled_up || false
           } catch (err) {
-            log.warn('Failed to award CP for AI question:', err)
+            log.warn('Failed to award CP:', err)
           }
 
           result = {
             response: {
-              id: `ai-response-${Date.now()}`,
+              id: `response-${Date.now()}`,
               user_id: user.id,
               question_id: state.question.id,
               response_text: responseText,
@@ -153,12 +161,6 @@ export function useDailyQuestionAI() {
             cp_earned: cpEarned,
             leveled_up: leveledUp,
           }
-        } else {
-          // For journey/pool questions, save with CP reward
-          result = await saveQuestionResponse(user.id, {
-            question_id: state.question.id,
-            response_text: responseText,
-          })
         }
 
         // Update state to show answered

--- a/src/modules/journey/services/dailyQuestionService.ts
+++ b/src/modules/journey/services/dailyQuestionService.ts
@@ -988,13 +988,21 @@ export async function saveDailyResponse(
   source: 'ai' | 'journey' | 'pool'
 ): Promise<boolean> {
   try {
-    // Save ALL responses to question_responses, including AI-generated questions
+    // question_responses.question_id is FK to daily_questions(id) — only valid UUIDs work.
+    // AI/template/pool questions use synthetic IDs (ai-xxx, pool-X) that aren't in the DB.
+    const isValidUUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(questionId)
+    if (!isValidUUID) {
+      log.info(`Skipping question_responses insert for non-DB question: ${questionId} (source=${source})`)
+      return true
+    }
+
     const { error } = await supabase.from('question_responses').insert({
       user_id: userId,
       question_id: questionId,
       response_text: responseText,
       responded_at: new Date().toISOString(),
-      ...(source === 'ai' ? { metadata: { source: 'ai', generated: true } } : {}),
+      question_source: source,
+      is_ai_generated_question: source === 'ai',
     })
 
     if (source === 'ai') {

--- a/src/pages/VidaPage.tsx
+++ b/src/pages/VidaPage.tsx
@@ -8,9 +8,10 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { Wallet, Heart, Building2, BookOpen, Scale, Mic, Briefcase, Ticket, Compass, type LucideIcon } from 'lucide-react';
+import { Wallet, Heart, Building2, BookOpen, Scale, Mic, Briefcase, Ticket, Compass, Flame, Zap, TrendingUp, type LucideIcon } from 'lucide-react';
 import { HeaderGlobal, ProfileDrawer, ModuleCard, ExploreMoreSection, CreditBalanceWidget, InviteShareCard, InviteModal } from '../components';
 import { VidaChatHero } from '@/components/features/VidaChatHero';
+import { LifeCouncilCard, PatternsSummary } from '@/components/features';
 import { FinanceCard } from '../modules/finance/components/FinanceCard';
 import { GrantsCard } from '../modules/grants/components/GrantsCard';
 import { JourneyHeroCard } from '../modules/journey';
@@ -18,6 +19,8 @@ import { FluxCard } from '../modules/flux';
 import { InterviewerCard } from '../modules/journey/components/interviewer';
 import { useConsciousnessPoints } from '../modules/journey/hooks/useConsciousnessPoints';
 import { LEVEL_COLORS } from '../modules/journey/types/consciousnessPoints';
+import { useLifeCouncil } from '@/hooks/useLifeCouncil';
+import { useUserPatterns } from '@/hooks/useUserPatterns';
 import { useGrantsHomeQuery } from '@/hooks/queries';
 import { ViewState } from '../../types';
 import { supabase } from '@/services/supabaseClient';
@@ -106,6 +109,12 @@ export default function VidaPage({
 
    // Identity data from Journey CP system
    const { stats: cpStats, progress: cpProgress } = useConsciousnessPoints();
+
+   // Life Council — auto-trigger daily insight generation
+   const council = useLifeCouncil({ autoTrigger: true });
+
+   // User Patterns — behavioral patterns from OpenClaw
+   const userPatterns = useUserPatterns();
 
    // User metadata for avatar and profile
    const avatarUrl = useMemo(() => user?.user_metadata?.avatar_url, [user]);
@@ -207,6 +216,89 @@ export default function VidaPage({
             >
                <VidaChatHero />
             </motion.div>
+
+            {/* Quick Stats — real-time user data */}
+            {cpStats && (
+               <motion.div
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.4, delay: 0.1 }}
+                  className="grid grid-cols-3 gap-2"
+               >
+                  <div className="bg-ceramic-base rounded-xl border border-ceramic-border p-3 flex items-center gap-2.5">
+                     <div className="w-8 h-8 rounded-lg bg-amber-500/10 flex items-center justify-center shrink-0">
+                        <Zap className="w-4 h-4 text-amber-500" />
+                     </div>
+                     <div className="min-w-0">
+                        <p className="text-lg font-bold text-ceramic-text-primary leading-tight">
+                           {cpStats.total_points || 0}
+                        </p>
+                        <p className="text-[10px] text-ceramic-text-secondary truncate">Total CP</p>
+                     </div>
+                  </div>
+                  <div className="bg-ceramic-base rounded-xl border border-ceramic-border p-3 flex items-center gap-2.5">
+                     <div className="w-8 h-8 rounded-lg bg-ceramic-warning/10 flex items-center justify-center shrink-0">
+                        <Flame className="w-4 h-4 text-ceramic-warning" />
+                     </div>
+                     <div className="min-w-0">
+                        <p className="text-lg font-bold text-ceramic-text-primary leading-tight">
+                           {cpStats.current_streak || 0}
+                        </p>
+                        <p className="text-[10px] text-ceramic-text-secondary truncate">Streak</p>
+                     </div>
+                  </div>
+                  <div className="bg-ceramic-base rounded-xl border border-ceramic-border p-3 flex items-center gap-2.5">
+                     <div className="w-8 h-8 rounded-lg bg-ceramic-info/10 flex items-center justify-center shrink-0">
+                        <TrendingUp className="w-4 h-4 text-ceramic-info" />
+                     </div>
+                     <div className="min-w-0">
+                        <p className="text-lg font-bold text-ceramic-text-primary leading-tight">
+                           {cpStats.total_moments || 0}
+                        </p>
+                        <p className="text-[10px] text-ceramic-text-secondary truncate">Momentos</p>
+                     </div>
+                  </div>
+               </motion.div>
+            )}
+
+            {/* Life Council — AI daily insight */}
+            <motion.div
+               initial={{ opacity: 0, y: 10 }}
+               animate={{ opacity: 1, y: 0 }}
+               transition={{ duration: 0.4, delay: 0.15 }}
+            >
+               <LifeCouncilCard
+                  insight={council.insight}
+                  isLoading={council.isLoading}
+                  isRunning={council.isRunning}
+                  error={council.error}
+                  onRun={council.runCouncil}
+                  onMarkViewed={council.markViewed}
+                  compact
+                  onViewMore={() => onNavigateToView('journey')}
+                  lastUpdated={council.insight?.insight_date}
+               />
+            </motion.div>
+
+            {/* Behavioral Patterns — compact */}
+            {(userPatterns.isLoading || userPatterns.patterns.length > 0) && (
+               <motion.div
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.4, delay: 0.2 }}
+               >
+                  <PatternsSummary
+                     patterns={userPatterns.patterns}
+                     isLoading={userPatterns.isLoading}
+                     isSynthesizing={userPatterns.isSynthesizing}
+                     error={userPatterns.error}
+                     onSynthesize={userPatterns.synthesize}
+                     compact
+                     onViewMore={() => onNavigateToView('journey')}
+                     lastUpdated={userPatterns.lastSynthesizedAt}
+                  />
+               </motion.div>
+            )}
 
             {/* Journey CTA — full width */}
             <motion.div

--- a/src/router/AppRouter.tsx
+++ b/src/router/AppRouter.tsx
@@ -630,8 +630,8 @@ export function AppRouter() {
             )}
 
             {/* Aica Chat FAB - Floating button for quick AI access */}
-            {/* Hidden on Vida page where VidaChatHero provides inline chat entry (#391) */}
-            {isAuthenticated && currentView !== 'vida-new' && <AicaChatFAB position="bottom-left" bottomOffset={shouldShowGlobalNav ? 80 : 16} />}
+            {/* On /vida, FAB button is hidden but drawer stays functional via CustomEvent from VidaChatHero (#391) */}
+            {isAuthenticated && <AicaChatFAB position="bottom-left" bottomOffset={shouldShowGlobalNav ? 80 : 16} hideButton={currentView === 'vida-new'} />}
 
             {/* Notification Toast Container */}
             <NotificationContainer />


### PR DESCRIPTION
## Summary
- **#399 CP +0**: Fixed `metadata` column reference (doesn't exist) → uses `question_source` + `is_ai_generated_question`. Also fixed FK constraint for synthetic question IDs (ai-xxx, pool-X, template-xxx) — skips DB insert, uses heuristic CP scoring (3-15 by word count)
- **#416 Life Council desconectado**: `LifeCouncilCard` and `PatternsSummary` were NOT rendered on VidaPage — added both with `autoTrigger: true`
- **#413 Chat input sem resposta**: `AicaChatFAB` was completely unmounted on `/vida` — now always rendered with `hideButton` prop. Auto-sends pending messages after drawer opens
- **#417 Sidebar desconectada + chat sem botões**: Added Quick Stats (CP, Streak, Moments) + 3 quick-action chips in chat empty state
- **#391 FAB desajustado**: FAB circle hidden on `/vida` (VidaChatHero replaces it), drawer stays functional via CustomEvent

## Files Changed (7)
| File | Change |
|------|--------|
| `dailyQuestionService.ts` | Skip DB insert for non-UUID question IDs, use correct columns |
| `useDailyQuestionAI.ts` | Route by UUID validity: real DB → Gemini eval, synthetic → heuristic CP |
| `VidaPage.tsx` | Add LifeCouncilCard, PatternsSummary, Quick Stats section |
| `AicaChatFAB.tsx` | `hideButton` prop, pendingMessageRef auto-send, quick-action chips |
| `AicaChatFAB.css` | Styles for quick-actions and empty state |
| `VidaChatHero.tsx` | Blur input before event dispatch (mobile keyboard fix) |
| `AppRouter.tsx` | Always render AicaChatFAB, pass `hideButton` on /vida |

## Test plan
- [ ] `npm run build` passes ✅
- [ ] Daily question answer awards CP > 0 (AI, pool, and journey sources)
- [ ] LifeCouncilCard visible on /vida with real insights
- [ ] PatternsSummary visible on /vida when patterns exist
- [ ] Quick Stats show real CP/streak/moments data
- [ ] VidaChatHero input opens chat drawer and auto-sends message
- [ ] FAB button hidden on /vida, visible on other pages
- [ ] Quick-action chips appear in chat empty state
- [ ] Mobile: keyboard dismisses when VidaChatHero opens drawer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Quick action buttons added to chat interface for faster interactions ("Registrar momento," "Pergunta do dia," "Meus padroes")
  * Life Council AI integration providing daily behavioral insights
  * User Patterns feature to track and summarize behavioral trends
  * Quick Stats section displaying progress metrics (points, streaks, moments)
  * External message auto-send capability for streamlined workflows

* **Bug Fixes**
  * Enhanced mobile keyboard dismissal when opening chat interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->