### PR TITLE
fix(flux,connections): Sprint G — feedback, groups, CP gating (#408, #419, #431, #432)

### DIFF
--- a/src/modules/connections/views/ConnectionsWhatsAppTab.tsx
+++ b/src/modules/connections/views/ConnectionsWhatsAppTab.tsx
@@ -32,6 +32,7 @@ import {
   CheckCircle2,
   Circle,
   Trash2,
+  Lock,
 } from 'lucide-react';
 import { CeramicTabSelector, ContactAvatar, ConfirmationModal } from '@/components/ui';
 import {
@@ -55,6 +56,7 @@ import whatsappAnalyticsService, {
 import { cn } from '@/lib/utils';
 import { staggerContainer, staggerItem } from '@/lib/animations/ceramic-motion';
 import { useWhatsAppGamification } from '../hooks/useWhatsAppGamification';
+import { useConsciousnessPoints } from '@/hooks/useConsciousnessPoints';
 import { supabase } from '@/services/supabaseClient';
 import { createNamespacedLogger } from '@/lib/logger';
 const log = createNamespacedLogger('ConnectionsWhatsAppTab');
@@ -64,6 +66,9 @@ const log = createNamespacedLogger('ConnectionsWhatsAppTab');
 // ============================================================================
 
 type TabId = 'import' | 'contacts' | 'intelligence' | 'analytics';
+
+// Minimum CP required to unlock intelligence features
+const MIN_CP_FOR_INTELLIGENCE = 50;
 
 interface ConnectionsWhatsAppTabProps {
   userId?: string;
@@ -278,6 +283,11 @@ export const ConnectionsWhatsAppTab: React.FC<ConnectionsWhatsAppTabProps> = ({
   // Gamification tracking
   const { trackAnalyticsView, trackContactAnalysis } = useWhatsAppGamification();
 
+  // Consciousness Points gate
+  const { balance } = useConsciousnessPoints({ autoFetch: true });
+  const currentCP = balance.total_cp;
+  const isIntelligenceUnlocked = currentCP >= MIN_CP_FOR_INTELLIGENCE;
+
   // Local sorting state
   const [sortBy, setSortBy] = useState<ContactSortField>('last_activity');
   const [sortOrder, setSortOrder] = useState<ContactSortOrder>('desc');
@@ -299,12 +309,13 @@ export const ConnectionsWhatsAppTab: React.FC<ConnectionsWhatsAppTabProps> = ({
   // Entity extraction (Conversation Intelligence Phase 3)
   const { entities, stats: entityStats, isLoading: isEntitiesLoading, isExtracting, acceptEntity, rejectEntity, extractEntities } = useExtractedEntities();
 
-  // Tab configuration
+  // Tab configuration — show lock icon on gated tabs when CP is below threshold
+  const lockIcon = !isIntelligenceUnlocked ? <Lock className="w-3.5 h-3.5 text-ceramic-text-secondary" /> : undefined;
   const tabs = [
     { id: 'import', label: 'Importar' },
-    { id: 'contacts', label: 'Contatos' },
-    { id: 'intelligence', label: 'Inteligencia' },
-    { id: 'analytics', label: 'Analytics' },
+    { id: 'contacts', label: 'Contatos', icon: lockIcon },
+    { id: 'intelligence', label: 'Inteligencia', icon: lockIcon },
+    { id: 'analytics', label: 'Analytics', icon: lockIcon },
   ];
 
   // Load data on mount
@@ -429,6 +440,68 @@ export const ConnectionsWhatsAppTab: React.FC<ConnectionsWhatsAppTabProps> = ({
       <Loader2 className="w-8 h-8 animate-spin text-ceramic-accent" />
     </div>
   );
+
+  // ── Locked State (CP gate) ──
+  const renderLockedState = () => {
+    const progressPercent = Math.min((currentCP / MIN_CP_FOR_INTELLIGENCE) * 100, 100);
+
+    return (
+      <motion.div
+        className="flex items-center justify-center py-16 px-4"
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.3 }}
+      >
+        <div className="ceramic-card p-8 rounded-3xl max-w-md w-full text-center space-y-6">
+          {/* Lock icon */}
+          <div className="w-20 h-20 rounded-full bg-ceramic-cool flex items-center justify-center mx-auto">
+            <Lock className="w-10 h-10 text-ceramic-text-secondary" />
+          </div>
+
+          {/* Title */}
+          <div className="space-y-2">
+            <h3 className="text-xl font-bold text-ceramic-text-primary">
+              Recurso Bloqueado
+            </h3>
+            <p className="text-sm text-ceramic-text-secondary leading-relaxed">
+              Desbloqueie com {MIN_CP_FOR_INTELLIGENCE} Pontos de Consciencia.
+              Continue registrando momentos e respondendo perguntas para desbloquear.
+            </p>
+          </div>
+
+          {/* Progress bar */}
+          <div className="space-y-2">
+            <div className="flex items-center justify-between text-xs font-medium">
+              <span className="text-ceramic-text-secondary">Progresso</span>
+              <span className="text-ceramic-accent">
+                {currentCP} / {MIN_CP_FOR_INTELLIGENCE} CP
+              </span>
+            </div>
+            <div className="w-full h-3 bg-ceramic-cool rounded-full overflow-hidden">
+              <motion.div
+                className="h-full bg-ceramic-accent rounded-full"
+                initial={{ width: 0 }}
+                animate={{ width: `${progressPercent}%` }}
+                transition={{ duration: 0.8, ease: 'easeOut' }}
+              />
+            </div>
+            <p className="text-xs text-ceramic-text-secondary">
+              Faltam {Math.max(MIN_CP_FOR_INTELLIGENCE - currentCP, 0)} CP
+            </p>
+          </div>
+
+          {/* CTA button */}
+          <a
+            href="/vida"
+            className="inline-flex items-center gap-2 px-6 py-3 bg-ceramic-accent text-white rounded-xl font-bold hover:scale-105 active:scale-95 transition-transform"
+          >
+            <Sparkles className="w-5 h-5" />
+            Ir para Vida
+          </a>
+        </div>
+      </motion.div>
+    );
+  };
 
   // ── Import Tab ──
   const renderImportTab = () => (
@@ -856,9 +929,9 @@ export const ConnectionsWhatsAppTab: React.FC<ConnectionsWhatsAppTabProps> = ({
             transition={{ duration: 0.2 }}
           >
             {activeTab === 'import' && renderImportTab()}
-            {activeTab === 'contacts' && renderContactsTab()}
-            {activeTab === 'intelligence' && renderIntelligenceTab()}
-            {activeTab === 'analytics' && renderAnalyticsTab()}
+            {activeTab === 'contacts' && (isIntelligenceUnlocked ? renderContactsTab() : renderLockedState())}
+            {activeTab === 'intelligence' && (isIntelligenceUnlocked ? renderIntelligenceTab() : renderLockedState())}
+            {activeTab === 'analytics' && (isIntelligenceUnlocked ? renderAnalyticsTab() : renderLockedState())}
           </motion.div>
         </AnimatePresence>
       </main>

--- a/src/modules/flux/components/AthleteCard.tsx
+++ b/src/modules/flux/components/AthleteCard.tsx
@@ -7,8 +7,8 @@
  */
 
 import React, { useState, useRef, useEffect } from 'react';
-import type { AthleteCardProps } from '../types';
-import { LEVEL_LABELS, STATUS_CONFIG, MODALITY_CONFIG } from '../types';
+import type { AthleteCardProps, AthleteGroup } from '../types';
+import { LEVEL_LABELS, STATUS_CONFIG, MODALITY_CONFIG, getGroupColorClasses } from '../types';
 import { LevelBadge } from './LevelBadge';
 import { AlertBadge } from './AlertBadge';
 import { ConnectionStatusDot } from './ConnectionStatusDot';
@@ -53,6 +53,8 @@ interface ExtendedAthleteCardProps extends Omit<AthleteCardProps, 'recentFeedbac
   onSendInvite?: () => void;
   onCopyLink?: () => void;
   inviteStatus?: 'none' | 'sent' | 'delivered' | 'bounced' | 'failed';
+  /** Group tags assigned to this athlete (from localStorage groups) */
+  groupTags?: AthleteGroup[];
 }
 
 export function AthleteCard({
@@ -67,6 +69,7 @@ export function AthleteCard({
   onSendInvite,
   onCopyLink,
   inviteStatus = 'none',
+  groupTags = [],
 }: ExtendedAthleteCardProps) {
   // Menu dropdown state
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -286,6 +289,23 @@ export function AthleteCard({
             </div>
           )}
         </div>
+
+        {/* Group Tags */}
+        {groupTags.length > 0 && (
+          <div className="flex flex-wrap gap-1.5">
+            {groupTags.map((group) => {
+              const colors = getGroupColorClasses(group.color);
+              return (
+                <span
+                  key={group.id}
+                  className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-bold uppercase tracking-wider ${colors.bg} ${colors.text}`}
+                >
+                  {group.name}
+                </span>
+              );
+            })}
+          </div>
+        )}
 
         {/* Metrics Row */}
         <div className="flex items-center justify-between gap-3 pt-2 border-t border-ceramic-text-secondary/10">

--- a/src/modules/flux/components/athlete/AthleteFeedbackView.tsx
+++ b/src/modules/flux/components/athlete/AthleteFeedbackView.tsx
@@ -1,9 +1,12 @@
 /**
- * AthleteFeedbackView — redesigned feedback tab with linear timeline
+ * AthleteFeedbackView -- redesigned feedback tab with linear timeline
  *
- * Replaces the old "Hoje"/"Semanal" toggle with a week-grouped timeline.
- * Each week shows weekly feedback status + per-exercise feedback status.
- * Uses the new `athlete_feedback_entries` table via `useAthleteFeedback`.
+ * Shows a week-grouped timeline with:
+ *   - Weekly feedback (one card per week)
+ *   - Daily feedback (one entry per workout day)
+ *
+ * Per-exercise questionnaire removed (#431).
+ * Radar chart added to feedback responses (#432).
  */
 
 import { MessageSquare, Loader2 } from 'lucide-react';
@@ -19,11 +22,10 @@ export interface AthleteFeedbackViewProps {
   selectedWeek?: number;
 }
 
-export function AthleteFeedbackView({ profile, onRefetch, selectedWeek }: AthleteFeedbackViewProps) {
+export function AthleteFeedbackView({ profile, onRefetch: _onRefetch, selectedWeek }: AthleteFeedbackViewProps) {
   const {
     weekSummaries,
     currentWeek,
-    submitExerciseFeedback,
     isSubmitting,
     isLoading,
     error,
@@ -33,11 +35,6 @@ export function AthleteFeedbackView({ profile, onRefetch, selectedWeek }: Athlet
   const filteredSummaries = selectedWeek != null
     ? weekSummaries.filter((ws) => ws.weekNumber === selectedWeek)
     : weekSummaries;
-
-  const handleSubmitExercise = async (input: Parameters<typeof submitExerciseFeedback>[0]) => {
-    await submitExerciseFeedback(input);
-    await onRefetch();
-  };
 
   return (
     <div className="space-y-5">
@@ -63,7 +60,6 @@ export function AthleteFeedbackView({ profile, onRefetch, selectedWeek }: Athlet
         <FeedbackTimeline
           weekSummaries={filteredSummaries}
           currentWeek={currentWeek}
-          onSubmitExercise={handleSubmitExercise}
           isSubmitting={isSubmitting}
           modality={profile.modality}
         />

--- a/src/modules/flux/components/athlete/FeedbackRadarChart.tsx
+++ b/src/modules/flux/components/athlete/FeedbackRadarChart.tsx
@@ -1,0 +1,235 @@
+/**
+ * FeedbackRadarChart -- Pure SVG radar/spider chart for feedback questionnaire data.
+ *
+ * Shows 6 dimensions derived from the athlete questionnaire:
+ *   Volume (avg of volume_adequate + volume_completed)
+ *   Intensidade (avg of intensity_adequate + intensity_completed)
+ *   Fadiga (inverted: low fatigue = good score)
+ *   Stress (inverted: low stress = good score)
+ *   Nutricao
+ *   Sono
+ *
+ * Reference implementation: EntityStatRadar.tsx (Life RPG module)
+ */
+
+import React, { useMemo } from 'react';
+import type { QuestionnaireData } from '../../hooks/useAthleteFeedback';
+
+export interface FeedbackRadarChartProps {
+  questionnaire: QuestionnaireData;
+  /** SVG logical size (viewBox). Defaults to 220. */
+  size?: number;
+  /** Fill color for the value polygon. Defaults to amber-500 (#F59E0B). */
+  accentColor?: string;
+}
+
+// ---- Geometry helpers (same pattern as EntityStatRadar) ----
+
+function polarToCartesian(
+  cx: number,
+  cy: number,
+  radius: number,
+  angleRad: number,
+): { x: number; y: number } {
+  return {
+    x: cx + radius * Math.cos(angleRad - Math.PI / 2),
+    y: cy + radius * Math.sin(angleRad - Math.PI / 2),
+  };
+}
+
+function buildPolygonPoints(
+  cx: number,
+  cy: number,
+  radius: number,
+  values: number[],
+  maxValue: number,
+): string {
+  const count = values.length;
+  return values
+    .map((v, i) => {
+      const angle = (2 * Math.PI * i) / count;
+      const r = (v / maxValue) * radius;
+      const { x, y } = polarToCartesian(cx, cy, r, angle);
+      return `${x},${y}`;
+    })
+    .join(' ');
+}
+
+// ---- Dimension extraction ----
+
+interface RadarDimension {
+  label: string;
+  value: number; // 0-5 scale
+}
+
+const MAX_VALUE = 5;
+
+/**
+ * Derive 6 radar dimensions from the raw 8-field questionnaire.
+ * Returns null if fewer than 3 fields are populated (not enough data to render).
+ */
+function extractDimensions(q: QuestionnaireData): RadarDimension[] | null {
+  const avg = (a?: number, b?: number): number | undefined => {
+    if (a != null && b != null) return (a + b) / 2;
+    return a ?? b;
+  };
+
+  const invert = (v?: number): number | undefined => {
+    if (v == null) return undefined;
+    return MAX_VALUE - v;
+  };
+
+  const dims: { label: string; raw: number | undefined }[] = [
+    { label: 'Volume', raw: avg(q.volume_adequate, q.volume_completed) },
+    { label: 'Intensidade', raw: avg(q.intensity_adequate, q.intensity_completed) },
+    { label: 'Fadiga', raw: invert(q.fatigue) },
+    { label: 'Stress', raw: invert(q.stress) },
+    { label: 'Nutricao', raw: q.nutrition },
+    { label: 'Sono', raw: q.sleep },
+  ];
+
+  // Need at least 3 populated dimensions
+  const populated = dims.filter((d) => d.raw != null);
+  if (populated.length < 3) return null;
+
+  // Fill missing with 0 so the polygon still closes
+  return dims.map((d) => ({
+    label: d.label,
+    value: d.raw ?? 0,
+  }));
+}
+
+// ---- Component ----
+
+export const FeedbackRadarChart: React.FC<FeedbackRadarChartProps> = ({
+  questionnaire,
+  size = 220,
+  accentColor = '#F59E0B', // amber-500
+}) => {
+  const dimensions = useMemo(() => extractDimensions(questionnaire), [questionnaire]);
+
+  if (!dimensions) return null;
+
+  const labels = dimensions.map((d) => d.label);
+  const values = dimensions.map((d) => d.value);
+  const count = labels.length;
+
+  const cx = size / 2;
+  const cy = size / 2;
+  const radius = size / 2 - 32;
+
+  const rings = [1, 2, 3, 4, 5];
+
+  // Radial grid lines from center to each vertex
+  const gridLines = labels.map((_, i) => {
+    const angle = (2 * Math.PI * i) / count;
+    const { x, y } = polarToCartesian(cx, cy, radius, angle);
+    return { x, y };
+  });
+
+  // Label positions (slightly outside the outermost ring)
+  const labelPositions = labels.map((label, i) => {
+    const angle = (2 * Math.PI * i) / count;
+    const { x, y } = polarToCartesian(cx, cy, radius + 20, angle);
+    return { label, x, y };
+  });
+
+  // Ideal (max) polygon -- dashed reference at 100%
+  const idealPoints = buildPolygonPoints(
+    cx,
+    cy,
+    radius,
+    labels.map(() => MAX_VALUE),
+    MAX_VALUE,
+  );
+
+  // Actual values polygon
+  const valuePoints = buildPolygonPoints(cx, cy, radius, values, MAX_VALUE);
+
+  return (
+    <div className="flex justify-center">
+      <svg
+        width="100%"
+        height="auto"
+        viewBox={`0 0 ${size} ${size}`}
+        className="max-w-[220px]"
+        role="img"
+        aria-label="Radar de feedback do atleta"
+      >
+        {/* Background rings */}
+        {rings.map((ring) => (
+          <polygon
+            key={ring}
+            points={buildPolygonPoints(
+              cx,
+              cy,
+              radius,
+              labels.map(() => ring),
+              MAX_VALUE,
+            )}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={0.5}
+            className="text-ceramic-border"
+          />
+        ))}
+
+        {/* Radial grid lines from center */}
+        {gridLines.map((point, i) => (
+          <line
+            key={i}
+            x1={cx}
+            y1={cy}
+            x2={point.x}
+            y2={point.y}
+            stroke="currentColor"
+            strokeWidth={0.5}
+            className="text-ceramic-border"
+          />
+        ))}
+
+        {/* Ideal polygon (dashed, faint reference at max) */}
+        <polygon
+          points={idealPoints}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={1}
+          strokeDasharray="4 2"
+          className="text-ceramic-border"
+        />
+
+        {/* Actual value polygon */}
+        <polygon
+          points={valuePoints}
+          fill={accentColor}
+          fillOpacity={0.2}
+          stroke={accentColor}
+          strokeWidth={2}
+          strokeLinejoin="round"
+        />
+
+        {/* Value dots on each vertex */}
+        {values.map((v, i) => {
+          const angle = (2 * Math.PI * i) / count;
+          const r = (v / MAX_VALUE) * radius;
+          const { x, y } = polarToCartesian(cx, cy, r, angle);
+          return <circle key={i} cx={x} cy={y} r={3} fill={accentColor} />;
+        })}
+
+        {/* Axis labels */}
+        {labelPositions.map(({ label, x, y }, i) => (
+          <text
+            key={i}
+            x={x}
+            y={y}
+            textAnchor="middle"
+            dominantBaseline="middle"
+            className="fill-ceramic-text-secondary text-[9px] font-medium"
+          >
+            {label}
+          </text>
+        ))}
+      </svg>
+    </div>
+  );
+};

--- a/src/modules/flux/components/athlete/FeedbackTimeline.tsx
+++ b/src/modules/flux/components/athlete/FeedbackTimeline.tsx
@@ -1,20 +1,22 @@
 /**
- * FeedbackTimeline — week-grouped timeline for the redesigned Feedback tab
+ * FeedbackTimeline -- week-grouped timeline for the redesigned Feedback tab
  *
  * Shows weeks in reverse order (most recent first).
- * Each week displays: weekly feedback status + per-exercise feedback status.
- * Exercises on the same day are grouped under a single day header.
- * Tapping a pending item opens the relevant form.
+ * Each week displays:
+ *   - Weekly feedback status + radar chart (if submitted)
+ *   - Daily feedback rows grouped by day of week
+ *
+ * Per-exercise questionnaire was removed (#431).
+ * Radar chart added at top of each feedback entry (#432).
  */
 
-import { useState, useCallback } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion } from 'framer-motion';
 import { MessageSquare } from 'lucide-react';
 import { FeedbackStatusRow } from './FeedbackStatusRow';
-import { ExerciseQuestionnaireSheet } from './ExerciseQuestionnaireSheet';
+import { FeedbackRadarChart } from './FeedbackRadarChart';
 import { MODALITY_CONFIG } from '../../types';
 import type { TrainingModality } from '../../types';
-import type { WeekFeedbackSummary, SubmitExerciseFeedbackInput, FeedbackSlotSummary } from '../../hooks/useAthleteFeedback';
+import type { WeekFeedbackSummary, FeedbackSlotSummary } from '../../hooks/useAthleteFeedback';
 
 const DAY_NAMES: Record<number, string> = {
   1: 'Seg', 2: 'Ter', 3: 'Qua', 4: 'Qui', 5: 'Sex', 6: 'Sab', 7: 'Dom',
@@ -45,11 +47,11 @@ function isSlotInFuture(
   currentWeek: number,
   dayOfWeek: number,
 ): boolean {
-  // Future week — all slots locked
+  // Future week -- all slots locked
   if (weekNumber > currentWeek) return true;
-  // Past week — all slots unlocked
+  // Past week -- all slots unlocked
   if (weekNumber < currentWeek) return false;
-  // Current week — compare day of week with today
+  // Current week -- compare day of week with today
   const now = new Date();
   const jsDay = now.getDay(); // 0=Sun, 1=Mon
   const todayIso = jsDay === 0 ? 7 : jsDay; // 1=Mon..7=Sun
@@ -59,7 +61,6 @@ function isSlotInFuture(
 export interface FeedbackTimelineProps {
   weekSummaries: WeekFeedbackSummary[];
   currentWeek: number;
-  onSubmitExercise: (input: SubmitExerciseFeedbackInput) => Promise<void>;
   onOpenWeeklyFeedback?: (weekNumber: number) => void;
   isSubmitting: boolean;
   modality?: TrainingModality;
@@ -68,37 +69,11 @@ export interface FeedbackTimelineProps {
 export function FeedbackTimeline({
   weekSummaries,
   currentWeek,
-  onSubmitExercise,
   onOpenWeeklyFeedback,
-  isSubmitting,
+  isSubmitting: _isSubmitting,
   modality,
 }: FeedbackTimelineProps) {
   const modalityIcon = modality ? MODALITY_CONFIG[modality]?.icon : undefined;
-  const [openQuestionnaire, setOpenQuestionnaire] = useState<{
-    slotId: string;
-    slotName: string;
-    dayLabel: string;
-  } | null>(null);
-
-  const handleOpenExercise = useCallback((slotId: string, slotName: string, dayOfWeek: number) => {
-    setOpenQuestionnaire({
-      slotId,
-      slotName,
-      dayLabel: DAY_NAMES[dayOfWeek] || '',
-    });
-  }, []);
-
-  const handleSubmitQuestionnaire = useCallback(
-    async (data: { slotId: string; questionnaire: Record<string, number | undefined>; notes: string }) => {
-      await onSubmitExercise({
-        slotId: data.slotId,
-        questionnaire: data.questionnaire,
-        notes: data.notes,
-      });
-      setOpenQuestionnaire(null);
-    },
-    [onSubmitExercise]
-  );
 
   if (weekSummaries.length === 0) {
     return (
@@ -119,63 +94,71 @@ export function FeedbackTimeline({
   }
 
   return (
-    <>
-      <div className="space-y-6">
-        {weekSummaries.map((ws, i) => {
-          const isCurrent = ws.weekNumber === currentWeek;
-          const weeklySubmitted = !!ws.weeklyFeedback;
-          const weeklyDate = ws.weeklyFeedback?.created_at;
-          const weeklyNotes = ws.weeklyFeedback?.notes || ws.weeklyFeedback?.voice_transcript;
-          const weeklyPreview = weeklyNotes
-            ? weeklyNotes.length > 50
-              ? weeklyNotes.slice(0, 50) + '...'
-              : weeklyNotes
-            : undefined;
+    <div className="space-y-6">
+      {weekSummaries.map((ws, i) => {
+        const isCurrent = ws.weekNumber === currentWeek;
+        const weeklySubmitted = !!ws.weeklyFeedback;
+        const weeklyDate = ws.weeklyFeedback?.created_at;
+        const weeklyNotes = ws.weeklyFeedback?.notes || ws.weeklyFeedback?.voice_transcript;
+        const weeklyPreview = weeklyNotes
+          ? weeklyNotes.length > 50
+            ? weeklyNotes.slice(0, 50) + '...'
+            : weeklyNotes
+          : undefined;
 
-          const isFutureWeek = ws.weekNumber > currentWeek;
+        const isFutureWeek = ws.weekNumber > currentWeek;
 
-          return (
-            <motion.div
-              key={ws.weekNumber}
-              initial={{ opacity: 0, y: 12 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: i * 0.06, duration: 0.3 }}
-              className="space-y-2"
-            >
-              {/* Week header */}
-              <div className="flex items-center gap-2 px-1">
-                <div className={`h-px flex-1 ${isCurrent ? 'bg-amber-300' : 'bg-ceramic-border/50'}`} />
-                <span className={`text-xs font-bold uppercase tracking-wider px-2 ${isCurrent ? 'text-amber-600' : 'text-ceramic-text-secondary'}`}>
-                  Semana {ws.weekNumber} {isCurrent ? '(atual)' : ''}
-                </span>
-                <div className={`h-px flex-1 ${isCurrent ? 'bg-amber-300' : 'bg-ceramic-border/50'}`} />
+        // Weekly feedback questionnaire data for radar chart
+        const weeklyQuestionnaire = ws.weeklyFeedback?.questionnaire;
+
+        return (
+          <motion.div
+            key={ws.weekNumber}
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: i * 0.06, duration: 0.3 }}
+            className="space-y-2"
+          >
+            {/* Week header */}
+            <div className="flex items-center gap-2 px-1">
+              <div className={`h-px flex-1 ${isCurrent ? 'bg-amber-300' : 'bg-ceramic-border/50'}`} />
+              <span className={`text-xs font-bold uppercase tracking-wider px-2 ${isCurrent ? 'text-amber-600' : 'text-ceramic-text-secondary'}`}>
+                Semana {ws.weekNumber} {isCurrent ? '(atual)' : ''}
+              </span>
+              <div className={`h-px flex-1 ${isCurrent ? 'bg-amber-300' : 'bg-ceramic-border/50'}`} />
+            </div>
+
+            <div className="bg-white rounded-2xl shadow-sm overflow-hidden">
+              {/* Weekly feedback row */}
+              <div className="px-2 pt-2">
+                <FeedbackStatusRow
+                  type="weekly"
+                  label="Feedback Semanal"
+                  isSubmitted={weeklySubmitted}
+                  locked={isFutureWeek}
+                  summary={weeklyPreview}
+                  dateLabel={weeklyDate ? formatDate(weeklyDate) : undefined}
+                  onTap={
+                    !weeklySubmitted && isCurrent && onOpenWeeklyFeedback
+                      ? () => onOpenWeeklyFeedback(ws.weekNumber)
+                      : undefined
+                  }
+                />
               </div>
 
-              <div className="bg-white rounded-2xl shadow-sm overflow-hidden">
-                {/* Weekly feedback row */}
-                <div className="px-2 pt-2">
-                  <FeedbackStatusRow
-                    type="weekly"
-                    label="Feedback Semanal"
-                    isSubmitted={weeklySubmitted}
-                    locked={isFutureWeek}
-                    summary={weeklyPreview}
-                    dateLabel={weeklyDate ? formatDate(weeklyDate) : undefined}
-                    onTap={
-                      !weeklySubmitted && isCurrent && onOpenWeeklyFeedback
-                        ? () => onOpenWeeklyFeedback(ws.weekNumber)
-                        : weeklySubmitted
-                          ? undefined
-                          : undefined
-                    }
-                  />
+              {/* Weekly radar chart (shown if weekly feedback has questionnaire data) */}
+              {weeklyQuestionnaire && (
+                <div className="px-4 py-3">
+                  <FeedbackRadarChart questionnaire={weeklyQuestionnaire} />
                 </div>
+              )}
 
-                {/* Exercise rows grouped by day */}
-                <div className="px-2 pb-2">
-                  {groupSlotsByDay(ws.slots).map((dayGroup) => (
+              {/* Daily feedback rows grouped by day */}
+              <div className="px-2 pb-2">
+                {groupSlotsByDay(ws.slots).map((dayGroup) => {
+                  return (
                     <div key={dayGroup.day}>
-                      {/* Day header — shown once per day */}
+                      {/* Day header */}
                       <div className="flex items-center gap-2 px-3 pt-2.5 pb-1">
                         <span className="text-[10px] font-black text-ceramic-text-secondary/70 uppercase tracking-wider w-7">
                           {DAY_NAMES[dayGroup.day] || ''}
@@ -183,64 +166,57 @@ export function FeedbackTimeline({
                         <div className="h-px flex-1 bg-ceramic-border/30" />
                       </div>
 
-                      {/* Exercises for this day */}
+                      {/* Slot rows for this day (daily feedback indicators) */}
                       <div className="space-y-0.5">
                         {dayGroup.slots.map((slot) => {
-                          const hasExerciseFeedback = !!slot.feedbackEntry;
                           const slotLocked = isSlotInFuture(ws.weekNumber, currentWeek, slot.dayOfWeek);
-                          const answered = slot.questionnaireAnswered;
+                          const isCompleted = slot.isCompleted;
                           const rpe = slot.rpe;
-                          const summary = hasExerciseFeedback
-                            ? `${answered}/8 resp.${rpe != null ? ` RPE ${rpe}` : ''}`
-                            : slot.isCompleted && rpe != null
-                              ? `RPE ${rpe}`
+                          const summary = isCompleted && rpe != null
+                            ? `RPE ${rpe}`
+                            : isCompleted
+                              ? 'Concluido'
                               : undefined;
 
+                          // Daily feedback radar: show if this slot has a feedback entry with questionnaire
+                          const slotQuestionnaire = slot.feedbackEntry?.questionnaire;
+
                           return (
-                            <FeedbackStatusRow
-                              key={slot.slotId}
-                              type="exercise"
-                              label={slot.templateName}
-                              isSubmitted={hasExerciseFeedback}
-                              locked={slotLocked}
-                              summary={summary}
-                              modalityIcon={modalityIcon}
-                              dateLabel={
-                                slot.feedbackEntry?.created_at
-                                  ? formatDate(slot.feedbackEntry.created_at)
-                                  : undefined
-                              }
-                              onTap={
-                                !slotLocked && !hasExerciseFeedback
-                                  ? () => handleOpenExercise(slot.slotId, slot.templateName, slot.dayOfWeek)
-                                  : undefined
-                              }
-                            />
+                            <div key={slot.slotId}>
+                              <FeedbackStatusRow
+                                type="exercise"
+                                label={slot.templateName}
+                                isSubmitted={isCompleted}
+                                locked={slotLocked}
+                                summary={summary}
+                                modalityIcon={modalityIcon}
+                                dateLabel={
+                                  slot.completedAt
+                                    ? formatDate(slot.completedAt)
+                                    : undefined
+                                }
+                              />
+                              {/* Radar chart for daily feedback entry */}
+                              {slotQuestionnaire && (
+                                <div className="px-4 py-2">
+                                  <FeedbackRadarChart
+                                    questionnaire={slotQuestionnaire}
+                                    size={180}
+                                  />
+                                </div>
+                              )}
+                            </div>
                           );
                         })}
                       </div>
                     </div>
-                  ))}
-                </div>
+                  );
+                })}
               </div>
-            </motion.div>
-          );
-        })}
-      </div>
-
-      {/* Exercise questionnaire sheet (bottom sheet) */}
-      <AnimatePresence>
-        {openQuestionnaire && (
-          <ExerciseQuestionnaireSheet
-            slotId={openQuestionnaire.slotId}
-            slotName={openQuestionnaire.slotName}
-            dayLabel={openQuestionnaire.dayLabel}
-            onSubmit={handleSubmitQuestionnaire}
-            onClose={() => setOpenQuestionnaire(null)}
-            isSubmitting={isSubmitting}
-          />
-        )}
-      </AnimatePresence>
-    </>
+            </div>
+          </motion.div>
+        );
+      })}
+    </div>
   );
 }

--- a/src/modules/flux/components/athlete/index.ts
+++ b/src/modules/flux/components/athlete/index.ts
@@ -19,3 +19,5 @@ export type { ExerciseQuestionnaireSheetProps } from './ExerciseQuestionnaireShe
 export { FeedbackTimeline } from './FeedbackTimeline';
 export type { FeedbackTimelineProps } from './FeedbackTimeline';
 export { FeedbackStatusRow } from './FeedbackStatusRow';
+export { FeedbackRadarChart } from './FeedbackRadarChart';
+export type { FeedbackRadarChartProps } from './FeedbackRadarChart';

--- a/src/modules/flux/components/coach/AthleteGroupManager.tsx
+++ b/src/modules/flux/components/coach/AthleteGroupManager.tsx
@@ -1,0 +1,497 @@
+/**
+ * AthleteGroupManager - CRUD para grupos de atletas
+ *
+ * Permite ao coach criar, renomear, excluir grupos e atribuir atletas.
+ * Dados armazenados em localStorage (sem migracao de banco).
+ * Segue Ceramic Design System.
+ */
+
+import React, { useState, useRef, useEffect } from 'react';
+import { X, Plus, Pencil, Trash2, Check, Users, Tag } from 'lucide-react';
+import type { Athlete, AthleteGroup, AthleteGroupData } from '../../types/flux';
+import { GROUP_COLORS, getGroupColorClasses } from '../../types/flux';
+
+// ============================================
+// localStorage helpers
+// ============================================
+
+const STORAGE_KEY_PREFIX = 'flux_athlete_groups_';
+
+function getStorageKey(coachUserId: string): string {
+  return `${STORAGE_KEY_PREFIX}${coachUserId}`;
+}
+
+export function loadGroupData(coachUserId: string): AthleteGroupData {
+  try {
+    const raw = localStorage.getItem(getStorageKey(coachUserId));
+    if (raw) {
+      const parsed = JSON.parse(raw) as AthleteGroupData;
+      // Validate structure
+      if (Array.isArray(parsed.groups) && typeof parsed.assignments === 'object') {
+        return parsed;
+      }
+    }
+  } catch (err) {
+    console.warn('[AthleteGroupManager] Failed to load group data from localStorage:', err);
+  }
+  return { groups: [], assignments: {} };
+}
+
+export function saveGroupData(coachUserId: string, data: AthleteGroupData): void {
+  try {
+    localStorage.setItem(getStorageKey(coachUserId), JSON.stringify(data));
+  } catch (err) {
+    console.error('[AthleteGroupManager] Failed to save group data to localStorage:', err);
+  }
+}
+
+/**
+ * Get groups assigned to a specific athlete
+ */
+export function getAthleteGroups(data: AthleteGroupData, athleteId: string): AthleteGroup[] {
+  const groupIds = data.assignments[athleteId] || [];
+  return data.groups.filter((g) => groupIds.includes(g.id));
+}
+
+/**
+ * Get all unique group names (for filter pills)
+ */
+export function getAllGroups(data: AthleteGroupData): AthleteGroup[] {
+  return data.groups;
+}
+
+/**
+ * Check if an athlete is in a specific group
+ */
+export function isAthleteInGroup(data: AthleteGroupData, athleteId: string, groupId: string): boolean {
+  return (data.assignments[athleteId] || []).includes(groupId);
+}
+
+// ============================================
+// Component Props
+// ============================================
+
+interface AthleteGroupManagerProps {
+  isOpen: boolean;
+  onClose: () => void;
+  coachUserId: string;
+  athletes: Athlete[];
+  groupData: AthleteGroupData;
+  onGroupDataChange: (data: AthleteGroupData) => void;
+}
+
+// ============================================
+// Component
+// ============================================
+
+export function AthleteGroupManager({
+  isOpen,
+  onClose,
+  coachUserId,
+  athletes,
+  groupData,
+  onGroupDataChange,
+}: AthleteGroupManagerProps) {
+  // Local state for editing
+  const [newGroupName, setNewGroupName] = useState('');
+  const [newGroupColor, setNewGroupColor] = useState(GROUP_COLORS[0].id);
+  const [editingGroupId, setEditingGroupId] = useState<string | null>(null);
+  const [editingName, setEditingName] = useState('');
+  const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const newGroupInputRef = useRef<HTMLInputElement>(null);
+
+  // Focus input when opening
+  useEffect(() => {
+    if (isOpen && newGroupInputRef.current) {
+      setTimeout(() => newGroupInputRef.current?.focus(), 200);
+    }
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  // Derived
+  const { groups, assignments } = groupData;
+
+  // Helpers to mutate and persist
+  const persist = (updated: AthleteGroupData) => {
+    saveGroupData(coachUserId, updated);
+    onGroupDataChange(updated);
+  };
+
+  // CREATE group
+  const handleCreateGroup = () => {
+    const trimmed = newGroupName.trim();
+    if (!trimmed) return;
+
+    // Check duplicate name
+    if (groups.some((g) => g.name.toLowerCase() === trimmed.toLowerCase())) return;
+
+    const newGroup: AthleteGroup = {
+      id: crypto.randomUUID(),
+      name: trimmed,
+      color: newGroupColor,
+      createdAt: new Date().toISOString(),
+    };
+
+    const updated: AthleteGroupData = {
+      groups: [...groups, newGroup],
+      assignments: { ...assignments },
+    };
+
+    persist(updated);
+    setNewGroupName('');
+    // Cycle to next color
+    const currentIdx = GROUP_COLORS.findIndex((c) => c.id === newGroupColor);
+    setNewGroupColor(GROUP_COLORS[(currentIdx + 1) % GROUP_COLORS.length].id);
+  };
+
+  // RENAME group
+  const handleRenameGroup = (groupId: string) => {
+    const trimmed = editingName.trim();
+    if (!trimmed) return;
+
+    const updated: AthleteGroupData = {
+      groups: groups.map((g) => (g.id === groupId ? { ...g, name: trimmed } : g)),
+      assignments: { ...assignments },
+    };
+
+    persist(updated);
+    setEditingGroupId(null);
+    setEditingName('');
+  };
+
+  // DELETE group
+  const handleDeleteGroup = (groupId: string) => {
+    // Remove group and all its assignments
+    const newAssignments = { ...assignments };
+    for (const athleteId of Object.keys(newAssignments)) {
+      newAssignments[athleteId] = newAssignments[athleteId].filter((gid) => gid !== groupId);
+      if (newAssignments[athleteId].length === 0) {
+        delete newAssignments[athleteId];
+      }
+    }
+
+    const updated: AthleteGroupData = {
+      groups: groups.filter((g) => g.id !== groupId),
+      assignments: newAssignments,
+    };
+
+    persist(updated);
+
+    // If we were viewing this group, deselect
+    if (selectedGroupId === groupId) {
+      setSelectedGroupId(null);
+    }
+  };
+
+  // TOGGLE athlete in group
+  const handleToggleAthleteInGroup = (athleteId: string, groupId: string) => {
+    const current = assignments[athleteId] || [];
+    let newList: string[];
+
+    if (current.includes(groupId)) {
+      newList = current.filter((gid) => gid !== groupId);
+    } else {
+      newList = [...current, groupId];
+    }
+
+    const newAssignments = { ...assignments };
+    if (newList.length === 0) {
+      delete newAssignments[athleteId];
+    } else {
+      newAssignments[athleteId] = newList;
+    }
+
+    const updated: AthleteGroupData = {
+      groups: [...groups],
+      assignments: newAssignments,
+    };
+
+    persist(updated);
+  };
+
+  // Athletes filtered by search
+  const filteredAthletes = athletes.filter((a) => {
+    if (!searchQuery.trim()) return true;
+    return a.name.toLowerCase().includes(searchQuery.toLowerCase().trim());
+  });
+
+  // Athletes in selected group
+  const athletesInSelectedGroup = selectedGroupId
+    ? filteredAthletes.filter((a) => (assignments[a.id] || []).includes(selectedGroupId))
+    : [];
+
+  const athletesNotInSelectedGroup = selectedGroupId
+    ? filteredAthletes.filter((a) => !(assignments[a.id] || []).includes(selectedGroupId))
+    : filteredAthletes;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 backdrop-blur-sm">
+      <div
+        className="bg-ceramic-base w-full max-w-lg max-h-[90vh] rounded-t-2xl sm:rounded-2xl shadow-xl flex flex-col overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-ceramic-border">
+          <div className="flex items-center gap-3">
+            <div className="ceramic-inset p-2">
+              <Tag className="w-5 h-5 text-ceramic-text-primary" />
+            </div>
+            <div>
+              <h2 className="text-lg font-bold text-ceramic-text-primary">Grupos de Atletas</h2>
+              <p className="text-xs text-ceramic-text-secondary">Organize seus atletas em grupos</p>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="ceramic-inset p-2 hover:bg-ceramic-cool transition-colors rounded-lg"
+          >
+            <X className="w-5 h-5 text-ceramic-text-secondary" />
+          </button>
+        </div>
+
+        {/* Content - scrollable */}
+        <div className="flex-1 overflow-y-auto px-6 py-4 space-y-6">
+          {/* Create new group */}
+          <div className="space-y-3">
+            <label className="text-xs font-bold text-ceramic-text-secondary uppercase tracking-wider">
+              Novo Grupo
+            </label>
+            <div className="flex items-center gap-2">
+              <input
+                ref={newGroupInputRef}
+                type="text"
+                value={newGroupName}
+                onChange={(e) => setNewGroupName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') handleCreateGroup();
+                }}
+                placeholder="Nome do grupo..."
+                className="flex-1 ceramic-inset px-3 py-2.5 rounded-lg text-sm text-ceramic-text-primary placeholder-ceramic-text-secondary/50 focus:outline-none focus:ring-2 focus:ring-ceramic-accent/50"
+                maxLength={40}
+              />
+              <button
+                onClick={handleCreateGroup}
+                disabled={!newGroupName.trim()}
+                className="ceramic-card p-2.5 hover:scale-105 transition-transform disabled:opacity-40 disabled:hover:scale-100"
+                title="Criar grupo"
+              >
+                <Plus className="w-4 h-4 text-ceramic-text-primary" />
+              </button>
+            </div>
+
+            {/* Color picker */}
+            <div className="flex flex-wrap gap-2">
+              {GROUP_COLORS.map((color) => (
+                <button
+                  key={color.id}
+                  onClick={() => setNewGroupColor(color.id)}
+                  className={`w-7 h-7 rounded-full ${color.bg} border-2 transition-all ${
+                    newGroupColor === color.id
+                      ? 'border-ceramic-text-primary scale-110'
+                      : 'border-transparent hover:scale-105'
+                  }`}
+                  title={color.label}
+                />
+              ))}
+            </div>
+          </div>
+
+          {/* Existing groups list */}
+          {groups.length > 0 && (
+            <div className="space-y-3">
+              <label className="text-xs font-bold text-ceramic-text-secondary uppercase tracking-wider">
+                Meus Grupos ({groups.length})
+              </label>
+              <div className="space-y-2">
+                {groups.map((group) => {
+                  const colors = getGroupColorClasses(group.color);
+                  const memberCount = Object.values(assignments).filter((ids) =>
+                    ids.includes(group.id)
+                  ).length;
+                  const isEditing = editingGroupId === group.id;
+                  const isSelected = selectedGroupId === group.id;
+
+                  return (
+                    <div
+                      key={group.id}
+                      className={`ceramic-card p-3 transition-all ${
+                        isSelected ? 'ring-2 ring-ceramic-accent' : ''
+                      }`}
+                    >
+                      <div className="flex items-center gap-3">
+                        {/* Color dot */}
+                        <div className={`w-3 h-3 rounded-full ${colors.bg} border border-black/10 flex-shrink-0`} />
+
+                        {/* Name (editable) */}
+                        {isEditing ? (
+                          <input
+                            type="text"
+                            value={editingName}
+                            onChange={(e) => setEditingName(e.target.value)}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter') handleRenameGroup(group.id);
+                              if (e.key === 'Escape') {
+                                setEditingGroupId(null);
+                                setEditingName('');
+                              }
+                            }}
+                            className="flex-1 ceramic-inset px-2 py-1 rounded text-sm text-ceramic-text-primary focus:outline-none focus:ring-1 focus:ring-ceramic-accent/50"
+                            autoFocus
+                            maxLength={40}
+                          />
+                        ) : (
+                          <button
+                            onClick={() => setSelectedGroupId(isSelected ? null : group.id)}
+                            className="flex-1 text-left"
+                          >
+                            <span className="text-sm font-bold text-ceramic-text-primary">
+                              {group.name}
+                            </span>
+                            <span className="ml-2 text-xs text-ceramic-text-secondary">
+                              {memberCount} atleta{memberCount !== 1 ? 's' : ''}
+                            </span>
+                          </button>
+                        )}
+
+                        {/* Actions */}
+                        <div className="flex items-center gap-1">
+                          {isEditing ? (
+                            <button
+                              onClick={() => handleRenameGroup(group.id)}
+                              className="p-1.5 hover:bg-ceramic-success/10 rounded transition-colors"
+                              title="Salvar"
+                            >
+                              <Check className="w-3.5 h-3.5 text-ceramic-success" />
+                            </button>
+                          ) : (
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                setEditingGroupId(group.id);
+                                setEditingName(group.name);
+                              }}
+                              className="p-1.5 hover:bg-ceramic-cool rounded transition-colors"
+                              title="Renomear"
+                            >
+                              <Pencil className="w-3.5 h-3.5 text-ceramic-text-secondary" />
+                            </button>
+                          )}
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleDeleteGroup(group.id);
+                            }}
+                            className="p-1.5 hover:bg-ceramic-error/10 rounded transition-colors"
+                            title="Excluir grupo"
+                          >
+                            <Trash2 className="w-3.5 h-3.5 text-ceramic-error" />
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {/* Athlete assignment (when a group is selected) */}
+          {selectedGroupId && (
+            <div className="space-y-3">
+              <div className="flex items-center justify-between">
+                <label className="text-xs font-bold text-ceramic-text-secondary uppercase tracking-wider">
+                  Atribuir Atletas - {groups.find((g) => g.id === selectedGroupId)?.name}
+                </label>
+                <button
+                  onClick={() => setSelectedGroupId(null)}
+                  className="text-xs text-ceramic-info hover:underline"
+                >
+                  Fechar
+                </button>
+              </div>
+
+              {/* Search athletes */}
+              <input
+                type="text"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                placeholder="Buscar atleta..."
+                className="w-full ceramic-inset px-3 py-2 rounded-lg text-sm text-ceramic-text-primary placeholder-ceramic-text-secondary/50 focus:outline-none focus:ring-2 focus:ring-ceramic-accent/50"
+              />
+
+              {/* Athletes in group */}
+              {athletesInSelectedGroup.length > 0 && (
+                <div className="space-y-1">
+                  <p className="text-[10px] font-bold text-ceramic-success uppercase tracking-wider">
+                    No grupo ({athletesInSelectedGroup.length})
+                  </p>
+                  {athletesInSelectedGroup.map((athlete) => (
+                    <button
+                      key={athlete.id}
+                      onClick={() => handleToggleAthleteInGroup(athlete.id, selectedGroupId)}
+                      className="w-full flex items-center gap-3 px-3 py-2 ceramic-card hover:bg-ceramic-cool transition-colors text-left"
+                    >
+                      <div className="w-2 h-2 rounded-full bg-ceramic-success flex-shrink-0" />
+                      <span className="text-sm text-ceramic-text-primary flex-1 truncate">
+                        {athlete.name}
+                      </span>
+                      <Check className="w-4 h-4 text-ceramic-success flex-shrink-0" />
+                    </button>
+                  ))}
+                </div>
+              )}
+
+              {/* Athletes NOT in group */}
+              {athletesNotInSelectedGroup.length > 0 && (
+                <div className="space-y-1">
+                  <p className="text-[10px] font-bold text-ceramic-text-secondary uppercase tracking-wider">
+                    Disponíveis ({athletesNotInSelectedGroup.length})
+                  </p>
+                  {athletesNotInSelectedGroup.map((athlete) => (
+                    <button
+                      key={athlete.id}
+                      onClick={() => handleToggleAthleteInGroup(athlete.id, selectedGroupId)}
+                      className="w-full flex items-center gap-3 px-3 py-2 ceramic-inset hover:bg-white/50 transition-colors text-left rounded-lg"
+                    >
+                      <div className="w-2 h-2 rounded-full bg-ceramic-border flex-shrink-0" />
+                      <span className="text-sm text-ceramic-text-secondary flex-1 truncate">
+                        {athlete.name}
+                      </span>
+                      <Plus className="w-4 h-4 text-ceramic-text-secondary flex-shrink-0" />
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Empty state */}
+          {groups.length === 0 && (
+            <div className="ceramic-inset p-8 text-center space-y-3">
+              <div className="w-12 h-12 mx-auto ceramic-card flex items-center justify-center">
+                <Users className="w-6 h-6 text-ceramic-text-secondary" />
+              </div>
+              <p className="text-sm font-bold text-ceramic-text-primary">Nenhum grupo criado</p>
+              <p className="text-xs text-ceramic-text-secondary">
+                Crie grupos para organizar seus atletas (ex: "Grupo Leme", "Corrida Avancado")
+              </p>
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="px-6 py-4 border-t border-ceramic-border">
+          <button
+            onClick={onClose}
+            className="w-full py-3 ceramic-card text-sm font-bold text-ceramic-text-primary hover:scale-[1.01] transition-transform"
+          >
+            Fechar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/modules/flux/types/flux.ts
+++ b/src/modules/flux/types/flux.ts
@@ -324,6 +324,51 @@ export interface MyAthleteProfile {
 }
 
 // ============================================
+// ATHLETE GROUPS (localStorage-based, no migration)
+// ============================================
+
+/**
+ * Athlete group for coach organization (stored in localStorage)
+ * Key: `flux_athlete_groups_${coachUserId}`
+ */
+export interface AthleteGroupData {
+  groups: AthleteGroup[];
+  assignments: Record<string, string[]>; // athleteId -> groupId[]
+}
+
+/**
+ * Single group definition
+ */
+export interface AthleteGroup {
+  id: string;
+  name: string;
+  color: string; // Tailwind color key e.g. 'amber', 'rose', 'sky'
+  createdAt: string;
+}
+
+/**
+ * Available group colors (Ceramic-friendly palette)
+ */
+export const GROUP_COLORS: { id: string; label: string; bg: string; text: string }[] = [
+  { id: 'amber', label: 'Amarelo', bg: 'bg-amber-100', text: 'text-amber-700' },
+  { id: 'rose', label: 'Rosa', bg: 'bg-rose-100', text: 'text-rose-700' },
+  { id: 'sky', label: 'Azul', bg: 'bg-sky-100', text: 'text-sky-700' },
+  { id: 'emerald', label: 'Verde', bg: 'bg-emerald-100', text: 'text-emerald-700' },
+  { id: 'violet', label: 'Violeta', bg: 'bg-violet-100', text: 'text-violet-700' },
+  { id: 'orange', label: 'Laranja', bg: 'bg-orange-100', text: 'text-orange-700' },
+  { id: 'teal', label: 'Teal', bg: 'bg-teal-100', text: 'text-teal-700' },
+  { id: 'pink', label: 'Pink', bg: 'bg-pink-100', text: 'text-pink-700' },
+];
+
+/**
+ * Helper: get group color classes by color id
+ */
+export function getGroupColorClasses(colorId: string): { bg: string; text: string } {
+  const found = GROUP_COLORS.find((c) => c.id === colorId);
+  return found ? { bg: found.bg, text: found.text } : { bg: 'bg-ceramic-cool', text: 'text-ceramic-text-secondary' };
+}
+
+// ============================================
 // UI STATE TYPES
 // ============================================
 

--- a/src/modules/flux/types/index.ts
+++ b/src/modules/flux/types/index.ts
@@ -40,6 +40,10 @@ export type {
   Alert,
   Exercise,
 
+  // Athlete Groups (localStorage-based)
+  AthleteGroupData,
+  AthleteGroup,
+
   // UI State
   FluxMode,
   FluxState,
@@ -69,6 +73,8 @@ export {
   SEVERITY_COLORS,
   MODALITY_CONFIG,
   TRAINING_MODALITIES,
+  GROUP_COLORS,
+  getGroupColorClasses,
 } from './flux';
 
 // ============================================

--- a/src/modules/flux/views/FluxDashboard.tsx
+++ b/src/modules/flux/views/FluxDashboard.tsx
@@ -14,16 +14,17 @@ import { useAthleteActivity } from '../hooks/useAthleteActivity';
 import { AthleteService, CreateAthleteInput } from '../services/athleteService';
 import { supabase } from '@/services/supabaseClient';
 import { AthleteProfileService } from '../services/athleteProfileService';
-import { MODALITY_CONFIG, TRAINING_MODALITIES } from '../types';
-import type { TrainingModality, AthleteLevel, Alert, ModalityLevel } from '../types';
+import { MODALITY_CONFIG, TRAINING_MODALITIES, getGroupColorClasses } from '../types';
+import type { TrainingModality, AthleteLevel, Alert, ModalityLevel, AthleteGroupData } from '../types';
 import { AthleteCard } from '../components/AthleteCard';
 import type { SlotFeedback } from '../components/AthleteCard';
 import { WhatsAppMessageModal } from '../components/WhatsAppMessageModal';
 import { AthleteFormDrawer } from '../components/forms';
 import DeleteConfirmationModal from '../components/DeleteConfirmationModal';
+import { AthleteGroupManager, loadGroupData, saveGroupData, getAthleteGroups } from '../components/coach/AthleteGroupManager';
 import type { Athlete } from '../types';
 import { useWorkoutTemplates } from '../hooks/useWorkoutTemplates';
-import { ArrowLeft, Users, TrendingUp, Plus, Filter, GraduationCap, ArrowUpDown, ArrowUp, ArrowDown, Search, CheckCircle, X } from 'lucide-react';
+import { ArrowLeft, Users, TrendingUp, Plus, Filter, GraduationCap, ArrowUpDown, ArrowUp, ArrowDown, Search, CheckCircle, X, Tag, Settings } from 'lucide-react';
 import { ErrorBoundary, ModuleErrorFallback } from '@/components/ui/ErrorBoundary';
 import { useFluxGamification } from '../hooks/useFluxGamification';
 
@@ -96,6 +97,24 @@ export default function FluxDashboard() {
   const [selectedLevel, setSelectedLevel] = useState<LevelCategory>('all');
   const [consistencySort, setAdherenceSort] = useState<SortOrder>('none');
   const [searchQuery, setSearchQuery] = useState<string>('');
+
+  // Group filter states
+  const [selectedGroupIds, setSelectedGroupIds] = useState<string[]>([]);
+  const [groupManagerOpen, setGroupManagerOpen] = useState(false);
+  const [coachUserId, setCoachUserId] = useState<string>('');
+  const [groupData, setGroupData] = useState<AthleteGroupData>({ groups: [], assignments: {} });
+
+  // Load coach user ID and group data
+  useEffect(() => {
+    const loadCoachData = async () => {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (user) {
+        setCoachUserId(user.id);
+        setGroupData(loadGroupData(user.id));
+      }
+    };
+    loadCoachData();
+  }, []);
 
   // WhatsApp modal state
   const [whatsAppModalOpen, setWhatsAppModalOpen] = useState(false);
@@ -238,6 +257,14 @@ export default function FluxDashboard() {
       }
     }
 
+    // Filter by group (OR logic: athlete must be in at least one selected group)
+    if (selectedGroupIds.length > 0) {
+      result = result.filter((a) => {
+        const athleteGroupIds = groupData.assignments[a.id] || [];
+        return selectedGroupIds.some((gid) => athleteGroupIds.includes(gid));
+      });
+    }
+
     // Sort by adherence rate
     if (consistencySort !== 'none') {
       result.sort((a, b) => {
@@ -248,7 +275,7 @@ export default function FluxDashboard() {
     }
 
     return result;
-  }, [allAthletes, selectedModality, selectedLevel, consistencySort, searchQuery]);
+  }, [allAthletes, selectedModality, selectedLevel, consistencySort, searchQuery, selectedGroupIds, groupData]);
 
   // Toggle sort order
   const toggleAdherenceSort = () => {
@@ -624,6 +651,105 @@ export default function FluxDashboard() {
               ))}
             </div>
           </div>
+
+          {/* Group Filter Pills */}
+          <div>
+            <div className="flex items-center justify-between mb-3">
+              <div className="flex items-center gap-2">
+                <Tag className="w-4 h-4 text-ceramic-text-secondary" />
+                <span className="text-xs font-bold text-ceramic-text-secondary uppercase tracking-wider">
+                  Grupos
+                </span>
+              </div>
+              <button
+                onClick={() => setGroupManagerOpen(true)}
+                className="flex items-center gap-1 px-2 py-1 rounded-lg hover:bg-ceramic-cool transition-colors"
+                title="Gerenciar grupos"
+              >
+                <Settings className="w-3.5 h-3.5 text-ceramic-text-secondary" />
+                <span className="text-[10px] font-bold text-ceramic-text-secondary uppercase tracking-wider">
+                  Gerenciar
+                </span>
+              </button>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {groupData.groups.length === 0 ? (
+                <button
+                  onClick={() => setGroupManagerOpen(true)}
+                  className="flex items-center gap-2 px-3 py-2 ceramic-inset hover:bg-white/50 rounded-lg transition-all"
+                >
+                  <Plus className="w-3.5 h-3.5 text-ceramic-text-secondary" />
+                  <span className="text-xs font-bold text-ceramic-text-secondary uppercase tracking-wider">
+                    Criar Grupo
+                  </span>
+                </button>
+              ) : (
+                <>
+                  {/* "Todos" pill to clear group filter */}
+                  <button
+                    onClick={() => setSelectedGroupIds([])}
+                    className={`flex items-center gap-2 px-3 py-2 rounded-lg transition-all ${
+                      selectedGroupIds.length === 0
+                        ? 'ceramic-card bg-ceramic-base shadow-md'
+                        : 'ceramic-inset hover:bg-white/50'
+                    }`}
+                  >
+                    <span className="text-xs font-bold uppercase tracking-wider text-ceramic-text-primary">
+                      Todos
+                    </span>
+                  </button>
+
+                  {/* Group pills */}
+                  {groupData.groups.map((group) => {
+                    const isSelected = selectedGroupIds.includes(group.id);
+                    const colors = getGroupColorClasses(group.color);
+                    const memberCount = (Object.values(groupData.assignments) as string[][]).filter((ids) =>
+                      ids.includes(group.id)
+                    ).length;
+
+                    return (
+                      <button
+                        key={group.id}
+                        onClick={() => {
+                          setSelectedGroupIds((prev) =>
+                            prev.includes(group.id)
+                              ? prev.filter((id) => id !== group.id)
+                              : [...prev, group.id]
+                          );
+                        }}
+                        className={`flex items-center gap-2 px-3 py-2 rounded-lg transition-all ${
+                          isSelected
+                            ? 'ceramic-card bg-ceramic-base shadow-md ring-1 ring-ceramic-accent/30'
+                            : 'ceramic-inset hover:bg-white/50'
+                        }`}
+                      >
+                        <span className={`w-2.5 h-2.5 rounded-full ${colors.bg} border border-black/10`} />
+                        <span className={`text-xs font-bold uppercase tracking-wider ${
+                          isSelected ? 'text-ceramic-text-primary' : 'text-ceramic-text-secondary'
+                        }`}>
+                          {group.name}
+                        </span>
+                        <span className={`text-xs font-medium px-1.5 py-0.5 rounded ${
+                          isSelected ? `${colors.bg} ${colors.text}` : 'bg-ceramic-cool text-ceramic-text-secondary'
+                        }`}>
+                          {memberCount}
+                        </span>
+                      </button>
+                    );
+                  })}
+
+                  {/* Quick add group */}
+                  <button
+                    onClick={() => setGroupManagerOpen(true)}
+                    className="flex items-center gap-1 px-2 py-2 ceramic-inset hover:bg-white/50 rounded-lg transition-all"
+                    title="Adicionar grupo"
+                  >
+                    <Plus className="w-3.5 h-3.5 text-ceramic-text-secondary" />
+                  </button>
+                </>
+              )}
+            </div>
+          </div>
         </div>
 
       </div>
@@ -652,7 +778,7 @@ export default function FluxDashboard() {
 
         <div className="flex items-center justify-between">
           <h2 className="text-lg font-bold text-ceramic-text-primary">
-            {selectedModality === 'all' && selectedLevel === 'all'
+            {selectedModality === 'all' && selectedLevel === 'all' && selectedGroupIds.length === 0
               ? 'Meus Atletas'
               : 'Atletas'}
             {selectedModality !== 'all' && (
@@ -662,6 +788,14 @@ export default function FluxDashboard() {
               <span className="ml-1">
                 {selectedModality !== 'all' ? ' - ' : 'de nivel '}
                 {LEVEL_CATEGORIES.find((c) => c.id === selectedLevel)?.label}
+              </span>
+            )}
+            {selectedGroupIds.length > 0 && (
+              <span className="ml-1">
+                {selectedModality !== 'all' || selectedLevel !== 'all' ? ' - ' : ''}
+                {selectedGroupIds.length === 1
+                  ? groupData.groups.find((g) => g.id === selectedGroupIds[0])?.name || ''
+                  : `${selectedGroupIds.length} grupos`}
               </span>
             )}
             <span className="ml-2 text-sm font-normal text-ceramic-text-secondary">
@@ -711,6 +845,7 @@ export default function FluxDashboard() {
           {filteredAthletes.slice(0, 20).map((athlete) => {
             const athleteAlerts: Alert[] = [];
             const athleteFeedbacks = feedbacksByAthlete[athlete.id] || [];
+            const athleteGroupTags = getAthleteGroups(groupData, athlete.id);
 
             return (
               <AthleteCard
@@ -726,6 +861,7 @@ export default function FluxDashboard() {
                 onDelete={() => handleDeleteClick(athlete)}
                 onSendInvite={() => handleSendInvite(athlete)}
                 onCopyLink={() => {}}
+                groupTags={athleteGroupTags}
               />
             );
           })}
@@ -748,12 +884,12 @@ export default function FluxDashboard() {
             </div>
             <div>
               <p className="text-lg font-bold text-ceramic-text-primary mb-2">
-                {selectedModality === 'all' && selectedLevel === 'all'
+                {selectedModality === 'all' && selectedLevel === 'all' && selectedGroupIds.length === 0
                   ? 'Nenhum atleta cadastrado'
                   : 'Nenhum atleta encontrado'}
               </p>
               <p className="text-sm text-ceramic-text-secondary font-light">
-                {selectedModality === 'all' && selectedLevel === 'all'
+                {selectedModality === 'all' && selectedLevel === 'all' && selectedGroupIds.length === 0
                   ? 'Gerencie treinos de natacao, corrida, ciclismo ou forca'
                   : 'Ajuste os filtros ou cadastre novos atletas'}
               </p>
@@ -761,18 +897,19 @@ export default function FluxDashboard() {
             <button
               onClick={() => {
                 // Se não há filtros ativos, abre modal de criar atleta
-                if (selectedModality === 'all' && selectedLevel === 'all') {
+                if (selectedModality === 'all' && selectedLevel === 'all' && selectedGroupIds.length === 0) {
                   setAthleteModalOpen(true);
                 } else {
                   // Se há filtros ativos, limpa os filtros
                   setSelectedModality('all');
                   setSelectedLevel('all');
                   setAdherenceSort('none');
+                  setSelectedGroupIds([]);
                 }
               }}
               className="px-6 py-3 ceramic-card text-sm font-bold text-ceramic-text-primary hover:scale-105 transition-transform"
             >
-              {selectedModality === 'all' && selectedLevel === 'all'
+              {selectedModality === 'all' && selectedLevel === 'all' && selectedGroupIds.length === 0
                 ? 'Adicionar Primeiro Atleta'
                 : 'Limpar Filtros'}
             </button>
@@ -820,6 +957,16 @@ export default function FluxDashboard() {
             ? `Tem certeza que deseja excluir ${athleteToDelete.name}? Esta ação não pode ser desfeita.`
             : ''
         }
+      />
+
+      {/* Athlete Group Manager Modal */}
+      <AthleteGroupManager
+        isOpen={groupManagerOpen}
+        onClose={() => setGroupManagerOpen(false)}
+        coachUserId={coachUserId}
+        athletes={allAthletes}
+        groupData={groupData}
+        onGroupDataChange={(updated) => setGroupData(updated)}
       />
 
       {/* Invite Toast */}


### PR DESCRIPTION
## Summary
- **Feedback Redesign** (#431, #432): Remove per-exercise questionnaire (keep daily+weekly only), add SVG radar chart showing Volume/Intensidade/Fadiga/Stress/Nutrição/Sono
- **Athlete Groups** (#419): localStorage-based group management for coaches — create/rename/delete groups, assign athletes, color-coded tags, group filter on dashboard
- **Connections Gating** (#408): Intelligence tabs (Contatos, Inteligência, Analytics) locked behind 50 CP threshold with progress bar and "Ir para Vida" CTA

## Issues Closed
Closes #408, closes #419, closes #431, closes #432

## Files Changed (10)
| File | Changes |
|------|---------|
| `FeedbackTimeline.tsx` | Remove exercise questionnaire, add radar integration |
| `AthleteFeedbackView.tsx` | Remove exercise feedback prop |
| `FeedbackRadarChart.tsx` | NEW — pure SVG radar chart (6 axes) |
| `AthleteGroupManager.tsx` | NEW — group CRUD + athlete assignment modal |
| `AthleteCard.tsx` | Group tags display |
| `FluxDashboard.tsx` | Group filter UI + integration |
| `flux.ts` | AthleteGroup types + GROUP_COLORS |
| `index.ts` (types + components) | Barrel exports |
| `ConnectionsWhatsAppTab.tsx` | CP gating with locked state |

## Test plan
- [ ] `npm run build` passes
- [ ] Feedback timeline shows only daily+weekly (no per-exercise)
- [ ] Radar chart renders when questionnaire data exists
- [ ] Coach can create/edit/delete athlete groups
- [ ] Group filter works on dashboard
- [ ] Connections intelligence tabs show locked state below 50 CP
- [ ] Import tab always accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>