### PR TITLE
fix(flux): Sprint H — aggregated radar chart + remove follow-up (#433, #415)

### DIFF
--- a/src/modules/flux/components/athlete/AthleteFeedbackView.tsx
+++ b/src/modules/flux/components/athlete/AthleteFeedbackView.tsx
@@ -9,10 +9,11 @@
  * Radar chart added to feedback responses (#432).
  */
 
-import { MessageSquare, Loader2 } from 'lucide-react';
+import { MessageSquare, Loader2, BarChart3 } from 'lucide-react';
 import type { MyAthleteProfile } from '../../types';
 import { useAthleteFeedback } from '../../hooks/useAthleteFeedback';
 import { FeedbackTimeline } from './FeedbackTimeline';
+import { FeedbackRadarChart } from './FeedbackRadarChart';
 
 export interface AthleteFeedbackViewProps {
   profile: MyAthleteProfile;
@@ -29,6 +30,7 @@ export function AthleteFeedbackView({ profile, onRefetch: _onRefetch, selectedWe
     isSubmitting,
     isLoading,
     error,
+    aggregatedQuestionnaire,
   } = useAthleteFeedback(profile);
 
   // Filter to selected week when provided
@@ -43,6 +45,28 @@ export function AthleteFeedbackView({ profile, onRefetch: _onRefetch, selectedWe
         <MessageSquare className="w-4 h-4 text-ceramic-text-secondary" />
         <h3 className="text-sm font-bold text-ceramic-text-primary">Meu Feedback</h3>
       </div>
+
+      {/* Aggregated Radar Chart (#433) */}
+      {aggregatedQuestionnaire ? (
+        <div className="bg-white rounded-xl p-4 shadow-sm border border-ceramic-border/30">
+          <FeedbackRadarChart
+            questionnaire={aggregatedQuestionnaire}
+            size={260}
+            title="Visao Geral"
+            subtitle="Media de todos os feedbacks respondidos"
+          />
+        </div>
+      ) : !isLoading && weekSummaries.length > 0 ? (
+        <div className="bg-ceramic-cool/50 rounded-xl p-4 text-center">
+          <BarChart3 className="w-6 h-6 text-ceramic-text-secondary mx-auto mb-2" />
+          <p className="text-xs text-ceramic-text-secondary">
+            Responda os questionarios para ver seu radar de performance
+          </p>
+          <p className="text-[10px] text-ceramic-text-secondary/60 mt-1">
+            Volume · Intensidade · Fadiga · Stress · Nutricao · Sono
+          </p>
+        </div>
+      ) : null}
 
       {/* Error */}
       {error && (

--- a/src/modules/flux/components/athlete/FeedbackRadarChart.tsx
+++ b/src/modules/flux/components/athlete/FeedbackRadarChart.tsx
@@ -21,6 +21,10 @@ export interface FeedbackRadarChartProps {
   size?: number;
   /** Fill color for the value polygon. Defaults to amber-500 (#F59E0B). */
   accentColor?: string;
+  /** Optional title displayed above the chart */
+  title?: string;
+  /** Optional subtitle displayed below the title */
+  subtitle?: string;
 }
 
 // ---- Geometry helpers (same pattern as EntityStatRadar) ----
@@ -105,6 +109,8 @@ export const FeedbackRadarChart: React.FC<FeedbackRadarChartProps> = ({
   questionnaire,
   size = 220,
   accentColor = '#F59E0B', // amber-500
+  title,
+  subtitle,
 }) => {
   const dimensions = useMemo(() => extractDimensions(questionnaire), [questionnaire]);
 
@@ -147,7 +153,13 @@ export const FeedbackRadarChart: React.FC<FeedbackRadarChartProps> = ({
   const valuePoints = buildPolygonPoints(cx, cy, radius, values, MAX_VALUE);
 
   return (
-    <div className="flex justify-center">
+    <div className="flex flex-col items-center">
+      {title && (
+        <h4 className="text-sm font-bold text-ceramic-text-primary mb-1">{title}</h4>
+      )}
+      {subtitle && (
+        <p className="text-xs text-ceramic-text-secondary mb-2">{subtitle}</p>
+      )}
       <svg
         width="100%"
         height="auto"

--- a/src/modules/flux/hooks/useAthleteFeedback.ts
+++ b/src/modules/flux/hooks/useAthleteFeedback.ts
@@ -401,11 +401,44 @@ export function useAthleteFeedback(profile: MyAthleteProfile | null) {
     []
   );
 
+  // Aggregated questionnaire averages across all completed feedbacks
+  const aggregatedQuestionnaire = useMemo<QuestionnaireData | null>(() => {
+    const withQ = feedbackRows.filter((r) => {
+      if (!r.questionnaire) return false;
+      return countAnswered(r.questionnaire) >= 3;
+    });
+    if (withQ.length === 0) return null;
+
+    const sums: Record<string, { total: number; count: number }> = {};
+    for (const row of withQ) {
+      for (const key of QUESTIONNAIRE_KEYS) {
+        const val = row.questionnaire?.[key];
+        if (val != null) {
+          if (!sums[key]) sums[key] = { total: 0, count: 0 };
+          sums[key].total += val;
+          sums[key].count += 1;
+        }
+      }
+    }
+
+    const result: QuestionnaireData = {};
+    let populated = 0;
+    for (const key of QUESTIONNAIRE_KEYS) {
+      if (sums[key] && sums[key].count > 0) {
+        (result as Record<string, number>)[key] = Math.round((sums[key].total / sums[key].count) * 10) / 10;
+        populated++;
+      }
+    }
+
+    return populated >= 3 ? result : null;
+  }, [feedbackRows]);
+
   return {
     // New API
     weekSummaries,
     feedbackRows,
     submitExerciseFeedback,
+    aggregatedQuestionnaire,
     isLoading,
 
     // Legacy API (backward compat)


### PR DESCRIPTION
## Summary
- **Radar Chart** (#433): Aggregated radar chart at top of feedback tab showing average scores across all completed feedbacks (Volume, Intensidade, Fadiga, Stress, Nutrição, Sono)
- **Follow-up removed** (#415): "Aprofundar" feature disabled to save tokens — question flow is now: one question → answer → CP → done (PR #436 already merged)

## Issues Closed
Closes #433

## Files Changed (3)
| File | Changes |
|------|---------|
| `useAthleteFeedback.ts` | Add `aggregatedQuestionnaire` computed value |
| `FeedbackRadarChart.tsx` | Add `title`/`subtitle` props |
| `AthleteFeedbackView.tsx` | Integrate aggregated radar + placeholder |

## Test plan
- [ ] `npm run build` passes
- [ ] Feedback tab shows aggregated radar when questionnaire data exists
- [ ] Placeholder shown when no questionnaire data yet
- [ ] Radar dimensions correct: Volume, Intensidade, Fadiga, Stress, Nutrição, Sono

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced aggregated feedback radar chart visualization for athlete performance data.
  * Added optional title and subtitle support to radar chart display.
  * Added a guidance card prompting users to complete feedback questionnaires when data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->