### PR TITLE
fix(vida,flux): remove Life Council/Patterns + clean dashboard (#440, #442)

### DIFF
--- a/src/modules/flux/views/FluxDashboard.tsx
+++ b/src/modules/flux/views/FluxDashboard.tsx
@@ -10,7 +10,7 @@ import { useNavigate } from 'react-router-dom';
 import { useAthletes } from '../hooks/useAthletes';
 import { useAthleteActivity } from '../hooks/useAthleteActivity';
 import { useWorkoutTemplates } from '../hooks/useWorkoutTemplates';
-import { ArrowLeft, Users, BookOpen, Dumbbell, TrendingUp, Plus, CheckCircle, X } from 'lucide-react';
+import { ArrowLeft, Users, BookOpen, Dumbbell, CheckCircle, X } from 'lucide-react';
 import { ErrorBoundary, ModuleErrorFallback } from '@/components/ui/ErrorBoundary';
 
 export default function FluxDashboard() {
@@ -25,14 +25,8 @@ export default function FluxDashboard() {
   // Workout templates count
   const { templates } = useWorkoutTemplates();
 
-  // Aggregate stats
+  // Aggregate stats (for card badges only)
   const activeAthletes = allAthletes.filter((a) => a.status === 'active').length;
-  const avgConsistency = React.useMemo(() => {
-    const activeWithAdherence = allAthletes.filter((a) => a.status === 'active');
-    if (activeWithAdherence.length === 0) return 0;
-    const sum = activeWithAdherence.reduce((acc, a) => acc + (a.adherence_rate ?? 0), 0);
-    return Math.round(sum / activeWithAdherence.length);
-  }, [allAthletes]);
 
   // Loading state
   if (isLoading) {
@@ -162,48 +156,7 @@ export default function FluxDashboard() {
           </button>
         </div>
 
-        {/* Quick Stats Row */}
-        <div className="grid grid-cols-2 gap-4">
-          <div className="ceramic-card p-4 space-y-2">
-            <div className="flex items-center gap-2">
-              <div className="ceramic-inset p-2">
-                <Users className="w-4 h-4 text-ceramic-info" />
-              </div>
-              <p className="text-[10px] text-ceramic-text-secondary font-medium uppercase tracking-wider">
-                Atletas Ativos
-              </p>
-            </div>
-            <p className="text-2xl font-bold text-ceramic-text-primary">
-              {activeAthletes}
-            </p>
-          </div>
-
-          <div className="ceramic-card p-4 space-y-2">
-            <div className="flex items-center gap-2">
-              <div className="ceramic-inset p-2">
-                <TrendingUp className="w-4 h-4 text-ceramic-success" />
-              </div>
-              <p className="text-[10px] text-ceramic-text-secondary font-medium uppercase tracking-wider">
-                Consistencia Media
-              </p>
-            </div>
-            <p className="text-2xl font-bold text-ceramic-text-primary">
-              {avgConsistency}%
-            </p>
-          </div>
-        </div>
-
-        {/* Novo Atleta Button */}
-        <div className="mt-6">
-          <button
-            data-tour="flux-add-athlete"
-            onClick={() => navigate('/flux/crm?new=1')}
-            className="w-full flex items-center justify-center gap-2 px-4 py-3 ceramic-card hover:scale-[1.01] transition-transform"
-          >
-            <Plus className="w-5 h-5 text-ceramic-text-primary" />
-            <span className="text-sm font-bold text-ceramic-text-primary">Novo Atleta</span>
-          </button>
-        </div>
+        {/* #442: Stats and Novo Atleta button removed — accessed via Command Center */}
       </div>
 
       {/* Activity Toast Notifications */}

--- a/src/pages/VidaPage.tsx
+++ b/src/pages/VidaPage.tsx
@@ -11,7 +11,7 @@ import { motion } from 'framer-motion';
 import { Wallet, Heart, Building2, BookOpen, Scale, Mic, Briefcase, Ticket, Compass, Flame, Zap, TrendingUp, type LucideIcon } from 'lucide-react';
 import { HeaderGlobal, ProfileDrawer, ModuleCard, ExploreMoreSection, CreditBalanceWidget, InviteShareCard, InviteModal } from '../components';
 import { VidaChatHero } from '@/components/features/VidaChatHero';
-import { LifeCouncilCard, PatternsSummary } from '@/components/features';
+// #440: LifeCouncilCard and PatternsSummary removed from /vida
 import { FinanceCard } from '../modules/finance/components/FinanceCard';
 import { GrantsCard } from '../modules/grants/components/GrantsCard';
 import { JourneyHeroCard } from '../modules/journey';
@@ -19,8 +19,7 @@ import { FluxCard } from '../modules/flux';
 import { InterviewerCard } from '../modules/journey/components/interviewer';
 import { useConsciousnessPoints } from '../modules/journey/hooks/useConsciousnessPoints';
 import { LEVEL_COLORS } from '../modules/journey/types/consciousnessPoints';
-import { useLifeCouncil } from '@/hooks/useLifeCouncil';
-import { useUserPatterns } from '@/hooks/useUserPatterns';
+// #440: useLifeCouncil and useUserPatterns removed from /vida
 import { useGrantsHomeQuery } from '@/hooks/queries';
 import { ViewState } from '../../types';
 import { supabase } from '@/services/supabaseClient';
@@ -110,11 +109,7 @@ export default function VidaPage({
    // Identity data from Journey CP system
    const { stats: cpStats, progress: cpProgress } = useConsciousnessPoints();
 
-   // Life Council — auto-trigger daily insight generation
-   const council = useLifeCouncil({ autoTrigger: true });
-
-   // User Patterns — behavioral patterns from OpenClaw
-   const userPatterns = useUserPatterns();
+   // #440: Life Council and Patterns hooks removed — re-enable when data is sufficient
 
    // User metadata for avatar and profile
    const avatarUrl = useMemo(() => user?.user_metadata?.avatar_url, [user]);
@@ -261,44 +256,7 @@ export default function VidaPage({
                </motion.div>
             )}
 
-            {/* Life Council — AI daily insight */}
-            <motion.div
-               initial={{ opacity: 0, y: 10 }}
-               animate={{ opacity: 1, y: 0 }}
-               transition={{ duration: 0.4, delay: 0.15 }}
-            >
-               <LifeCouncilCard
-                  insight={council.insight}
-                  isLoading={council.isLoading}
-                  isRunning={council.isRunning}
-                  error={council.error}
-                  onRun={council.runCouncil}
-                  onMarkViewed={council.markViewed}
-                  compact
-                  onViewMore={() => onNavigateToView('journey')}
-                  lastUpdated={council.insight?.insight_date}
-               />
-            </motion.div>
-
-            {/* Behavioral Patterns — compact */}
-            {(userPatterns.isLoading || userPatterns.patterns.length > 0) && (
-               <motion.div
-                  initial={{ opacity: 0, y: 10 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ duration: 0.4, delay: 0.2 }}
-               >
-                  <PatternsSummary
-                     patterns={userPatterns.patterns}
-                     isLoading={userPatterns.isLoading}
-                     isSynthesizing={userPatterns.isSynthesizing}
-                     error={userPatterns.error}
-                     onSynthesize={userPatterns.synthesize}
-                     compact
-                     onViewMore={() => onNavigateToView('journey')}
-                     lastUpdated={userPatterns.lastSynthesizedAt}
-                  />
-               </motion.div>
-            )}
+            {/* #440: Life Council and Patterns removed from /vida — re-enable when data is sufficient */}
 
             {/* Journey CTA — full width */}
             <motion.div


### PR DESCRIPTION
## Summary
- **#440**: Remove "Conselho de Vida" (LifeCouncilCard) and "Seus Padrões" (PatternsSummary) from `/vida` page — saves tokens, re-enable when data is sufficient
- **#442**: Remove stats row (Atletas Ativos / Consistência Média) and "Novo Atleta" button from FluxDashboard — these are now in Command Center

## Issues Closed
Closes #440, closes #442

## Test plan
- [ ] `npm run build` passes
- [ ] `/vida` page no longer shows Life Council or Patterns sections
- [ ] `/flux` dashboard shows only 3 navigation cards (no stats, no button)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Moved stats display and Novo Atleta button access to Command Center.
  * Temporarily removed Life Council and Patterns sections from the dashboard; planned for future re-enablement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->