### PR TITLE
fix(flux): navigate Prescrever Treino to canvas editor (#445)

### DIFF
--- a/src/modules/flux/views/AthleteDetailView.tsx
+++ b/src/modules/flux/views/AthleteDetailView.tsx
@@ -769,7 +769,7 @@ export default function AthleteDetailView() {
         </h2>
         <div className="grid grid-cols-2 gap-3">
           <button
-            onClick={() => navigate('/flux/microcycle/new')}
+            onClick={() => navigate(`/flux/canvas/${athleteId}`)}
             className="ceramic-card p-4 hover:scale-[1.02] transition-all group text-left"
           >
             <div className="flex items-start gap-3">


### PR DESCRIPTION
## Summary
- Fixed "Prescrever Treino" button navigating to `/flux/microcycle/new` which caused `invalid input syntax for type uuid: "new"` error
- Now navigates to `/flux/canvas/:athleteId` — the proper coach canvas prescription interface with the athlete pre-selected

Closes #445

## Test plan
- [ ] `npm run build` passes
- [ ] Navigate to athlete detail → click "Prescrever Treino" → should open canvas editor with athlete pre-selected
- [ ] No console error about UUID syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the "Prescrever Treino / Flow Tools" action to navigate to the correct athlete-specific canvas location instead of a generic route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->