### PR TITLE
fix(flux): Sprint J — CRM modalities, radar scale, block athlete, timeline (#459-#465)

### DIFF
--- a/src/modules/flux/components/athlete/FeedbackRadarChart.tsx
+++ b/src/modules/flux/components/athlete/FeedbackRadarChart.tsx
@@ -228,6 +228,24 @@ export const FeedbackRadarChart: React.FC<FeedbackRadarChartProps> = ({
           return <circle key={i} cx={x} cy={y} r={3} fill={accentColor} />;
         })}
 
+        {/* Numeric scale labels along first axis (12 o'clock) */}
+        {rings.map((ring) => {
+          const r = (ring / MAX_VALUE) * radius;
+          const { x, y } = polarToCartesian(cx, cy, r, 0);
+          return (
+            <text
+              key={`scale-${ring}`}
+              x={x + 8}
+              y={y}
+              textAnchor="start"
+              dominantBaseline="middle"
+              className="fill-ceramic-text-secondary text-[8px] font-bold"
+            >
+              {ring}
+            </text>
+          );
+        })}
+
         {/* Axis labels */}
         {labelPositions.map(({ label, x, y }, i) => (
           <text

--- a/src/modules/flux/components/forms/TemplateFormDrawer.tsx
+++ b/src/modules/flux/components/forms/TemplateFormDrawer.tsx
@@ -219,6 +219,13 @@ export default function TemplateFormDrawer({
               </button>
             </div>
 
+            {/* Timeline Visual — sticky above form (#465) */}
+            {formData.exercise_structure?.series && formData.exercise_structure.series.length > 0 && (
+              <div className="px-6 py-3 border-b border-ceramic-text-secondary/10 bg-ceramic-base/95 backdrop-blur-sm">
+                <TimelineVisual series={formData.exercise_structure.series} />
+              </div>
+            )}
+
             {/* Form Content (scrollable) */}
             <form onSubmit={handleFormSubmit} className="flex-1 overflow-y-auto">
               <div className="p-6 space-y-6">
@@ -370,11 +377,6 @@ export default function TemplateFormDrawer({
                           {cooldownCharCount}/140
                         </span>
                       </div>
-
-                      {/* Timeline Visual (after cooldown) */}
-                      {formData.exercise_structure?.series && formData.exercise_structure.series.length > 0 && (
-                        <TimelineVisual series={formData.exercise_structure.series} />
-                      )}
 
                       {/* Coach Notes */}
                       <div>

--- a/src/modules/flux/views/AthleteDetailView.tsx
+++ b/src/modules/flux/views/AthleteDetailView.tsx
@@ -37,6 +37,8 @@ import {
   Calculator,
   Save,
   CheckCircle,
+  Lock,
+  Unlock,
 } from 'lucide-react';
 
 const AVATAR_COLORS = [
@@ -92,6 +94,9 @@ export default function AthleteDetailView() {
     practice_duration_months: '',
   });
   const [profileSaving, setProfileSaving] = useState(false);
+
+  // Block/unblock athlete state
+  const [blockingAthlete, setBlockingAthlete] = useState(false);
 
   const docs = useAthleteDocuments({ athleteId: athleteId || '' });
 
@@ -282,6 +287,23 @@ export default function AthleteDetailView() {
     }
   };
 
+  // Handle block/unblock athlete
+  const handleToggleBlock = async () => {
+    if (!athleteId || !athlete) return;
+    setBlockingAthlete(true);
+    try {
+      const newStatus = athlete.status === 'paused' ? 'active' : 'paused';
+      const { data, error } = await AthleteService.updateStatus(athleteId, newStatus);
+      if (error) {
+        console.error('Error toggling athlete block status:', error);
+      } else if (data) {
+        setAthlete(data);
+      }
+    } finally {
+      setBlockingAthlete(false);
+    }
+  };
+
   // Handle back
   const handleBack = () => {
     actions.viewDashboard();
@@ -329,6 +351,19 @@ export default function AthleteDetailView() {
           </div>
           <span className="text-xs font-bold uppercase tracking-wider">Voltar</span>
         </button>
+
+        {/* Blocked Banner */}
+        {athlete.status === 'paused' && (
+          <div className="flex items-center gap-3 p-4 mb-4 bg-ceramic-error/10 border border-ceramic-error/20 rounded-xl">
+            <Lock className="w-5 h-5 text-ceramic-error flex-shrink-0" />
+            <div>
+              <p className="text-sm font-bold text-ceramic-error">Atleta Bloqueado</p>
+              <p className="text-xs text-ceramic-error/80">
+                Este atleta esta com acesso pausado e nao pode visualizar treinos.
+              </p>
+            </div>
+          </div>
+        )}
 
         {/* Athlete Profile Card */}
         <div className="ceramic-card p-6 space-y-4">
@@ -777,7 +812,7 @@ export default function AthleteDetailView() {
                 <Calendar className="w-5 h-5 text-ceramic-info" />
               </div>
               <div>
-                <p className="text-sm font-bold text-ceramic-text-primary">Prescrever Treino</p>
+                <p className="text-sm font-bold text-ceramic-text-primary">Prescrever e ver Treinos</p>
                 <p className="text-xs text-ceramic-text-secondary">Plano de 4 semanas</p>
               </div>
             </div>
@@ -823,6 +858,40 @@ export default function AthleteDetailView() {
               <span className="text-xs font-bold text-ceramic-success">Treino Liberado</span>
             </div>
           )}
+        </div>
+      </div>
+
+      {/* Gerenciamento Section — #464 */}
+      <div className="px-6 mb-6">
+        <h2 className="text-lg font-bold text-ceramic-text-primary mb-3">
+          Gerenciamento
+        </h2>
+        <div className="ceramic-card p-4">
+          <button
+            onClick={handleToggleBlock}
+            disabled={blockingAthlete}
+            className={`w-full flex items-center gap-3 px-4 py-3 rounded-lg font-bold text-sm transition-all disabled:opacity-50 disabled:cursor-not-allowed ${
+              athlete.status === 'paused'
+                ? 'bg-ceramic-success/10 text-ceramic-success hover:bg-ceramic-success/20 border border-ceramic-success/20'
+                : 'bg-ceramic-error/10 text-ceramic-error hover:bg-ceramic-error/20 border border-ceramic-error/20'
+            }`}
+          >
+            {blockingAthlete ? (
+              <Loader2 className="w-5 h-5 animate-spin" />
+            ) : athlete.status === 'paused' ? (
+              <Unlock className="w-5 h-5" />
+            ) : (
+              <Lock className="w-5 h-5" />
+            )}
+            <div className="text-left">
+              <p>{athlete.status === 'paused' ? 'Desbloquear Atleta' : 'Bloquear Atleta'}</p>
+              <p className="text-xs font-normal opacity-70">
+                {athlete.status === 'paused'
+                  ? 'Reativar acesso aos treinos'
+                  : 'Pausar acesso aos treinos'}
+              </p>
+            </div>
+          </button>
         </div>
       </div>
 

--- a/src/modules/flux/views/CRMCommandCenterView.tsx
+++ b/src/modules/flux/views/CRMCommandCenterView.tsx
@@ -1061,6 +1061,30 @@ export default function CRMCommandCenterView() {
                     onCopyLink={() => {}}
                     groupTags={athleteGroupTags}
                   />
+
+                  {/* CRM extra info: all practiced modalities + level */}
+                  {athlete.practiced_modalities && athlete.practiced_modalities.length > 1 && (
+                    <div className="px-4 py-2 bg-ceramic-cool/50 border-t border-ceramic-border flex items-center gap-1.5 flex-wrap rounded-b-xl -mt-1">
+                      <span className="text-[10px] font-bold text-ceramic-text-secondary uppercase tracking-wider mr-1">
+                        Modalidades:
+                      </span>
+                      {athlete.practiced_modalities.map((mod) => {
+                        const config = MODALITY_CONFIG[mod as TrainingModality];
+                        return config ? (
+                          <span
+                            key={mod}
+                            className="inline-flex items-center gap-0.5 px-1.5 py-0.5 bg-ceramic-base rounded text-[10px] font-medium text-ceramic-text-primary"
+                            title={config.label}
+                          >
+                            {config.icon} {config.label}
+                          </span>
+                        ) : null;
+                      })}
+                      <span className="text-[10px] text-ceramic-text-secondary ml-1">
+                        &bull; {LEVEL_LABELS[athlete.level]}
+                      </span>
+                    </div>
+                  )}
                 </div>
               );
             })}


### PR DESCRIPTION
## Summary
- **#459**: Show all practiced modalities + level below athlete cards in CRM Command Center
- **#461**: Add numeric scale labels (1-5) along top axis of feedback radar chart
- **#462**: Rename "Prescrever Treino" → "Prescrever e ver Treinos" in athlete detail
- **#464**: Add block/unblock athlete toggle (paused/active) with red banner when blocked
- **#465**: Move zone timeline from inside modal form to persistent sticky header

Closes #459, #461, #462, #464, #465

## Test plan
- [ ] `npm run build` passes
- [ ] CRM: athlete cards show all modalities + level
- [ ] Radar chart: numeric scale 1-5 visible on top axis
- [ ] Athlete detail: button reads "Prescrever e ver Treinos"
- [ ] Athlete detail: block/unblock toggle works, red banner appears
- [ ] Template form: zone timeline visible above scrollable form

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to block and unblock athletes with status management and visual indicators
  * Added display of athlete modalities and level information in athlete cards
  * Added numeric axis labels to radar charts for easier reading

* **Improvements**
  * Repositioned timeline visualization to a sticky header for better visibility
  * Updated workout prescription action labels for clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->