### PR TITLE
fix(flux,home): Sprint J — immutable templates, expired events, home cleanup (#458,#466-#468)

### DIFF
--- a/src/components/features/NextTwoDaysView.tsx
+++ b/src/components/features/NextTwoDaysView.tsx
@@ -54,8 +54,18 @@ export function detectEventCategory(title: string, description?: string): string
 }
 
 // Calcular tempo ate o evento
-export function calculateTimeUntil(startTime: string): string {
+// Accepts optional endTime to detect events that already ended
+export function calculateTimeUntil(startTime: string, endTime?: string): string {
   const now = new Date();
+
+  // If endTime is provided and the event has already ended, mark it
+  if (endTime) {
+    const end = new Date(endTime);
+    if (!isNaN(end.getTime()) && now >= end) {
+      return 'Encerrado';
+    }
+  }
+
   const start = new Date(startTime);
   const diffMs = start.getTime() - now.getTime();
 
@@ -131,7 +141,7 @@ export const NextTwoDaysView: React.FC<NextTwoDaysViewProps> = ({
       const newMap: Record<string, string> = {};
       events.forEach(event => {
         if (event.isToday) {
-          newMap[event.id] = calculateTimeUntil(event.startTime);
+          newMap[event.id] = calculateTimeUntil(event.startTime, event.endTime);
         }
       });
       setTimeUntilMap(newMap);

--- a/src/modules/flux/views/TemplateLibraryView.tsx
+++ b/src/modules/flux/views/TemplateLibraryView.tsx
@@ -2,7 +2,8 @@
  * TemplateLibraryView - Biblioteca de Templates de Treino
  *
  * Tela 1 do Flow Module: Grid filtrável de templates com drag support,
- * quick actions (edit/duplicate/delete/favorite), e criação de novos templates.
+ * quick actions (duplicate/delete/favorite), e criação de novos templates.
+ * #458: Templates are immutable — no edit action. Only clone + delete (own only).
  */
 
 import React, { useState, useEffect } from 'react';
@@ -12,7 +13,6 @@ import {
   Plus,
   Star,
   Copy,
-  Edit2,
   Trash2,
   GripVertical,
   X,
@@ -86,10 +86,9 @@ export default function TemplateLibraryView() {
   const location = useLocation();
 
   // Determine mode based on URL
-  const mode: 'create' | 'edit' | 'list' = location.pathname.includes('/new')
+  // #458: Edit mode removed — templates are immutable. Edit URLs redirect to list.
+  const mode: 'create' | 'list' = location.pathname.includes('/new')
     ? 'create'
-    : location.pathname.includes('/edit')
-    ? 'edit'
     : 'list';
 
   // Auth for creator attribution
@@ -110,30 +109,20 @@ export default function TemplateLibraryView() {
     applyFilters();
   }, [templates, filters]);
 
-  // Load template for editing
+  // #458: Redirect legacy /edit URLs to list (templates are immutable)
   useEffect(() => {
-    if (mode === 'edit' && templateId) {
-      loadTemplateForEdit(templateId);
-    } else if (mode === 'list') {
+    if (location.pathname.includes('/edit')) {
+      navigate('/flux/templates', { replace: true });
+      return;
+    }
+    if (mode === 'list') {
       setEditingTemplate(null);
       setModalOpen(false);
     } else if (mode === 'create') {
       setEditingTemplate(null);
       setModalOpen(true);
     }
-  }, [mode, templateId]);
-
-  const loadTemplateForEdit = async (id: string) => {
-    const { data, error } = await WorkoutTemplateService.getTemplateById(id);
-
-    if (error) {
-      console.error('Error loading template:', error);
-      navigate('/flux/templates');
-    } else if (data) {
-      setEditingTemplate(data);
-      setModalOpen(true);
-    }
-  };
+  }, [mode, templateId, location.pathname]);
 
   const handleModalClose = () => {
     setModalOpen(false);
@@ -142,16 +131,8 @@ export default function TemplateLibraryView() {
   };
 
   const handleModalSave = (template: WorkoutTemplate) => {
-    // Optimistic update — immediately reflect the saved template in the grid
-    setFilteredTemplates((prev) => {
-      const exists = prev.some((t) => t.id === template.id);
-      if (exists) {
-        // Edit: replace existing template
-        return prev.map((t) => (t.id === template.id ? template : t));
-      }
-      // Create: prepend new template
-      return [template, ...prev];
-    });
+    // Optimistic update — prepend new template to grid (#458: no edit path)
+    setFilteredTemplates((prev) => [template, ...prev]);
 
     // Also refresh from DB to ensure consistency with real-time subscription
     refresh();
@@ -422,8 +403,9 @@ export default function TemplateLibraryView() {
       </div>
 
       {/* Template Form Drawer */}
+      {/* #458: Always create mode — templates are immutable */}
       <TemplateFormDrawer
-        mode={mode === 'edit' ? 'edit' : 'create'}
+        mode="create"
         initialData={editingTemplate || undefined}
         isOpen={isModalOpen}
         onClose={handleModalClose}
@@ -458,7 +440,6 @@ function TemplateCard({
   onDragEnd,
   isDragging,
 }: TemplateCardProps) {
-  const navigate = useNavigate();
   const modalityConfig = MODALITY_CONFIG[template.modality as TrainingModality];
 
   return (
@@ -606,16 +587,8 @@ function TemplateCard({
           )}
         </div>
 
-        {/* Actions */}
+        {/* Actions — #458: Templates are immutable (no Edit button) */}
         <div className="flex items-center gap-2 pt-2 border-t border-ceramic-text-secondary/10">
-          <button
-            onClick={() => navigate(`/flux/templates/${template.id}/edit`)}
-            className="flex-1 flex items-center justify-center gap-2 px-3 py-2 ceramic-inset hover:bg-white/50 rounded-lg transition-colors"
-          >
-            <Edit2 className="w-3.5 h-3.5 text-ceramic-text-secondary" />
-            <span className="text-xs font-medium text-ceramic-text-primary">Editar</span>
-          </button>
-
           <button
             onClick={() => onDuplicate(template)}
             className="flex-1 flex items-center justify-center gap-2 px-3 py-2 ceramic-inset hover:bg-white/50 rounded-lg transition-colors"
@@ -624,12 +597,15 @@ function TemplateCard({
             <span className="text-xs font-medium text-ceramic-text-primary" title="Cria um novo template com base neste">Criar a partir deste</span>
           </button>
 
-          <button
-            onClick={() => onDelete(template)}
-            className="px-3 py-2 ceramic-inset hover:bg-ceramic-error/10 rounded-lg transition-colors"
-          >
-            <Trash2 className="w-3.5 h-3.5 text-ceramic-error" />
-          </button>
+          {/* Delete only for own templates */}
+          {currentUserId && template.user_id === currentUserId && (
+            <button
+              onClick={() => onDelete(template)}
+              className="px-3 py-2 ceramic-inset hover:bg-ceramic-error/10 rounded-lg transition-colors"
+            >
+              <Trash2 className="w-3.5 h-3.5 text-ceramic-error" />
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,13 +1,11 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { Wallet, Heart, Building2, BookOpen, Scale, Mic, Briefcase, Ticket, Compass, type LucideIcon } from 'lucide-react';
+import { Wallet, Heart, Building2, BookOpen, Scale, Mic, Briefcase, Compass, type LucideIcon } from 'lucide-react';
 import { HeaderGlobal, ProfileDrawer, ModuleCard, ExploreMoreSection, CreditBalanceWidget, InviteShareCard, InviteModal } from '../components';
 import { FinanceCard } from '../modules/finance/components/FinanceCard';
 import { GrantsCard } from '../modules/grants/components/GrantsCard';
 import { JourneyHeroCard } from '../modules/journey';
 import { FluxCard } from '../modules/flux';
-import { InterviewerCard } from '../modules/journey/components/interviewer';
 import { useConsciousnessPoints } from '../modules/journey/hooks/useConsciousnessPoints';
 import { LEVEL_COLORS } from '../modules/journey/types/consciousnessPoints';
 import { useGrantsHomeQuery } from '@/hooks/queries';
@@ -91,7 +89,6 @@ export default function Home({
    onSelectArchetype,
    onCreateAssociation
 }: HomeProps) {
-   const navigate = useNavigate();
    const { user } = useAuth();
 
    const [modulesStatus, setModulesStatus] = useState<Record<string, number>>({});
@@ -341,52 +338,6 @@ export default function Home({
                         </p>
                      </div>
                   </motion.div>
-               </motion.div>
-
-               {/* Convites — compact inline card */}
-               <motion.div
-                  variants={cardVariants}
-                  initial="hidden"
-                  animate="visible"
-                  custom={cardIndex++}
-                  onClick={() => navigate('/invites')}
-                  className="cursor-pointer"
-               >
-                  <motion.div
-                     className="ceramic-card relative overflow-hidden p-3 min-h-[100px] flex flex-col group"
-                     style={{
-                        background: 'linear-gradient(135deg, #F0EFE9 0%, #FEF3C7 100%)'
-                     }}
-                     variants={cardElevationVariants}
-                     initial="rest"
-                     whileHover="hover"
-                     whileTap="pressed"
-                  >
-                     <Ticket className="absolute -right-2 -bottom-2 w-20 h-20 text-amber-500 opacity-10" />
-                     <div className="relative z-10 flex flex-col h-full">
-                        <div className="flex items-center gap-2 mb-2">
-                           <div className="ceramic-inset p-1.5">
-                              <Ticket className="w-4 h-4 text-amber-500" />
-                           </div>
-                           <span className="text-xs font-bold text-ceramic-text-secondary uppercase tracking-wider">Convites</span>
-                        </div>
-                        <p className="text-xs text-ceramic-text-secondary line-clamp-1">
-                           Gerencie seus convites
-                        </p>
-                     </div>
-                  </motion.div>
-               </motion.div>
-
-               {/* Interviewer — compact */}
-               <motion.div
-                  variants={cardVariants}
-                  initial="hidden"
-                  animate="visible"
-                  custom={cardIndex++}
-                  onClick={() => onNavigateToView('journey')}
-                  className="cursor-pointer"
-               >
-                  <InterviewerCard compact />
                </motion.div>
 
                {/* EraForge — Historical RPG for kids */}

--- a/src/views/AgendaView.tsx
+++ b/src/views/AgendaView.tsx
@@ -342,8 +342,10 @@ export const AgendaView: React.FC<AgendaViewProps> = ({ userId, userEmail, onLog
             .filter(item => !nextTwoDaysIds.has(item.id))
             .sort((a, b) => a.startTime.localeCompare(b.startTime));
 
-        // Check if next event is happening now
-        const isNow = nextEventData && new Date(nextEventData.startTime) <= now;
+        // Check if next event is happening now (started but not yet ended)
+        const isNow = nextEventData &&
+            new Date(nextEventData.startTime) <= now &&
+            now < new Date(nextEventData.endTime);
 
         return {
             nextEvent: nextEventData ? {
@@ -407,7 +409,7 @@ export const AgendaView: React.FC<AgendaViewProps> = ({ userId, userEmail, onLog
                     category: detectEventCategory(event.title, event.description),
                     isToday,
                     isTomorrow,
-                    timeUntil: isToday ? calculateTimeUntil(event.startTime) : undefined,
+                    timeUntil: isToday ? calculateTimeUntil(event.startTime, event.endTime) : undefined,
                     skipped: skippedEvents.has(event.id)
                 };
             });


### PR DESCRIPTION
## Summary
- **#458**: Template cards are now immutable — removed Edit button, Delete only for owned templates, legacy `/edit` URLs redirect to list
- **#468**: "Acontecendo Agora" no longer shows expired events — checks `endTime` before marking as active
- **#467**: Removed InterviewerCard from home page
- **#466**: Removed duplicate "Convites" card from home page, kept InviteShareCard with modal

## Test plan
- [ ] `npm run build` passes
- [ ] `npm run typecheck` passes (0 new errors)
- [ ] Home page: InterviewerCard gone, single invite card with modal
- [ ] Agenda: expired events no longer show "Acontecendo agora"
- [ ] `/flux/templates`: no Edit button, only "Criar a partir deste" + Delete (own only)
- [ ] `/flux/templates/:id/edit` redirects to `/flux/templates`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Event countdowns now display when events have ended.

* **Changes**
  * Templates are now immutable; editing is no longer supported.
  * Delete functionality restricted to templates you own.
  * Removed Invite/Convites and Interviewer cards from Home page for a streamlined experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->