### PR TITLE
fix(home): Sprint K — restore Convites page card, remove modal card (#466, #467)

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { Wallet, Heart, Building2, BookOpen, Scale, Mic, Briefcase, Compass, type LucideIcon } from 'lucide-react';
-import { HeaderGlobal, ProfileDrawer, ModuleCard, ExploreMoreSection, CreditBalanceWidget, InviteShareCard, InviteModal } from '../components';
+import { Wallet, Heart, Building2, BookOpen, Scale, Mic, Briefcase, Ticket, Compass, type LucideIcon } from 'lucide-react';
+import { HeaderGlobal, ProfileDrawer, ModuleCard, ExploreMoreSection, CreditBalanceWidget } from '../components';
 import { FinanceCard } from '../modules/finance/components/FinanceCard';
 import { GrantsCard } from '../modules/grants/components/GrantsCard';
 import { JourneyHeroCard } from '../modules/journey';
@@ -89,11 +90,11 @@ export default function Home({
    onSelectArchetype,
    onCreateAssociation
 }: HomeProps) {
+   const navigate = useNavigate();
    const { user } = useAuth();
 
    const [modulesStatus, setModulesStatus] = useState<Record<string, number>>({});
    const [isProfileDrawerOpen, setProfileDrawerOpen] = useState(false);
-   const [isInviteModalOpen, setInviteModalOpen] = useState(false);
 
    // Identity data from Journey CP system
    const { stats: cpStats, progress: cpProgress, isLoading: cpLoading } = useConsciousnessPoints();
@@ -370,14 +371,38 @@ export default function Home({
                   </motion.div>
                </motion.div>
 
-               {/* Invites — compact */}
+               {/* Convites — compact inline card */}
                <motion.div
                   variants={cardVariants}
                   initial="hidden"
                   animate="visible"
                   custom={cardIndex++}
+                  onClick={() => navigate('/invites')}
+                  className="cursor-pointer"
                >
-                  <InviteShareCard onClick={() => setInviteModalOpen(true)} />
+                  <motion.div
+                     className="ceramic-card relative overflow-hidden p-3 min-h-[100px] flex flex-col group"
+                     style={{
+                        background: 'linear-gradient(135deg, #F0EFE9 0%, #FEF3C7 100%)'
+                     }}
+                     variants={cardElevationVariants}
+                     initial="rest"
+                     whileHover="hover"
+                     whileTap="pressed"
+                  >
+                     <Ticket className="absolute -right-2 -bottom-2 w-20 h-20 text-amber-500 opacity-10" />
+                     <div className="relative z-10 flex flex-col h-full">
+                        <div className="flex items-center gap-2 mb-2">
+                           <div className="ceramic-inset p-1.5">
+                              <Ticket className="w-4 h-4 text-amber-500" />
+                           </div>
+                           <span className="text-xs font-bold text-ceramic-text-secondary uppercase tracking-wider">Convites</span>
+                        </div>
+                        <p className="text-xs text-ceramic-text-secondary line-clamp-1">
+                           Gerencie seus convites
+                        </p>
+                     </div>
+                  </motion.div>
                </motion.div>
 
                {/* Active generic modules — compact ModuleCards */}
@@ -442,12 +467,6 @@ export default function Home({
             userId={userId}
             userEmail={userEmail || ''}
             onDeleteAccount={handleDeleteAccount}
-         />
-
-         {/* Invite Modal */}
-         <InviteModal
-            isOpen={isInviteModalOpen}
-            onClose={() => setInviteModalOpen(false)}
          />
       </div>
    );


### PR DESCRIPTION
## Summary
- **#466**: Restored the "Convites" card that navigates to `/invites` page. Removed the `InviteShareCard` (modal-opening card) that was incorrectly kept. Cleaned up `InviteModal` and `isInviteModalOpen` state from Home.tsx.
- **#467**: `InterviewerCard` was already removed in PR #472 — confirmed, no additional changes needed.

## Changes
- `src/pages/Home.tsx`: Restored `Convites` inline card with `Ticket` icon + `navigate('/invites')`, removed `InviteShareCard` + `InviteModal` + related state/imports

## Test plan
- [x] `npm run build` passes
- [x] `npm run typecheck` passes (no Home.tsx errors)
- [ ] Verify "Convites" card on home page navigates to `/invites` page
- [ ] Verify InterviewerCard is no longer present

Closes #466, Closes #467

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new Convites card on the home page that provides quick navigation to the invites section, featuring an updated visual design with gradient styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->