### PR TITLE
fix(flux,agenda): Sprint L — template visibility toggle, stale events (#458, #468)

### DIFF
--- a/src/components/features/NextTwoDaysView.tsx
+++ b/src/components/features/NextTwoDaysView.tsx
@@ -135,6 +135,13 @@ export const NextTwoDaysView: React.FC<NextTwoDaysViewProps> = ({
 }) => {
   const [timeUntilMap, setTimeUntilMap] = useState<Record<string, string>>({});
 
+  // Tick counter forces re-render every 60s so time-dependent UI stays fresh
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const tickInterval = setInterval(() => setTick(t => t + 1), 60_000);
+    return () => clearInterval(tickInterval);
+  }, []);
+
   // Update countdown every minute
   useEffect(() => {
     const updateCountdowns = () => {
@@ -148,7 +155,7 @@ export const NextTwoDaysView: React.FC<NextTwoDaysViewProps> = ({
     };
 
     updateCountdowns();
-    const interval = setInterval(updateCountdowns, 60000);
+    const interval = setInterval(updateCountdowns, 60_000);
     return () => clearInterval(interval);
   }, [events]);
 
@@ -188,10 +195,15 @@ export const NextTwoDaysView: React.FC<NextTwoDaysViewProps> = ({
 
   const renderEventCard = (event: EventWithCategory, index: number) => {
     const timeUntil = timeUntilMap[event.id] || event.timeUntil;
+    const now = new Date();
+    const startDate = new Date(event.startTime);
     const endDate = new Date(event.endTime);
+    const isStartValid = !isNaN(startDate.getTime());
     const isEndValid = !isNaN(endDate.getTime());
-    const isPast = isEndValid && endDate < new Date() && timeUntil !== 'Agora';
-    const isHappening = timeUntil === 'Agora';
+    // An event is "happening now" only if it has started AND not yet ended
+    const isHappening = isStartValid && isEndValid && startDate <= now && now < endDate;
+    // An event is "past" if its end time is in the past (and it's not happening now)
+    const isPast = isEndValid && endDate <= now;
     const completing = isTaskCompleting(event.id);
 
     // Quadrant color border for task items

--- a/src/modules/flux/components/forms/TemplateFormDrawer.tsx
+++ b/src/modules/flux/components/forms/TemplateFormDrawer.tsx
@@ -9,7 +9,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { motion, AnimatePresence, PanInfo, useMotionValue } from 'framer-motion';
-import { X, AlertCircle, CheckCircle } from 'lucide-react';
+import { X, AlertCircle, CheckCircle, Lock, Globe } from 'lucide-react';
 import { useTemplateForm } from './useTemplateForm';
 import SeriesEditor from './SeriesEditor';
 import TimelineVisual from './TimelineVisual';
@@ -292,6 +292,49 @@ export default function TemplateFormDrawer({
                       className="space-y-6 overflow-hidden"
                     >
                       {/* #426: Prompt removed — fields revealed smoothly */}
+
+                      {/* #458: Public/Private visibility toggle */}
+                      <div>
+                        <label className="block text-sm font-medium text-ceramic-text-primary mb-2">
+                          Visibilidade
+                        </label>
+                        <div className="grid grid-cols-2 gap-2">
+                          <button
+                            type="button"
+                            onClick={() => handleChange('is_public', false)}
+                            className={`flex items-center justify-center gap-2 px-4 py-3 rounded-lg text-sm font-medium transition-all ${
+                              !formData.is_public
+                                ? 'bg-ceramic-text-primary text-white shadow-md'
+                                : 'ceramic-inset hover:bg-white/50 text-ceramic-text-secondary'
+                            }`}
+                          >
+                            <Lock className="w-4 h-4" />
+                            <div className="text-left">
+                              <span className="block">Privado</span>
+                              <span className={`block text-xs font-normal ${!formData.is_public ? 'text-white/70' : 'text-ceramic-text-secondary/70'}`}>
+                                So para voce
+                              </span>
+                            </div>
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => handleChange('is_public', true)}
+                            className={`flex items-center justify-center gap-2 px-4 py-3 rounded-lg text-sm font-medium transition-all ${
+                              formData.is_public
+                                ? 'bg-ceramic-accent text-white shadow-md'
+                                : 'ceramic-inset hover:bg-white/50 text-ceramic-text-secondary'
+                            }`}
+                          >
+                            <Globe className="w-4 h-4" />
+                            <div className="text-left">
+                              <span className="block">Publico</span>
+                              <span className={`block text-xs font-normal ${formData.is_public ? 'text-white/70' : 'text-ceramic-text-secondary/70'}`}>
+                                Visivel para todos
+                              </span>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
 
                       {/* Name & Description (#421: show in both modes for consistency) */}
                       {mode === 'edit' && (

--- a/src/modules/flux/components/forms/useTemplateForm.ts
+++ b/src/modules/flux/components/forms/useTemplateForm.ts
@@ -26,6 +26,7 @@ export interface TemplateFormState {
   description?: string; // Editable in edit mode, auto-generated in create
   exercise_structure?: ExerciseStructureV2;
   coach_notes?: string; // Free-text notes from the coach
+  is_public: boolean; // #458: Public (marketplace) vs Private (coach-only)
 }
 
 type FormErrors = Partial<Record<keyof TemplateFormState, string>>;
@@ -47,6 +48,7 @@ const EMPTY_FORM_STATE: TemplateFormState = {
     cooldown: '',
   },
   coach_notes: '',
+  is_public: false, // #458: Default to private (safer)
 };
 
 export function useTemplateForm({ mode, isOpen, initialData, onSuccess }: UseTemplateFormProps = {}) {
@@ -59,6 +61,7 @@ export function useTemplateForm({ mode, isOpen, initialData, onSuccess }: UseTem
         description: initialData.description,
         exercise_structure: initialData.exercise_structure as ExerciseStructureV2,
         coach_notes: initialData.coach_notes || '',
+        is_public: initialData.is_public ?? false,
       };
     }
 
@@ -99,6 +102,7 @@ export function useTemplateForm({ mode, isOpen, initialData, onSuccess }: UseTem
         description: initialData.description,
         exercise_structure: initialData.exercise_structure as ExerciseStructureV2,
         coach_notes: initialData.coach_notes || '',
+        is_public: initialData.is_public ?? false,
       });
       setErrors({});
       setTouched(new Set());
@@ -271,7 +275,7 @@ export function useTemplateForm({ mode, isOpen, initialData, onSuccess }: UseTem
         exercise_structure: formData.exercise_structure,
       };
 
-      const extras = { coach_notes: formData.coach_notes };
+      const extras = { coach_notes: formData.coach_notes, is_public: formData.is_public };
 
       let result;
       if (initialData) {

--- a/src/modules/flux/services/workoutTemplateService.ts
+++ b/src/modules/flux/services/workoutTemplateService.ts
@@ -333,7 +333,7 @@ export class WorkoutTemplateService {
    */
   static async createTemplateV2(
     input: CreateWorkoutTemplateV2Input,
-    extras?: { coach_notes?: string }
+    extras?: { coach_notes?: string; is_public?: boolean }
   ): Promise<{ data: WorkoutTemplate | null; error: any }> {
     try {
       const { data: userData } = await supabase.auth.getUser();
@@ -364,6 +364,11 @@ export class WorkoutTemplateService {
         insertData.coach_notes = extras.coach_notes || null;
       }
 
+      // #458: Include visibility (default false = private)
+      if (extras?.is_public !== undefined) {
+        insertData.is_public = extras.is_public;
+      }
+
       const { data, error } = await supabase
         .from('workout_templates')
         .insert(insertData)
@@ -382,7 +387,7 @@ export class WorkoutTemplateService {
    */
   static async updateTemplateV2(
     input: UpdateWorkoutTemplateV2Input,
-    extras?: { coach_notes?: string }
+    extras?: { coach_notes?: string; is_public?: boolean }
   ): Promise<{ data: WorkoutTemplate | null; error: any }> {
     try {
       const { id, ...updates } = input;
@@ -400,6 +405,11 @@ export class WorkoutTemplateService {
 
       if (extras?.coach_notes !== undefined) {
         dbUpdates.coach_notes = extras.coach_notes || null;
+      }
+
+      // #458: Include visibility
+      if (extras?.is_public !== undefined) {
+        dbUpdates.is_public = extras.is_public;
       }
 
       const { data, error } = await supabase

--- a/src/views/AgendaView.tsx
+++ b/src/views/AgendaView.tsx
@@ -1,3 +1,23 @@
+// TODO #468: Apply chat context UI pattern to Agenda
+// The expanded chat uses a ChatContextSidebar (src/components/features/AicaChatFAB/ChatContextSidebar.tsx)
+// that renders StatCard / ListCard components with module-specific data (tasks, finance, events).
+// Data is fetched via useChatContextData (src/hooks/useChatContextData.ts) which calls
+// getUserAIContext() from userAIContextService. The ContextCard component
+// (src/components/ContextCard/ContextCard.tsx) is a separate hero card on Home that shows
+// contextual prompts (event-based, journey-based, daily question) using the useContextSource
+// hook (src/hooks/useContextSource.ts) with a 3-tier priority cascade.
+//
+// To unify Agenda into a single-page view (like List/Kanban/Matrix modes), consider:
+// 1. Reuse ChatContextSidebar's StatCard/ListCard pattern for an Agenda context panel
+// 2. Use useContextSource to surface event-based prompts inline in the Agenda timeline
+// 3. The sidebar could show: upcoming events summary, task counts, calendar sync status
+// Reference files:
+//   - src/components/features/AicaChatFAB/ChatContextSidebar.tsx (context cards)
+//   - src/components/ContextCard/ContextCard.tsx (contextual prompt hero)
+//   - src/hooks/useChatContextData.ts (data fetching for chat context)
+//   - src/hooks/useContextSource.ts (3-tier priority: event > journey > daily)
+//   - src/services/userAIContextService.ts (AI context data aggregation)
+
 import React, { useState, useEffect, useMemo, useRef } from 'react';
 import {
     DndContext,
@@ -61,6 +81,15 @@ export const AgendaView: React.FC<AgendaViewProps> = ({ userId, userEmail, onLog
     useTourAutoStart('atlas-first-visit');
     const isDesktop = useIsDesktop();
     const [mobileMode, setMobileMode] = useState<AgendaMode>('agenda');
+
+    // Tick counter — increments every 60s so time-dependent useMemos
+    // (nextEvent, restOfDay, nextTwoDaysEvents) recalculate with a fresh `now`.
+    // This prevents stale "Acontecendo Agora" badges on ended events (#468).
+    const [timeTick, setTimeTick] = useState(0);
+    useEffect(() => {
+        const id = setInterval(() => setTimeTick(t => t + 1), 60_000);
+        return () => clearInterval(id);
+    }, []);
 
     const [matrixTasks, setMatrixTasks] = useState<Record<Quadrant, Task[]>>({
         'urgent-important': [],
@@ -361,7 +390,7 @@ export const AgendaView: React.FC<AgendaViewProps> = ({ userId, userEmail, onLog
             } : undefined,
             restOfDay: combinedRest
         };
-    }, [calendarEvents, timelineTasks]);
+    }, [calendarEvents, timelineTasks, timeTick]);
 
     // Prepare next 2 days events with categories
     const nextTwoDaysEvents = useMemo(() => {
@@ -462,7 +491,7 @@ export const AgendaView: React.FC<AgendaViewProps> = ({ userId, userEmail, onLog
         });
 
         return filtered;
-    }, [calendarEvents, skippedEvents, allDueDateTasks]);
+    }, [calendarEvents, skippedEvents, allDueDateTasks, timeTick]);
 
     const loadAllTasks = async (forDate?: Date, { silent = false }: { silent?: boolean } = {}) => {
         try {


### PR DESCRIPTION
## Summary
- **#458**: Added public/private segmented toggle to "Novo Exercício" form (TemplateFormDrawer). Defaults to private. Uses existing `is_public` DB column — no migration needed. Ceramic-styled with Lock/Globe icons.
- **#468 Part 1**: Fixed stale "Acontecendo Agora" — added 60s tick interval to NextTwoDaysView and AgendaView to force recalculation. Replaced string-based `timeUntil === 'Agora'` with proper `start <= now < end` Date comparison.
- **#468 Part 2**: Research TODO added to AgendaView.tsx documenting chat context UI pattern (ChatContextSidebar, ContextCard, useChatContextData, useContextSource) for future Agenda unification.

## Changes
- `src/modules/flux/components/forms/TemplateFormDrawer.tsx` — public/private segmented control
- `src/modules/flux/components/forms/useTemplateForm.ts` — `is_public` field in form state
- `src/modules/flux/services/workoutTemplateService.ts` — `is_public` in create/update payloads
- `src/components/features/NextTwoDaysView.tsx` — 60s tick + proper Date-based happening check
- `src/views/AgendaView.tsx` — 60s timeTick + TODO research comment

## Test plan
- [x] `npm run build` passes
- [ ] Create template → verify private is default, toggle works
- [ ] Leave Agenda open → verify events move out of "Acontecendo Agora" after ending

Closes #458, Closes #468

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added public/private visibility toggle for workout templates, allowing you to control whether templates appear in the marketplace or remain private.

* **Bug Fixes**
  * Improved event status accuracy to ensure "happening now" badges and past event indicators display correctly.
  * Enhanced UI refresh to maintain accurate real-time updates throughout your session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->