### PR TITLE
fix(journey,invites): Sprint P — header alignment, invites UX (#486, #491, #488)

### DIFF
--- a/src/modules/journey/views/JourneyFullScreen.tsx
+++ b/src/modules/journey/views/JourneyFullScreen.tsx
@@ -326,30 +326,31 @@ export function JourneyFullScreen({ onBack }: JourneyFullScreenProps) {
   }
 
   return (
-    <div className="min-h-screen bg-[#F0EFE9]">
+    <div className="min-h-screen bg-ceramic-base">
       {/* Header - Digital Ceramic System */}
-      <div className="ceramic-card rounded-none p-6 border-b border-[#A39E91]/10" data-tour="journey-header">
+      <div className="ceramic-card rounded-none p-4 lg:p-6 border-b border-[#A39E91]/10" data-tour="journey-header">
         <div className="max-w-7xl mx-auto">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-3">
+          <div className="flex items-center justify-between gap-2">
+            {/* Left: Back button + icon + title */}
+            <div className="flex items-center gap-3 min-w-0">
               {/* Back Navigation Button */}
               <button
                 onClick={() => onBack ? onBack() : navigate('/')}
-                className="ceramic-card hover:ceramic-elevated p-2 rounded-full transition-all"
+                className="ceramic-card hover:ceramic-elevated p-2 rounded-full transition-all shrink-0"
                 aria-label="Voltar para página inicial"
               >
-                <ArrowLeftIcon className="h-5 w-5 text-[#5C554B]" />
+                <ArrowLeftIcon className="h-5 w-5 text-ceramic-text-secondary" />
               </button>
 
-              <SparklesIcon className="h-8 w-8 text-amber-600" />
-              <h1 className="text-2xl font-semibold tracking-tight text-etched">Minha Jornada</h1>
+              <SparklesIcon className="h-6 w-6 lg:h-8 lg:w-8 text-amber-600 shrink-0" />
+              <h1 className="text-lg lg:text-2xl font-semibold tracking-tight text-etched truncate">Minha Jornada</h1>
             </div>
 
-            {/* CP Stats with progress */}
+            {/* Center: CP Stats — desktop only */}
             {stats ? (() => {
               const progress = getProgressToNextLevel(stats.total_points)
               return (
-                <div className="flex items-center gap-4" data-tour="consciousness-points">
+                <div className="hidden lg:flex items-center gap-4" data-tour="consciousness-points">
                   {/* Level badge */}
                   <div
                     className="w-8 h-8 rounded-full flex items-center justify-center text-xs font-bold text-white shadow-sm shrink-0"
@@ -397,18 +398,40 @@ export function JourneyFullScreen({ onBack }: JourneyFullScreenProps) {
                 </div>
               )
             })() : (
-              <div className="flex items-center gap-3 animate-pulse" data-tour="consciousness-points">
-                <div className="w-8 h-8 bg-[#E0DDD5] rounded-full" />
+              <div className="hidden lg:flex items-center gap-3 animate-pulse" data-tour="consciousness-points">
+                <div className="w-8 h-8 bg-ceramic-cool rounded-full" />
                 <div className="flex flex-col gap-1.5">
-                  <div className="h-4 w-20 bg-[#E0DDD5] rounded" />
-                  <div className="h-1.5 w-28 bg-[#E0DDD5] rounded-full" />
+                  <div className="h-4 w-20 bg-ceramic-cool rounded" />
+                  <div className="h-1.5 w-28 bg-ceramic-cool rounded-full" />
                 </div>
               </div>
             )}
 
-            <div className="flex items-center gap-3">
+            {/* Mobile: compact level badge (replaces the full CP stats) */}
+            {stats && (
+              <div className="flex lg:hidden items-center gap-1.5 shrink-0" data-tour="consciousness-points">
+                <div
+                  className="w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold text-white shadow-sm"
+                  style={{ backgroundColor: LEVEL_COLORS[stats.level] }}
+                  title={stats.level_name}
+                >
+                  {stats.level}
+                </div>
+                <span className="text-sm font-semibold text-ceramic-text-primary">
+                  {stats.total_points.toLocaleString()}
+                </span>
+                <span className="text-xs text-ceramic-text-secondary">CP</span>
+              </div>
+            )}
+
+            {/* Right: Help + Settings */}
+            <div className="flex items-center gap-2 lg:gap-3 shrink-0">
               <HelpButton tourKey="journey-first-visit" />
-              <SettingsMenu userEmail={user?.email} />
+              <SettingsMenu
+                userEmail={user?.email}
+                avatarUrl={user?.user_metadata?.avatar_url}
+                userName={user?.user_metadata?.full_name || user?.email?.split('@')[0]}
+              />
             </div>
           </div>
         </div>

--- a/src/pages/InvitesPage.tsx
+++ b/src/pages/InvitesPage.tsx
@@ -5,6 +5,7 @@
  */
 
 import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import {
   Ticket,
@@ -17,6 +18,9 @@ import {
   Loader2,
   Trash2,
   Link2,
+  Users,
+  ArrowRight,
+  AlertCircle,
 } from 'lucide-react';
 import { QRCodeSVG } from 'qrcode.react';
 import { PageShell } from '@/components/ui';
@@ -49,6 +53,8 @@ function StatusBadge({ status, isActive }: { status: EnrichedReferral['status'];
 }
 
 export default function InvitesPage() {
+  const navigate = useNavigate();
+
   const {
     stats,
     enrichedReferrals,
@@ -69,8 +75,15 @@ export default function InvitesPage() {
 
   const [copied, setCopied] = useState(false);
   const [copiedCode, setCopiedCode] = useState(false);
+  const [dashboardError, setDashboardError] = useState<string | null>(null);
 
-  useEffect(() => { refreshDashboard(); }, [refreshDashboard]);
+  useEffect(() => {
+    setDashboardError(null);
+    refreshDashboard().catch((err) => {
+      console.error('[InvitesPage] Dashboard load failed:', err);
+      setDashboardError('Nao foi possivel carregar os dados de convites. Verifique sua conexao e tente novamente.');
+    });
+  }, [refreshDashboard]);
 
   useEffect(() => {
     if (copied) { const t = setTimeout(() => setCopied(false), 2000); return () => clearTimeout(t); }
@@ -99,7 +112,7 @@ export default function InvitesPage() {
 
   if (loading) {
     return (
-      <PageShell title="Convites">
+      <PageShell title="Convites" onBack={() => navigate('/')}>
         <div className="flex items-center justify-center py-20">
           <Loader2 className="w-6 h-6 animate-spin text-ceramic-text-secondary" />
         </div>
@@ -108,8 +121,19 @@ export default function InvitesPage() {
   }
 
   return (
-    <PageShell title="Convites">
+    <PageShell title="Convites" onBack={() => navigate('/')}>
       <div className="max-w-lg mx-auto px-4 py-6 pb-24 space-y-6">
+        {/* Error banner */}
+        {dashboardError && (
+          <div className="ceramic-inset p-4 rounded-xl flex items-start gap-3 border border-ceramic-error/20">
+            <AlertCircle className="w-5 h-5 text-ceramic-error flex-shrink-0 mt-0.5" />
+            <div>
+              <div className="text-sm font-bold text-ceramic-error mb-0.5">Erro ao carregar</div>
+              <div className="text-xs text-ceramic-text-secondary">{dashboardError}</div>
+            </div>
+          </div>
+        )}
+
         {/* Stats */}
         <div className="grid grid-cols-4 gap-2">
           {[
@@ -163,10 +187,16 @@ export default function InvitesPage() {
             <span className="font-bold">Gerar Convite</span>
           </button>
         ) : (
-          <div className="ceramic-inset p-6 rounded-2xl text-center">
+          <div className="ceramic-inset p-6 rounded-2xl text-center space-y-2">
             <div className="text-4xl mb-2">📭</div>
-            <div className="text-ceramic-text-primary font-bold mb-1">Sem convites disponiveis</div>
-            <div className="text-sm text-ceramic-text-secondary">Voce ganha +2 convites quando alguem aceita!</div>
+            <div className="text-ceramic-text-primary font-bold">Sem convites disponiveis</div>
+            <div className="text-sm text-ceramic-text-secondary">
+              Voce ganha +2 convites sempre que alguem aceitar seu convite e se tornar ativo.
+            </div>
+            <div className="pt-2 text-xs text-ceramic-text-secondary bg-ceramic-cool/50 rounded-lg p-3">
+              <span className="font-semibold text-ceramic-text-primary">Como funciona:</span> Cada convite aceito gera
+              XP para voce e para quem foi convidado. Convites expiram em 7 dias se nao forem usados.
+            </div>
           </div>
         )}
 
@@ -239,13 +269,33 @@ export default function InvitesPage() {
           </div>
         )}
 
-        {/* Empty state */}
-        {enrichedReferrals.length === 0 && (
-          <div className="ceramic-inset p-8 rounded-2xl text-center">
+        {/* Empty state — no referrals at all */}
+        {enrichedReferrals.length === 0 && !dashboardError && (
+          <div className="ceramic-inset p-8 rounded-2xl text-center space-y-2">
             <Ticket className="w-8 h-8 text-ceramic-text-secondary mx-auto mb-3" />
-            <div className="text-sm text-ceramic-text-secondary">Nenhum convite enviado ainda</div>
+            <div className="text-sm font-bold text-ceramic-text-primary">Nenhum convite enviado ainda</div>
+            <div className="text-sm text-ceramic-text-secondary">
+              Gere seu primeiro convite acima e compartilhe com quem voce quer trazer para o Aica.
+            </div>
           </div>
         )}
+
+        {/* Minha Rede — link to Connections (#488) */}
+        <button
+          onClick={() => navigate('/connections')}
+          className="w-full ceramic-card p-4 rounded-2xl flex items-center gap-4 hover:scale-[1.01] active:scale-[0.99] transition-transform text-left"
+        >
+          <div className="w-10 h-10 rounded-full bg-ceramic-info/10 flex items-center justify-center flex-shrink-0">
+            <Users className="w-5 h-5 text-ceramic-info" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="text-sm font-bold text-ceramic-text-primary">Minha Rede</div>
+            <div className="text-xs text-ceramic-text-secondary">
+              Veja sua rede completa de conexoes e contatos
+            </div>
+          </div>
+          <ArrowRight className="w-4 h-4 text-ceramic-text-secondary flex-shrink-0" />
+        </button>
       </div>
     </PageShell>
   );


### PR DESCRIPTION
## Summary
- **#486**: Journey header responsive — CP stats `hidden lg:flex`, compact mobile badge, Ceramic tokens, SettingsMenu full props, title truncation
- **#491**: InvitesPage back navigation + error visibility + informative empty states
- **#488**: "Minha Rede" card linking to /connections for full network view

## Files changed (2)
- `src/modules/journey/views/JourneyFullScreen.tsx` — responsive header, Ceramic tokens
- `src/pages/InvitesPage.tsx` — back nav, error state, empty state, network link

## Test plan
- [x] `npm run build` passes
- [ ] Manual: Journey header on mobile — no overflow, shows compact CP badge
- [ ] Manual: Journey header on desktop — full CP stats visible
- [ ] Manual: /invites page has back button, shows error if RPCs fail
- [ ] Manual: "Minha Rede" card navigates to /connections

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Minha Rede" section for easy access to connections
  * Enhanced settings menu with user avatar and name display

* **Improvements**
  * Redesigned header layout for better mobile and desktop responsiveness
  * Optimized stats display across different screen sizes
  * Added user-facing error notifications for failed data loads
  * Improved messaging for empty states and invite sections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->