### PR TITLE
fix(chat,memento): Sprint Q — chat errors, life expectancy, multi-task (#495, #496, #483)

### DIFF
--- a/src/components/features/AicaChatFAB/ChatActionButtons.tsx
+++ b/src/components/features/AicaChatFAB/ChatActionButtons.tsx
@@ -12,6 +12,7 @@ import {
   Calendar,
   Star,
   PenLine,
+  Plus,
   Loader2,
   AlertCircle,
 } from 'lucide-react'
@@ -23,6 +24,7 @@ const ICON_MAP: Record<string, typeof CheckCircle> = {
   Calendar,
   Star,
   PenLine,
+  Plus,
 }
 
 interface ChatActionButtonsProps {
@@ -55,7 +57,7 @@ export function ChatActionButtons({ actions, onExecute }: ChatActionButtonsProps
 
   if (!actions.length) return null
 
-  const visibleActions = actions.slice(0, 3)
+  const visibleActions = actions.slice(0, 5)
 
   return (
     <div className="aica-fab-actions">

--- a/src/components/features/MementoMoriBar/MementoMoriBar.tsx
+++ b/src/components/features/MementoMoriBar/MementoMoriBar.tsx
@@ -6,10 +6,10 @@
  *
  * Fallback: prompts user to set birthdate if not available.
  *
- * Max human lifespan used (not life expectancy):
- *   Female: 122y (Jeanne Calment)
- *   Male: 116y (Jiroemon Kimura)
- *   Default/unknown: 119y
+ * IBGE 2024 Brazilian life expectancy:
+ *   Female: 80y (IBGE: 79.9)
+ *   Male: 73y (IBGE: 73.3)
+ *   Default/unknown: 77y (IBGE: 76.6)
  */
 
 import { useState, useMemo } from 'react'
@@ -20,20 +20,20 @@ import { updateUserProfile } from '@/services/supabaseService'
 import { useAuth } from '@/hooks/useAuth'
 import { LifeWeeksStrip } from '@/modules/journey/components/ceramic/LifeWeeksStrip'
 
-// Max recorded human lifespan by gender (not life expectancy)
-const MAX_LIFESPAN: Record<string, number> = {
-  female: 122,
-  feminino: 122,
-  f: 122,
-  male: 116,
-  masculino: 116,
-  m: 116,
+// IBGE 2024 Brazilian life expectancy by gender
+const LIFE_EXPECTANCY: Record<string, number> = {
+  female: 80,
+  feminino: 80,
+  f: 80,
+  male: 73,
+  masculino: 73,
+  m: 73,
 }
-const DEFAULT_MAX_LIFESPAN = 119
+const DEFAULT_LIFE_EXPECTANCY = 77
 
-function getMaxLifespan(gender: string | null): number {
-  if (!gender) return DEFAULT_MAX_LIFESPAN
-  return MAX_LIFESPAN[gender.toLowerCase()] ?? DEFAULT_MAX_LIFESPAN
+function getLifeExpectancy(gender: string | null): number {
+  if (!gender) return DEFAULT_LIFE_EXPECTANCY
+  return LIFE_EXPECTANCY[gender.toLowerCase()] ?? DEFAULT_LIFE_EXPECTANCY
 }
 
 interface MementoMoriBarProps {
@@ -141,8 +141,8 @@ export function MementoMoriBar({ onSetBirthdate }: MementoMoriBarProps) {
   const [saved, setSaved] = useState(false)
   const [dateError, setDateError] = useState(false)
 
-  const maxLifespanYears = getMaxLifespan(gender)
-  const totalWeeks = Math.ceil(maxLifespanYears * 52.1429)
+  const lifeExpectancyYears = getLifeExpectancy(gender)
+  const totalWeeks = Math.ceil(lifeExpectancyYears * 52.1429)
 
   const lifeData = useMemo(() => {
     if (!birthdate) return null
@@ -284,7 +284,7 @@ export function MementoMoriBar({ onSetBirthdate }: MementoMoriBarProps) {
           </div>
         </div>
 
-        {/* Life-dots visualization — each bar = 1 year of max human lifespan */}
+        {/* Life-dots visualization — each bar = 1 year of life expectancy */}
         <motion.div
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
@@ -314,14 +314,14 @@ export function MementoMoriBar({ onSetBirthdate }: MementoMoriBarProps) {
 
               <LifeWeeksStrip
                 birthDate={lifeData.birthDate}
-                expectedLifespan={maxLifespanYears}
+                expectedLifespan={lifeExpectancyYears}
               />
 
               <div className="mt-3 flex items-center gap-4 text-[10px] text-ceramic-text-secondary">
                 <span>{formatter.format(lifeData.remainingWeeks)} semanas restantes</span>
                 <span className="opacity-60">
                   {/* Amber = atual · Escuro = vivido · Vazio = futuro */}
-                  Maximo: {maxLifespanYears} anos
+                  Expectativa: {lifeExpectancyYears} anos
                 </span>
               </div>
             </div>

--- a/src/lib/gemini/client.ts
+++ b/src/lib/gemini/client.ts
@@ -125,8 +125,13 @@ export class GeminiClient {
     }
 
     // Fazer chamada com retry
+    // agent-proxy expects flat payload (message, session_id, context), not the wrapper
+    const requestBody = DEDICATED_EDGE_FUNCTIONS[request.action] === 'agent-proxy'
+      ? request.payload as GeminiChatRequest
+      : request
+
     return callWithRetry(async () => {
-      return this.makeRequest(endpoint, request)
+      return this.makeRequest(endpoint, requestBody)
     }, options)
   }
 

--- a/src/services/chatActionService.ts
+++ b/src/services/chatActionService.ts
@@ -3,6 +3,9 @@
  *
  * Executes deterministic chat actions (complete task, create moment, etc.)
  * by calling the gemini-chat Edge Function with action_type execute_chat_action.
+ *
+ * Supports batch task creation via 'create_tasks' action type,
+ * which executes multiple 'create_task' calls in parallel.
  */
 
 import { GeminiClient } from '@/lib/gemini';
@@ -10,8 +13,36 @@ import type { ChatAction } from '@/types/chatActions';
 
 export async function executeChatAction(
   action: ChatAction
-): Promise<{ success: boolean; error?: string }> {
+): Promise<{ success: boolean; error?: string; results?: unknown[] }> {
   const client = GeminiClient.getInstance();
+
+  // Batch task creation — execute each individually
+  if (action.type === 'create_tasks' && Array.isArray(action.params.tasks)) {
+    const tasks = action.params.tasks as unknown as Array<Record<string, string>>;
+    const results = await Promise.allSettled(
+      tasks.map(task =>
+        client.call({
+          action: 'execute_chat_action',
+          payload: {
+            action_type: 'create_task',
+            params: task,
+          },
+        })
+      )
+    );
+
+    const succeeded = results.filter(r => r.status === 'fulfilled').length;
+    const failed = results.filter(r => r.status === 'rejected').length;
+
+    return {
+      success: failed === 0,
+      results: results.map(r =>
+        r.status === 'fulfilled' ? r.value : { error: (r as PromiseRejectedResult).reason?.message }
+      ),
+      error: failed > 0 ? `${succeeded} criadas, ${failed} falharam` : undefined,
+    };
+  }
+
   const response = await client.call({
     action: 'execute_chat_action',
     payload: {

--- a/src/services/userAIContextService.ts
+++ b/src/services/userAIContextService.ts
@@ -63,7 +63,7 @@ export async function getUserAIContext(forceRefresh = false): Promise<UserAICont
         .from('profiles')
         .select('full_name')
         .eq('id', userId)
-        .single(),
+        .maybeSingle(),
       supabase
         .from('work_items')
         .select('*', { count: 'exact', head: true })
@@ -98,15 +98,9 @@ export async function getUserAIContext(forceRefresh = false): Promise<UserAICont
         .gte('transaction_date', monthStart),
     ])
 
-    // calendar_events may not exist yet — query separately with graceful fallback
-    const eventsRes = await supabase
-      .from('calendar_events')
-      .select('title, start_time')
-      .eq('user_id', userId)
-      .gte('start_time', new Date().toISOString())
-      .order('start_time', { ascending: true })
-      .limit(5)
-      .then(res => res, () => ({ data: null, error: null }))
+    // TODO: Re-enable when calendar_events table is created
+    // calendar_events table not yet migrated — skip query to avoid 404 noise
+    const eventsRes = { data: null as any, error: null }
 
     // Calculate finance summary
     let financeSummary: UserAIContext['financeSummary'] = null

--- a/src/types/chatActions.ts
+++ b/src/types/chatActions.ts
@@ -11,7 +11,9 @@ export type ChatActionType =
   | 'start_task'
   | 'update_priority'
   | 'reschedule_task'
-  | 'create_moment';
+  | 'create_moment'
+  | 'create_task'
+  | 'create_tasks';
 
 export interface ChatAction {
   /** Unique action ID (e.g., "complete_task_abc123") */
@@ -23,7 +25,7 @@ export interface ChatAction {
   /** Lucide icon name (e.g., "CheckCircle", "Play", "Calendar") */
   icon: string;
   /** Source module for the action */
-  module: 'atlas' | 'journey';
+  module: 'atlas' | 'journey' | 'agenda';
   /** Parameters passed to execute_chat_action */
   params: Record<string, string | number | boolean>;
 }

--- a/supabase/functions/agent-proxy/index.ts
+++ b/supabase/functions/agent-proxy/index.ts
@@ -72,8 +72,10 @@ serve(async (req) => {
     }
 
     // Parse request body
+    // Support both direct payload and GeminiClient wrapper format
     const body = await req.json()
-    const { message, session_id, context } = body
+    const payload = body.payload || body
+    const { message, session_id, context, history } = payload
 
     if (!message) {
       return new Response(


### PR DESCRIPTION
## Summary
- **#495 MementoMori**: Changed from max human lifespan (122/116 years) to IBGE 2024 Brazilian life expectancy (80F/73M/77 avg)
- **#496 Chat errors**: Fixed 3 API errors on Vida page — profiles 406 (`.single()` → `.maybeSingle()`), calendar_events 404 (skip query — table not migrated), agent-proxy 400 (payload unwrap mismatch)
- **#483 Multi-task**: Added `create_task`/`create_tasks` action types + batch execution via `Promise.allSettled` in chatActionService

## Changes (7 files)
| File | Change |
|------|--------|
| `MementoMoriBar.tsx` | Life expectancy constants + rename variables |
| `userAIContextService.ts` | `.maybeSingle()` + skip calendar_events query |
| `client.ts` (GeminiClient) | Flatten payload for agent-proxy |
| `agent-proxy/index.ts` | Accept both wrapped and flat payload formats |
| `chatActions.ts` | Add `create_task`, `create_tasks` types + `agenda` module |
| `ChatActionButtons.tsx` | Add `Plus` icon, increase visible actions to 5 |
| `chatActionService.ts` | Batch `create_tasks` handler with `Promise.allSettled` |

## Test plan
- [x] `npm run build` passes
- [ ] `npm run typecheck` passes
- [ ] Manual test: MementoMori shows ~77 years instead of 119
- [ ] Manual test: Chat on /vida opens without console errors
- [ ] Manual test: Chat action buttons render correctly

## Deploy note
`agent-proxy` Edge Function needs separate deploy after merge:
```bash
SUPABASE_ACCESS_TOKEN=sbp_... npx supabase functions deploy agent-proxy --no-verify-jwt
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased visible action buttons from 3 to 5 in the chat interface.
  * Added batch task creation support for multiple tasks.
  * Added agenda module support.

* **Updates**
  * Life expectancy data now reflects IBGE 2024 statistics for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->