### PR TITLE
feat(chat): context injection — user patterns + Life Council (#194)

### DIFF
--- a/src/components/features/AicaChatFAB/ChatContextSidebar.tsx
+++ b/src/components/features/AicaChatFAB/ChatContextSidebar.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import type { UserAIContext } from '@/services/userAIContextService'
+import type { UserAIContext, UserPattern, LifeCouncilInsight } from '@/services/userAIContextService'
 
 interface ChatContextSidebarProps {
   activeModule: string
@@ -63,6 +63,88 @@ function ListCard({ title, items, accentColor }: { title: string; items: string[
   )
 }
 
+const PATTERN_LABELS: Record<string, string> = {
+  productivity: 'Produtividade',
+  emotional: 'Emocional',
+  routine: 'Rotina',
+  social: 'Social',
+  health: 'Saude',
+  learning: 'Aprendizado',
+  trigger: 'Gatilho',
+  strength: 'Forca',
+}
+
+function PatternsCard({ patterns }: { patterns: UserPattern[] }) {
+  if (!patterns.length) return null
+  return (
+    <div className="aica-context-card">
+      <p className="aica-context-card__title text-violet-500">Seus Padroes</p>
+      <ul className="aica-context-card__list">
+        {patterns.map((p, i) => (
+          <li key={i} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 4 }}>
+            <span style={{ flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {p.description}
+            </span>
+            <span style={{
+              fontSize: 10,
+              padding: '1px 5px',
+              borderRadius: 8,
+              background: p.confidence >= 0.8 ? 'rgba(16,185,129,0.15)' : 'rgba(139,92,246,0.12)',
+              color: p.confidence >= 0.8 ? '#059669' : '#7c3aed',
+              whiteSpace: 'nowrap',
+            }}>
+              {PATTERN_LABELS[p.patternType] || p.patternType} {(p.confidence * 100).toFixed(0)}%
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+function InsightCard({ insight }: { insight: LifeCouncilInsight }) {
+  const statusColors: Record<string, string> = {
+    thriving: '#059669',
+    balanced: '#2563eb',
+    strained: '#d97706',
+    burnout_risk: '#dc2626',
+  }
+  const statusLabels: Record<string, string> = {
+    thriving: 'Otimo',
+    balanced: 'Equilibrado',
+    strained: 'Tensionado',
+    burnout_risk: 'Risco',
+  }
+  const color = statusColors[insight.overallStatus] || '#6b7280'
+  const label = statusLabels[insight.overallStatus] || insight.overallStatus
+
+  return (
+    <div className="aica-context-card">
+      <p className="aica-context-card__title text-cyan-600">
+        Insight do Dia
+        <span style={{
+          marginLeft: 6,
+          fontSize: 10,
+          padding: '1px 6px',
+          borderRadius: 8,
+          background: `${color}18`,
+          color,
+        }}>
+          {label}
+        </span>
+      </p>
+      {insight.headline && (
+        <p style={{ fontSize: 12, fontWeight: 500, margin: '4px 0 2px' }}>{insight.headline}</p>
+      )}
+      {insight.actionItems.length > 0 && (
+        <ul className="aica-context-card__list">
+          {insight.actionItems.slice(0, 2).map((item, i) => <li key={i}>{item}</li>)}
+        </ul>
+      )}
+    </div>
+  )
+}
+
 function renderCards(module: string, context: UserAIContext): React.ReactNode {
   switch (module) {
     case 'atlas':
@@ -86,7 +168,11 @@ function renderCards(module: string, context: UserAIContext): React.ReactNode {
       )
     case 'journey':
       return (
-        <ListCard title="Momentos Recentes" items={context.recentMoments} accentColor="text-teal-500" />
+        <>
+          <ListCard title="Momentos Recentes" items={context.recentMoments} accentColor="text-teal-500" />
+          {context.latestInsight && <InsightCard insight={context.latestInsight} />}
+          <PatternsCard patterns={context.patterns.filter(p => ['emotional', 'trigger', 'strength'].includes(p.patternType))} />
+        </>
       )
     case 'agenda':
       return (
@@ -107,12 +193,14 @@ function renderCards(module: string, context: UserAIContext): React.ReactNode {
     default: // coordinator overview
       return (
         <>
+          {context.latestInsight && <InsightCard insight={context.latestInsight} />}
           <StatCard title="Tarefas Pendentes" value={context.pendingTasks} label="no Atlas" accentColor="text-blue-500" />
           {context.financeSummary && (
             <StatCard title="Saldo do Mes" value={formatCurrency(context.financeSummary.balance)} accentColor="text-amber-500" />
           )}
           <StatCard title="Momentos" value={context.recentMoments.length} label="registrados recentemente" accentColor="text-teal-500" />
           <StatCard title="Proximos Eventos" value={context.upcomingEvents?.length ?? 0} label="na agenda" accentColor="text-indigo-500" />
+          <PatternsCard patterns={context.patterns} />
         </>
       )
   }

--- a/src/hooks/useChatSession.ts
+++ b/src/hooks/useChatSession.ts
@@ -161,6 +161,8 @@ export function useChatSession(): UseChatSessionReturn {
             completedTasksToday: ctx.completedTasksToday,
             activeGrants: ctx.activeGrants,
             upcomingEpisodes: ctx.upcomingEpisodes,
+            patterns: ctx.patterns,
+            latestInsight: ctx.latestInsight,
           }
         }
       } catch {

--- a/src/services/userAIContextService.ts
+++ b/src/services/userAIContextService.ts
@@ -18,6 +18,20 @@ import { createNamespacedLogger } from '@/lib/logger'
 
 const log = createNamespacedLogger('userAIContextService')
 
+export interface UserPattern {
+  patternType: string
+  description: string
+  confidence: number
+}
+
+export interface LifeCouncilInsight {
+  overallStatus: string
+  headline: string
+  synthesis: string
+  actionItems: string[]
+  createdAt: string
+}
+
 export interface UserAIContext {
   userName: string
   pendingTasks: number
@@ -31,6 +45,8 @@ export interface UserAIContext {
     balance: number
   } | null
   upcomingEvents: Array<{ title: string; startTime: string }> | null
+  patterns: UserPattern[]
+  latestInsight: LifeCouncilInsight | null
 }
 
 // Cache with 5-minute TTL
@@ -58,7 +74,7 @@ export async function getUserAIContext(forceRefresh = false): Promise<UserAICont
       .toISOString().split('T')[0]
 
     // Run all queries in parallel
-    const [profileRes, pendingTasksRes, completedTasksRes, momentsRes, grantsRes, episodesRes, financeRes] = await Promise.all([
+    const [profileRes, pendingTasksRes, completedTasksRes, momentsRes, grantsRes, episodesRes, financeRes, patternsRes, insightRes] = await Promise.all([
       supabase
         .from('profiles')
         .select('full_name')
@@ -96,6 +112,20 @@ export async function getUserAIContext(forceRefresh = false): Promise<UserAICont
         .select('type, amount')
         .eq('user_id', userId)
         .gte('transaction_date', monthStart),
+      supabase
+        .from('user_patterns')
+        .select('pattern_type, description, confidence')
+        .eq('user_id', userId)
+        .eq('is_active', true)
+        .gte('confidence', 0.5)
+        .order('confidence', { ascending: false })
+        .limit(5),
+      supabase
+        .from('daily_council_insights')
+        .select('overall_status, headline, synthesis, action_items, created_at')
+        .eq('user_id', userId)
+        .order('created_at', { ascending: false })
+        .limit(1),
     ])
 
     // TODO: Re-enable when calendar_events table is created
@@ -118,6 +148,26 @@ export async function getUserAIContext(forceRefresh = false): Promise<UserAICont
       }
     }
 
+    // Map patterns
+    const patterns: UserPattern[] = (patternsRes.data || []).map((p: any) => ({
+      patternType: p.pattern_type,
+      description: p.description,
+      confidence: p.confidence,
+    }))
+
+    // Map latest insight
+    let latestInsight: LifeCouncilInsight | null = null
+    if (insightRes.data?.length) {
+      const ins = insightRes.data[0] as any
+      latestInsight = {
+        overallStatus: ins.overall_status || 'unknown',
+        headline: ins.headline || '',
+        synthesis: ins.synthesis || '',
+        actionItems: Array.isArray(ins.action_items) ? ins.action_items : [],
+        createdAt: ins.created_at,
+      }
+    }
+
     const context: UserAIContext = {
       userName: profileRes.data?.full_name?.split(' ')[0] || 'usuario',
       pendingTasks: pendingTasksRes.count || 0,
@@ -132,6 +182,8 @@ export async function getUserAIContext(forceRefresh = false): Promise<UserAICont
         title: e.title || 'Sem titulo',
         startTime: e.start_time,
       })),
+      patterns,
+      latestInsight,
     }
 
     // Update cache

--- a/supabase/functions/gemini-chat/index.ts
+++ b/supabase/functions/gemini-chat/index.ts
@@ -768,11 +768,11 @@ async function buildUserContext(supabaseAdmin: any, userId: string, module: stri
       }
     }
 
-    // Fetch Life Council insights for coordinator proactive guidance
-    if (module === 'coordinator') {
+    // Fetch Life Council insights for coordinator and journey agents
+    if (module === 'coordinator' || module === 'journey') {
       const { data: councilInsights } = await supabaseAdmin
         .from('daily_council_insights')
-        .select('insight_type, content, action_items, created_at')
+        .select('insight_type, content, action_items, overall_status, headline, created_at')
         .eq('user_id', userId)
         .order('created_at', { ascending: false })
         .limit(3)
@@ -781,13 +781,64 @@ async function buildUserContext(supabaseAdmin: any, userId: string, module: stri
         contextParts.push(`\n### Insights do Life Council (últimos ${councilInsights.length})`)
         councilInsights.forEach((insight: any) => {
           const date = new Date(insight.created_at).toLocaleDateString('pt-BR')
-          contextParts.push(`- [${date}] ${insight.insight_type}: ${typeof insight.content === 'string' ? insight.content.substring(0, 200) : JSON.stringify(insight.content).substring(0, 200)}`)
+          const status = insight.overall_status ? ` [${insight.overall_status}]` : ''
+          const headline = insight.headline ? ` — ${insight.headline}` : ''
+          contextParts.push(`- [${date}]${status}${headline} ${insight.insight_type}: ${typeof insight.content === 'string' ? insight.content.substring(0, 200) : JSON.stringify(insight.content).substring(0, 200)}`)
           if (insight.action_items?.length) {
             insight.action_items.slice(0, 2).forEach((item: string) => {
               contextParts.push(`  · Ação: ${item}`)
             })
           }
         })
+      }
+    }
+
+    // Fetch user behavioral patterns for personalized responses (all modules)
+    {
+      const { data: patterns } = await supabaseAdmin
+        .from('user_patterns')
+        .select('pattern_type, description, confidence, evidence_count, last_observed')
+        .eq('user_id', userId)
+        .eq('is_active', true)
+        .gte('confidence', 0.5)
+        .order('confidence', { ascending: false })
+        .limit(5)
+
+      if (patterns?.length) {
+        contextParts.push(`\n### Padrões Comportamentais do Usuário (${patterns.length})`)
+        contextParts.push(`Use estes padrões para personalizar suas respostas:`)
+        patterns.forEach((p: any) => {
+          const lastSeen = p.last_observed ? new Date(p.last_observed).toLocaleDateString('pt-BR') : 'N/A'
+          contextParts.push(`- [${p.pattern_type}] ${p.description} (confiança: ${(p.confidence * 100).toFixed(0)}%, evidências: ${p.evidence_count || 0}, visto: ${lastSeen})`)
+        })
+      }
+    }
+
+    // Fetch weekly summary for coordinator and journey
+    if (module === 'coordinator' || module === 'journey') {
+      const weekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString()
+      const { data: weeklySummaries } = await supabaseAdmin
+        .from('weekly_summaries')
+        .select('summary_data, week_start, week_end, created_at')
+        .eq('user_id', userId)
+        .gte('created_at', weekAgo)
+        .order('created_at', { ascending: false })
+        .limit(1)
+
+      if (weeklySummaries?.length) {
+        const ws = weeklySummaries[0]
+        const data = typeof ws.summary_data === 'string' ? JSON.parse(ws.summary_data) : ws.summary_data
+        if (data) {
+          contextParts.push(`\n### Resumo Semanal (${ws.week_start || ''} a ${ws.week_end || ''})`)
+          if (data.emotionalTrend) contextParts.push(`- Tendência emocional: ${data.emotionalTrend}`)
+          if (data.dominantEmotions?.length) contextParts.push(`- Emoções dominantes: ${data.dominantEmotions.join(', ')}`)
+          if (data.insights?.length) {
+            data.insights.slice(0, 3).forEach((insight: string) => {
+              contextParts.push(`- Insight: ${insight}`)
+            })
+          }
+          if (data.suggestedFocus) contextParts.push(`- Foco sugerido: ${data.suggestedFocus}`)
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- **Backend**: `buildUserContext()` now injects `user_patterns` (top 5 high-confidence, all modules), `weekly_summaries` (coordinator + journey), and expanded Life Council insights (was coordinator-only, now includes journey agent)
- **Frontend service**: `UserAIContext` enriched with `patterns[]` and `latestInsight` — fetched in parallel with existing queries (zero extra round-trips)
- **Frontend sidebar**: New `PatternsCard` (confidence % badges) and `InsightCard` (status pill + headlines) in coordinator and journey views
- **Context payload**: `useChatSession` now forwards patterns + insight data to agent-proxy for ADK agents

Phase 1 of 4 for #194 (Chat Redesign) — makes the AI genuinely aware of who the user is.

## Test plan
- [x] `npm run build` passes
- [x] `npm run typecheck` passes (no new errors)
- [ ] Open chat in coordinator mode → verify InsightCard appears if daily_council_insights has data
- [ ] Open chat in journey mode → verify emotional/trigger patterns appear
- [ ] Verify new queries don't break chat when tables are empty (graceful degradation)
- [ ] Test chat response quality — AI should reference patterns and insights naturally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added pattern cards displaying user behavioral insights with confidence metrics
- Introduced insight cards showing daily insights with status indicators and headlines
- Enhanced chat AI context with user behavioral patterns and latest insight data
- Expanded contextual information available to the chat system for improved responses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->