### PR TITLE
fix(journey): emotional trend em português + justificativa (#524)

### DIFF
--- a/src/modules/journey/components/insights/WeeklySummaryCard.tsx
+++ b/src/modules/journey/components/insights/WeeklySummaryCard.tsx
@@ -13,6 +13,7 @@ const log = createNamespacedLogger('WeeklySummaryCard')
 import {
   EMOTIONAL_TREND_COLORS,
   EMOTIONAL_TREND_DESCRIPTIONS,
+  EMOTIONAL_TREND_LABELS,
 } from '../../types/weeklySummary'
 import {
   SparklesIcon,
@@ -181,10 +182,17 @@ export function WeeklySummaryCard({ summary, onAddReflection }: WeeklySummaryCar
               className="px-4 py-2 rounded-lg font-medium text-white"
               style={{ backgroundColor: trendColor }}
             >
-              {summary.summary_data.emotionalTrend}
+              {EMOTIONAL_TREND_LABELS[summary.summary_data.emotionalTrend] || summary.summary_data.emotionalTrend}
             </div>
             <p className="text-sm text-ceramic-text-secondary">{trendDescription}</p>
           </div>
+
+          {/* Trend justification — explains WHY the trend is what it is */}
+          {summary.summary_data.trendJustification && (
+            <p className="mt-2 text-sm text-ceramic-text-secondary italic">
+              {summary.summary_data.trendJustification}
+            </p>
+          )}
         </div>
 
         {/* Dominant emotions */}

--- a/src/modules/journey/services/weeklySummaryService.ts
+++ b/src/modules/journey/services/weeklySummaryService.ts
@@ -337,8 +337,36 @@ function generateFallbackSummary(moments: Moment[]): WeeklySummaryData {
     created_at: m.created_at,
   }))
 
+  // Compute trend from sentiments
+  const sentiments = moments
+    .map(m => m.sentiment_data?.sentiment)
+    .filter(Boolean) as string[]
+  const positive = sentiments.filter(s => s === 'positive').length
+  const negative = sentiments.filter(s => s === 'negative' || s === 'very_negative').length
+  const total = sentiments.length || 1
+  const posRatio = positive / total
+  const negRatio = negative / total
+
+  let trend: import('../types/weeklySummary').EmotionalTrend = 'stable'
+  let trendJustification = 'Seus momentos apresentaram sentimento predominantemente neutro ou equilibrado esta semana.'
+
+  if (posRatio > 0.6) {
+    trend = 'ascending'
+    trendJustification = `A maioria dos seus momentos (${positive} de ${total}) teve sentimento positivo.`
+  } else if (negRatio > 0.6) {
+    trend = 'descending'
+    const emotionHint = dominantEmotions.length > 0
+      ? ` As emoções predominantes foram: ${dominantEmotions.slice(0, 2).join(', ')}.`
+      : ''
+    trendJustification = `A maioria dos seus momentos (${negative} de ${total}) teve sentimento negativo.${emotionHint}`
+  } else if (positive > 0 && negative > 0 && Math.abs(positive - negative) <= 1) {
+    trend = 'volatile'
+    trendJustification = `Seus momentos alternaram entre positivos (${positive}) e negativos (${negative}), indicando oscilações emocionais.`
+  }
+
   return {
-    emotionalTrend: 'stable',
+    emotionalTrend: trend,
+    trendJustification,
     dominantEmotions,
     keyMoments,
     insights: ['Você registrou ' + moments.length + ' momentos esta semana.'],
@@ -351,7 +379,8 @@ function generateFallbackSummary(moments: Moment[]): WeeklySummaryData {
  */
 function generateEmptyWeekSummary(): WeeklySummaryData {
   return {
-    emotionalTrend: 'neutral',
+    emotionalTrend: 'stable',
+    trendJustification: 'Nenhum momento foi registrado esta semana para avaliar a tendência emocional.',
     dominantEmotions: [],
     keyMoments: [],
     insights: [

--- a/src/modules/journey/types/weeklySummary.ts
+++ b/src/modules/journey/types/weeklySummary.ts
@@ -16,6 +16,7 @@ export interface KeyMoment {
 
 export interface WeeklySummaryData {
   emotionalTrend: EmotionalTrend
+  trendJustification?: string
   dominantEmotions: string[]
   keyMoments: KeyMoment[]
   insights: string[]
@@ -84,6 +85,14 @@ export function getWeekDateRange(year: number, week: number): { start: Date; end
   const end = new Date(ISOweekStart)
   end.setDate(end.getDate() + 6)
   return { start, end }
+}
+
+// Emotional trend labels (Portuguese display names)
+export const EMOTIONAL_TREND_LABELS: Record<EmotionalTrend, string> = {
+  ascending: 'Ascendente',
+  stable: 'Estável',
+  descending: 'Em declínio',
+  volatile: 'Volátil',
 }
 
 // Emotional trend descriptions


### PR DESCRIPTION
## Summary
- Corrige tendência emocional exibida em inglês ("stable") para português ("Estável")
- Adiciona justificativa explicando POR QUE a tendência é o que é
- Corrige fallback summary que calculava trend errado (hardcoded "stable" mesmo com momentos negativos)
- Corrige `generateEmptyWeekSummary` usando tipo inválido "neutral" (agora usa "stable")
- Deletou cache stale da semana 9 que mostrava "stable" incorretamente para momentos negativos

## Mudanças
- `weeklySummary.ts`: novo tipo `trendJustification`, novo mapa `EMOTIONAL_TREND_LABELS`
- `WeeklySummaryCard.tsx`: exibe label PT-BR + justificativa abaixo do trend
- `weeklySummaryService.ts`: fallback computa trend a partir de sentiments reais

## Chat errors (#524)
Os erros de chat (gemini-chat 500, agent-proxy 401) são **problemas de backend/Edge Function**, não de frontend:
- `gemini-chat` 500: intermitente, timeouts da Gemini API (~10-14s). Logs recentes mostram 200s — está funcionando
- `agent-proxy` 401: autenticação entre Edge Function e ADK backend

## Test plan
- [x] `npm run typecheck` — sem erros novos (3 pre-existentes em `model`/`usageMetadata`)
- [ ] Recarregar página Journey — resumo deve mostrar "Em declínio" com justificativa
- [ ] Verificar que cache stale foi deletado e regenera

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Weekly summaries now display emotional trend justifications, explaining why emotions shifted up, down, or remained stable.
  * Added suggested focus recommendations in weekly summaries to guide user attention.
  * Emotional trends now show human-readable labels instead of technical values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->