### PR TITLE
fix(chat,journey): eliminate console errors from non-existent tables and schema mismatches (#524)

### DIFF
--- a/src/modules/journey/services/dailyQuestionService.ts
+++ b/src/modules/journey/services/dailyQuestionService.ts
@@ -409,28 +409,11 @@ async function getUserContext(userId: string): Promise<UserContext> {
       mentalHealthFlags.push('overwhelm')
     }
 
-    // 2. Fetch áreas críticas (áreas com problemas bloqueados)
-    const { data: userAreas } = await supabase
-      .from('user_areas')
-      .select('id, name, status, is_critical')
-      .eq('user_id', userId)
+    // 2. Critical areas — user_areas table not yet created (future feature)
+    const criticalAreas: UserContext['criticalAreas'] = []
 
-    const criticalAreas = (userAreas || [])
-      .filter(a => a.is_critical)
-      .map(a => ({
-        areaId: a.id,
-        areaName: a.name,
-        severity: a.status === 'critical' ? 'high' : 'medium',
-        isBlocking: true,
-      }))
-
-    // 3. Fetch trilhas ativas
-    const { data: activeJourneys } = await supabase
-      .from('user_journeys')
-      .select('area_id, journey_type, completion_percentage')
-      .eq('user_id', userId)
-      .eq('status', 'active')
-      .limit(5)
+    // 3. Active journeys — user_journeys table not yet created (future feature)
+    const activeJourneys: Array<{ area_id: string; journey_type: string; completion_percentage: number }> = []
 
     // 4. Fetch respostas recentes a perguntas (últimos 7 dias)
     const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString()
@@ -953,23 +936,14 @@ export async function saveDailyResponse(
 
 /**
  * Registra métrica de uso (para otimização de custos)
+ * NOTE: gemini_api_logs table was never created. Usage is now tracked
+ * via aiUsageTrackingService (ai_usage_logs table). This function is
+ * kept as a no-op for backward compatibility.
  */
 export async function logDailyQuestionUsage(
-  userId: string,
-  source: 'ai' | 'journey' | 'pool',
-  responseTime: number
+  _userId: string,
+  _source: 'ai' | 'journey' | 'pool',
+  _responseTime: number
 ): Promise<void> {
-  try {
-    await supabase.from('gemini_api_logs').insert({
-      user_id: userId,
-      action: 'daily_question',
-      model: source === 'ai' ? 'gemini-2.5-flash' : 'fallback',
-      tokens_used: 0, // Será preenchido pelo backend
-      response_time_ms: responseTime,
-      status: 'success',
-      created_at: new Date().toISOString(),
-    })
-  } catch (error) {
-    log.error('Error logging usage:', error)
-  }
+  // No-op: usage tracked via trackAIUsage() in generateAIDrivenQuestion()
 }

--- a/src/modules/journey/views/JourneyFullScreen.tsx
+++ b/src/modules/journey/views/JourneyFullScreen.tsx
@@ -198,14 +198,16 @@ export function JourneyFullScreen({ onBack }: JourneyFullScreenProps) {
   }, [activeTab, summary, isLoadingSummary, refreshSummary])
 
   // Initialize File Search: immediately on desktop (inline), or on search tab on mobile
+  // Guard: only initialize when we have a userId to avoid ensureCorpus errors
   useEffect(() => {
+    if (!user?.id) return
     const isDesktop = window.innerWidth >= 1024
     if (isDesktop || activeTab === 'search') {
       initializeFileSearch().catch((err) => {
         log.warn('File search initialization failed (non-critical):', err)
       })
     }
-  }, [activeTab, initializeFileSearch])
+  }, [activeTab, initializeFileSearch, user?.id])
 
   // Handle moment creation
   const handleCreateMoment = async (input: CreateMomentInput) => {

--- a/src/services/userAIContextService.ts
+++ b/src/services/userAIContextService.ts
@@ -114,15 +114,15 @@ export async function getUserAIContext(forceRefresh = false): Promise<UserAICont
         .gte('transaction_date', monthStart),
       supabase
         .from('user_patterns')
-        .select('pattern_type, description, confidence')
+        .select('pattern_type, description, confidence_score')
         .eq('user_id', userId)
         .eq('is_active', true)
-        .gte('confidence', 0.5)
-        .order('confidence', { ascending: false })
+        .gte('confidence_score', 0.5)
+        .order('confidence_score', { ascending: false })
         .limit(5),
       supabase
         .from('daily_council_insights')
-        .select('overall_status, headline, synthesis, action_items, created_at')
+        .select('overall_status, headline, synthesis, actions, created_at')
         .eq('user_id', userId)
         .order('created_at', { ascending: false })
         .limit(1),
@@ -152,7 +152,7 @@ export async function getUserAIContext(forceRefresh = false): Promise<UserAICont
     const patterns: UserPattern[] = (patternsRes.data || []).map((p: any) => ({
       patternType: p.pattern_type,
       description: p.description,
-      confidence: p.confidence,
+      confidence: p.confidence_score,
     }))
 
     // Map latest insight
@@ -163,7 +163,7 @@ export async function getUserAIContext(forceRefresh = false): Promise<UserAICont
         overallStatus: ins.overall_status || 'unknown',
         headline: ins.headline || '',
         synthesis: ins.synthesis || '',
-        actionItems: Array.isArray(ins.action_items) ? ins.action_items : [],
+        actionItems: Array.isArray(ins.actions) ? ins.actions : [],
         createdAt: ins.created_at,
       }
     }


### PR DESCRIPTION
## Summary
- Fix `user_patterns` query using wrong column name (`confidence` → `confidence_score`) causing 400 errors
- Fix `daily_council_insights` query using wrong column name (`action_items` → `actions`) causing 400 errors
- Remove queries to non-existent tables (`user_areas`, `user_journeys`) causing 404 errors
- Make `logDailyQuestionUsage` a no-op since `gemini_api_logs` table was never created (404 errors); usage already tracked via `aiUsageTrackingService`
- Guard `JourneyFullScreen` file search initialization with `userId` check to prevent `ensureCorpus` error spam

Closes #524

## Test plan
- [x] `npm run build` passes
- [x] `npm run typecheck` — no new errors (pre-existing errors unchanged)
- [ ] Manual testing: open `/vida`, verify console has no 400/404 errors from these queries
- [ ] Manual testing: open chat, verify streaming works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential issue with file search initialization by ensuring user data is properly loaded before setup.

* **Chores**
  * Cleaned up internal service logic and data field mappings for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->