### PR TITLE
fix(flux): resolve 3 Flux issues — badge overlap, assessoria display, user selection

### DIFF
--- a/src/modules/connections/services/spaceService.ts
+++ b/src/modules/connections/services/spaceService.ts
@@ -162,7 +162,7 @@ export const spaceService = {
         color_theme: data.color_theme || archetypeConfig.color_theme,
         is_active: true,
         is_favorite: false,
-        settings: {}
+        settings: data.settings || {},
       };
 
       const { data: spaceData, error } = await supabase

--- a/src/modules/flux/components/AthleteCard.tsx
+++ b/src/modules/flux/components/AthleteCard.tsx
@@ -141,9 +141,10 @@ export function AthleteCard({
 
           {/* Name + Level + Modality */}
           <div className="flex-1 min-w-0">
-            <h3 className="text-base font-bold text-ceramic-text-primary truncate flex items-center gap-1.5">
-              {athlete.name}
-              <ConnectionStatusDot status={athlete.invitation_status} />
+            <div className="flex items-center gap-1.5">
+              <h3 className="text-base font-bold text-ceramic-text-primary truncate">
+                {athlete.name}
+              </h3>
               {/* Status Indicators — #389 */}
               {athlete.financial_status && athlete.financial_status !== 'ok' && (
                 <span
@@ -162,7 +163,7 @@ export function AthleteCard({
                   }
                 />
               )}
-            </h3>
+            </div>
             <div className="mt-1 flex items-center gap-2">
               <LevelBadge level={athlete.level} size="sm" />
               {athlete.modality && (
@@ -173,13 +174,14 @@ export function AthleteCard({
                   {MODALITY_CONFIG[athlete.modality]?.icon}
                 </span>
               )}
+              <ConnectionStatusDot status={athlete.invitation_status} />
             </div>
           </div>
 
           {/* Status Badge */}
           <div
             className={`
-              px-2 py-1 rounded-lg text-[10px] font-bold uppercase tracking-wider
+              px-2 py-1 rounded-lg text-[10px] font-bold uppercase tracking-wider flex-shrink-0
               ${statusConfig.color === 'green' ? 'bg-ceramic-success/20 text-ceramic-success' : ''}
               ${statusConfig.color === 'yellow' ? 'bg-ceramic-warning/20 text-ceramic-warning' : ''}
               ${statusConfig.color === 'blue' ? 'bg-ceramic-info/20 text-ceramic-info' : ''}

--- a/src/modules/flux/components/forms/AthleteFormDrawer.tsx
+++ b/src/modules/flux/components/forms/AthleteFormDrawer.tsx
@@ -12,7 +12,7 @@
  * - 3 secoes: Basic Info + Modalities + Health Config
  */
 
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import { motion, AnimatePresence, PanInfo, useMotionValue } from 'framer-motion';
 import {
   X,
@@ -34,6 +34,8 @@ import {
   MODALITY_OPTIONS,
   LEVEL_OPTIONS,
 } from '../../hooks/useAthleteForm';
+import UserSearchSection from './UserSearchSection';
+import type { UserSearchResult } from '../../hooks/useUserSearch';
 
 interface AthleteFormDrawerProps {
   mode: 'create' | 'edit';
@@ -65,6 +67,51 @@ export default function AthleteFormDrawer({
     handleSubmit,
     handleClose,
   } = useAthleteForm({ mode, initialData, isOpen, onSave, onClose, autoCloseDelayMs: 1000 });
+
+  // User search state (create mode only)
+  const [selectedUser, setSelectedUser] = useState<UserSearchResult | null>(null);
+  const [isManualMode, setIsManualMode] = useState(false);
+
+  // Reset user search state when drawer opens/closes
+  React.useEffect(() => {
+    if (isOpen) {
+      setSelectedUser(null);
+      setIsManualMode(false);
+    }
+  }, [isOpen]);
+
+  const handleUserSelected = useCallback(
+    (user: UserSearchResult) => {
+      setSelectedUser(user);
+      // Auto-fill form fields from selected user
+      if (user.full_name) handleChange('name', user.full_name);
+      if (user.email) handleChange('email', user.email);
+      handleChange('auth_user_id', user.id);
+      handleChange('invitation_status', 'connected');
+    },
+    [handleChange]
+  );
+
+  const handleClearUserSelection = useCallback(() => {
+    setSelectedUser(null);
+    handleChange('name', '');
+    handleChange('email', '');
+    handleChange('auth_user_id', undefined);
+    handleChange('invitation_status', undefined);
+  }, [handleChange]);
+
+  const handleToggleManualMode = useCallback(() => {
+    setIsManualMode((prev) => {
+      const goingToManual = !prev;
+      if (goingToManual) {
+        // Switching to manual: clear any selected user
+        setSelectedUser(null);
+        handleChange('auth_user_id', undefined);
+        handleChange('invitation_status', undefined);
+      }
+      return goingToManual;
+    });
+  }, [handleChange]);
 
   // Invite system state (Drawer-specific)
   const [isSendingInvite, setIsSendingInvite] = useState(false);
@@ -214,6 +261,17 @@ export default function AthleteFormDrawer({
                   </motion.div>
                 )}
 
+                {/* User Search Section (create mode only) */}
+                {mode === 'create' && (
+                  <UserSearchSection
+                    onUserSelected={handleUserSelected}
+                    onClear={handleClearUserSelection}
+                    selectedUser={selectedUser}
+                    isManualMode={isManualMode}
+                    onToggleManualMode={handleToggleManualMode}
+                  />
+                )}
+
                 {/* Section 1: Basic Info */}
                 <div className="ceramic-card overflow-hidden">
                   <button
@@ -247,7 +305,10 @@ export default function AthleteFormDrawer({
                           type="text"
                           value={formData.name}
                           onChange={(e) => handleChange('name', e.target.value)}
-                          className="w-full ceramic-inset px-4 py-3 rounded-lg text-sm text-ceramic-text-primary placeholder-ceramic-text-secondary/50 focus:outline-none focus:ring-2 focus:ring-ceramic-accent/50"
+                          disabled={!!selectedUser}
+                          className={`w-full ceramic-inset px-4 py-3 rounded-lg text-sm text-ceramic-text-primary placeholder-ceramic-text-secondary/50 focus:outline-none focus:ring-2 focus:ring-ceramic-accent/50 ${
+                            selectedUser ? 'opacity-60 cursor-not-allowed' : ''
+                          }`}
                           placeholder="Nome completo do atleta"
                         />
                         {errors.name && (
@@ -264,9 +325,9 @@ export default function AthleteFormDrawer({
                           type="email"
                           value={formData.email}
                           onChange={(e) => handleChange('email', e.target.value)}
-                          disabled={initialData?.invitation_status === 'connected'}
+                          disabled={!!selectedUser || initialData?.invitation_status === 'connected'}
                           className={`w-full ceramic-inset px-4 py-3 rounded-lg text-sm text-ceramic-text-primary placeholder-ceramic-text-secondary/50 focus:outline-none focus:ring-2 focus:ring-ceramic-accent/50 ${
-                            initialData?.invitation_status === 'connected'
+                            selectedUser || initialData?.invitation_status === 'connected'
                               ? 'opacity-60 cursor-not-allowed'
                               : ''
                           }`}

--- a/src/modules/flux/components/forms/UserSearchSection.tsx
+++ b/src/modules/flux/components/forms/UserSearchSection.tsx
@@ -1,0 +1,199 @@
+/**
+ * UserSearchSection Component
+ *
+ * Search for existing AICA users to link as athletes.
+ * Shown at the top of AthleteFormDrawer in 'create' mode.
+ *
+ * Features:
+ * - Debounced search input (300ms)
+ * - Results list with avatar, name, email
+ * - Selected user display with option to clear
+ * - Toggle to switch to manual entry mode
+ */
+
+import React from 'react';
+import { Search, X, UserCheck, UserPlus, Loader2 } from 'lucide-react';
+import { useUserSearch, type UserSearchResult } from '../../hooks/useUserSearch';
+
+interface UserSearchSectionProps {
+  onUserSelected: (user: UserSearchResult) => void;
+  onClear: () => void;
+  selectedUser: UserSearchResult | null;
+  isManualMode: boolean;
+  onToggleManualMode: () => void;
+}
+
+export default function UserSearchSection({
+  onUserSelected,
+  onClear,
+  selectedUser,
+  isManualMode,
+  onToggleManualMode,
+}: UserSearchSectionProps) {
+  const { query, setQuery, results, isSearching, error, hasSearched, clearResults } =
+    useUserSearch(300);
+
+  const handleSelectUser = (user: UserSearchResult) => {
+    onUserSelected(user);
+    clearResults();
+  };
+
+  const handleClearSelection = () => {
+    onClear();
+    clearResults();
+  };
+
+  // If a user is selected, show the selected user card
+  if (selectedUser) {
+    return (
+      <div className="ceramic-card p-4">
+        <div className="flex items-center justify-between mb-2">
+          <div className="flex items-center gap-2">
+            <UserCheck className="w-4 h-4 text-ceramic-success" />
+            <span className="text-xs font-bold text-ceramic-success uppercase tracking-wider">
+              Usuario AICA vinculado
+            </span>
+          </div>
+          <button
+            type="button"
+            onClick={handleClearSelection}
+            className="p-1 hover:bg-white/30 rounded transition-colors"
+            title="Remover vinculo"
+          >
+            <X className="w-4 h-4 text-ceramic-text-secondary" />
+          </button>
+        </div>
+        <div className="flex items-center gap-3 p-3 bg-ceramic-success/10 border border-ceramic-success/20 rounded-lg">
+          {selectedUser.avatar_url ? (
+            <img
+              src={selectedUser.avatar_url}
+              alt=""
+              className="w-10 h-10 rounded-full object-cover"
+            />
+          ) : (
+            <div className="w-10 h-10 rounded-full bg-ceramic-success/20 flex items-center justify-center">
+              <UserCheck className="w-5 h-5 text-ceramic-success" />
+            </div>
+          )}
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-bold text-ceramic-text-primary truncate">
+              {selectedUser.full_name || 'Usuario sem nome'}
+            </p>
+            {selectedUser.email && (
+              <p className="text-xs text-ceramic-text-secondary truncate">
+                {selectedUser.email}
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // If in manual mode, show toggle to switch back
+  if (isManualMode) {
+    return (
+      <div className="ceramic-card p-4">
+        <button
+          type="button"
+          onClick={onToggleManualMode}
+          className="w-full flex items-center justify-center gap-2 px-4 py-2.5 ceramic-inset hover:bg-white/50 rounded-lg transition-colors"
+        >
+          <Search className="w-4 h-4 text-ceramic-info" />
+          <span className="text-xs font-bold text-ceramic-info">
+            Buscar usuario AICA existente
+          </span>
+        </button>
+      </div>
+    );
+  }
+
+  // Search mode
+  return (
+    <div className="ceramic-card p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Search className="w-4 h-4 text-ceramic-info" />
+          <span className="text-xs font-bold text-ceramic-info uppercase tracking-wider">
+            Vincular usuario AICA
+          </span>
+        </div>
+      </div>
+
+      {/* Search Input */}
+      <div className="relative">
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          className="w-full ceramic-inset pl-10 pr-4 py-3 rounded-lg text-sm text-ceramic-text-primary placeholder-ceramic-text-secondary/50 focus:outline-none focus:ring-2 focus:ring-ceramic-info/50"
+          placeholder="Buscar por nome ou email..."
+        />
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-ceramic-text-secondary/50" />
+        {isSearching && (
+          <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-ceramic-info animate-spin" />
+        )}
+      </div>
+
+      {/* Error Message */}
+      {error && (
+        <p className="text-xs text-ceramic-warning px-1">{error}</p>
+      )}
+
+      {/* Search Results */}
+      {results.length > 0 && (
+        <div className="space-y-1 max-h-48 overflow-y-auto">
+          {results.map((user) => (
+            <button
+              key={user.id}
+              type="button"
+              onClick={() => handleSelectUser(user)}
+              className="w-full flex items-center gap-3 p-2.5 rounded-lg hover:bg-ceramic-info/10 transition-colors text-left"
+            >
+              {user.avatar_url ? (
+                <img
+                  src={user.avatar_url}
+                  alt=""
+                  className="w-8 h-8 rounded-full object-cover flex-shrink-0"
+                />
+              ) : (
+                <div className="w-8 h-8 rounded-full bg-ceramic-cool flex items-center justify-center flex-shrink-0">
+                  <UserCheck className="w-4 h-4 text-ceramic-text-secondary" />
+                </div>
+              )}
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium text-ceramic-text-primary truncate">
+                  {user.full_name || 'Usuario sem nome'}
+                </p>
+                {user.email && (
+                  <p className="text-xs text-ceramic-text-secondary truncate">
+                    {user.email}
+                  </p>
+                )}
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* No Results */}
+      {hasSearched && !isSearching && results.length === 0 && !error && (
+        <p className="text-xs text-ceramic-text-secondary px-1 italic">
+          Nenhum usuario encontrado para "{query}"
+        </p>
+      )}
+
+      {/* Manual Entry Toggle */}
+      <button
+        type="button"
+        onClick={onToggleManualMode}
+        className="w-full flex items-center justify-center gap-2 px-4 py-2 ceramic-inset hover:bg-white/50 rounded-lg transition-colors"
+      >
+        <UserPlus className="w-4 h-4 text-ceramic-text-secondary" />
+        <span className="text-xs font-bold text-ceramic-text-secondary">
+          Ou cadastrar manualmente
+        </span>
+      </button>
+    </div>
+  );
+}

--- a/src/modules/flux/components/forms/index.ts
+++ b/src/modules/flux/components/forms/index.ts
@@ -12,6 +12,7 @@ export { default as TimelineVisual } from './TimelineVisual';
 // Athlete Forms
 export { default as AthleteFormDrawer } from './AthleteFormDrawer';
 export { default as AthleteFormModal } from './AthleteFormModal';
+export { default as UserSearchSection } from './UserSearchSection';
 
 // Form state management
 export { useTemplateForm } from './useTemplateForm';

--- a/src/modules/flux/hooks/useAthleteForm.ts
+++ b/src/modules/flux/hooks/useAthleteForm.ts
@@ -35,6 +35,8 @@ export interface AthleteFormData {
   requires_cardio_exam: boolean;
   requires_clearance_cert: boolean;
   allow_parq_onboarding: boolean;
+  auth_user_id?: string;
+  invitation_status?: 'none' | 'pending' | 'connected';
 }
 
 export interface AthleteFormErrors {
@@ -63,7 +65,7 @@ export interface UseAthleteFormReturn {
   isLoadingProfiles: boolean;
   isFormValid: boolean;
   errorCount: number;
-  handleChange: (field: keyof AthleteFormData, value: string | boolean) => void;
+  handleChange: (field: keyof AthleteFormData, value: string | boolean | undefined) => void;
   handleModalityToggle: (modality: TrainingModality) => void;
   handleLevelChange: (modality: TrainingModality, level: SimpleAthleteLevel) => void;
   handleSubmit: (e: React.FormEvent) => Promise<void>;
@@ -113,6 +115,8 @@ export function useAthleteForm({
         requires_cardio_exam: initialData.requires_cardio_exam || false,
         requires_clearance_cert: initialData.requires_clearance_cert || false,
         allow_parq_onboarding: initialData.allow_parq_onboarding || false,
+        auth_user_id: initialData.auth_user_id,
+        invitation_status: initialData.invitation_status,
       };
     }
     return {
@@ -123,6 +127,8 @@ export function useAthleteForm({
       requires_cardio_exam: false,
       requires_clearance_cert: false,
       allow_parq_onboarding: false,
+      auth_user_id: undefined,
+      invitation_status: undefined,
     };
   }, [initialData]);
 
@@ -179,7 +185,7 @@ export function useAthleteForm({
   }, [mode, initialData?.id, isOpen]);
 
   const handleChange = useCallback(
-    (field: keyof AthleteFormData, value: string | boolean) => {
+    (field: keyof AthleteFormData, value: string | boolean | undefined) => {
       setFormData((prev) => ({ ...prev, [field]: value }));
       setIsDirty(true);
       setErrors((prev) => {
@@ -282,6 +288,10 @@ export function useAthleteForm({
           requires_clearance_cert: formData.requires_clearance_cert,
           allow_parq_onboarding: formData.allow_parq_onboarding,
           modalityLevels: formData.modalityLevels,
+          ...(formData.auth_user_id && {
+            auth_user_id: formData.auth_user_id,
+            invitation_status: formData.invitation_status || 'connected',
+          }),
         };
 
         await onSave(athleteData);

--- a/src/modules/flux/hooks/useUserSearch.ts
+++ b/src/modules/flux/hooks/useUserSearch.ts
@@ -1,0 +1,117 @@
+/**
+ * useUserSearch Hook
+ *
+ * Debounced search for AICA users (profiles table).
+ * Used by AthleteFormDrawer to link existing users as athletes.
+ *
+ * Calls the `search_aica_users` RPC which is a SECURITY DEFINER function
+ * that returns basic profile info (id, full_name, avatar_url, email)
+ * without exposing private data.
+ *
+ * Falls back gracefully if the RPC doesn't exist yet.
+ */
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { supabase } from '@/services/supabaseClient';
+
+export interface UserSearchResult {
+  id: string;
+  full_name: string | null;
+  avatar_url: string | null;
+  email: string | null;
+}
+
+interface UseUserSearchReturn {
+  query: string;
+  setQuery: (q: string) => void;
+  results: UserSearchResult[];
+  isSearching: boolean;
+  error: string | null;
+  hasSearched: boolean;
+  clearResults: () => void;
+}
+
+export function useUserSearch(debounceMs = 300): UseUserSearchReturn {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<UserSearchResult[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [hasSearched, setHasSearched] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearResults = useCallback(() => {
+    setResults([]);
+    setQuery('');
+    setError(null);
+    setHasSearched(false);
+  }, []);
+
+  useEffect(() => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+    }
+
+    const trimmed = query.trim();
+    if (trimmed.length < 2) {
+      setResults([]);
+      setHasSearched(false);
+      return;
+    }
+
+    debounceRef.current = setTimeout(async () => {
+      setIsSearching(true);
+      setError(null);
+
+      try {
+        // Try the SECURITY DEFINER RPC first
+        const { data, error: rpcError } = await supabase.rpc('search_aica_users', {
+          p_query: trimmed,
+        });
+
+        if (rpcError) {
+          // RPC doesn't exist yet — fallback to profiles table query
+          // This will only return the coach's own profile (due to RLS),
+          // but we handle it gracefully
+          if (rpcError.code === '42883' || rpcError.message?.includes('does not exist')) {
+            console.warn(
+              '[useUserSearch] RPC search_aica_users not found. A migration is needed to enable user search.'
+            );
+            setError(
+              'Busca de usuarios ainda nao configurada. Use cadastro manual por enquanto.'
+            );
+            setResults([]);
+          } else {
+            console.error('[useUserSearch] Search error:', rpcError);
+            setError('Erro ao buscar usuarios');
+            setResults([]);
+          }
+        } else {
+          setResults((data as UserSearchResult[]) || []);
+        }
+      } catch (err) {
+        console.error('[useUserSearch] Unexpected error:', err);
+        setError('Erro ao buscar usuarios');
+        setResults([]);
+      } finally {
+        setIsSearching(false);
+        setHasSearched(true);
+      }
+    }, debounceMs);
+
+    return () => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+    };
+  }, [query, debounceMs]);
+
+  return {
+    query,
+    setQuery,
+    results,
+    isSearching,
+    error,
+    hasSearched,
+    clearResults,
+  };
+}

--- a/src/modules/flux/services/assessoriaService.ts
+++ b/src/modules/flux/services/assessoriaService.ts
@@ -29,8 +29,10 @@ export const assessoriaService = {
   async getAssessoria(): Promise<ConnectionSpace | null> {
     try {
       const ventures = await spaceService.getSpacesByArchetype('ventures');
+      // Primary: match by settings marker; Fallback: match by subtitle (for spaces created before settings fix)
       const assessoria = ventures.find(
-        (s) => s.settings && (s.settings as Record<string, unknown>).space_type === ASSESSORIA_MARKER
+        (s) => (s.settings && (s.settings as Record<string, unknown>).space_type === ASSESSORIA_MARKER)
+            || s.subtitle === 'Assessoria Esportiva'
       );
       return assessoria || null;
     } catch (error) {

--- a/src/modules/flux/services/athleteService.ts
+++ b/src/modules/flux/services/athleteService.ts
@@ -22,6 +22,8 @@ export interface CreateAthleteInput {
   ftp?: number;
   pace_threshold?: string;
   swim_css?: string;
+  auth_user_id?: string;
+  invitation_status?: 'none' | 'pending' | 'connected';
 }
 
 export interface UpdateAthleteInput extends Partial<CreateAthleteInput> {
@@ -149,14 +151,21 @@ export class AthleteService {
       }
 
       // 2. Create athlete with platform_contact_id
+      const insertData: Record<string, unknown> = {
+        ...input,
+        user_id: userData.user.id,
+        status: input.status || 'active',
+        platform_contact_id: platformContactId,
+      };
+
+      // Set linked_at when connecting to an existing AICA user
+      if (input.auth_user_id && input.invitation_status === 'connected') {
+        insertData.linked_at = new Date().toISOString();
+      }
+
       const { data, error } = await supabase
         .from('athletes')
-        .insert({
-          ...input,
-          user_id: userData.user.id,
-          status: input.status || 'active',
-          platform_contact_id: platformContactId,
-        })
+        .insert(insertData)
         .select()
         .single();
 

--- a/supabase/migrations/20260227120000_search_aica_users_rpc.sql
+++ b/supabase/migrations/20260227120000_search_aica_users_rpc.sql
@@ -1,0 +1,50 @@
+-- Migration: search_aica_users RPC
+-- Date: 2026-02-27
+-- Description: SECURITY DEFINER RPC to allow coaches to search AICA users
+-- by name or email for linking as athletes in Flux CRM.
+-- Returns only basic public info (id, full_name, avatar_url, email).
+
+-- Create the search function
+CREATE OR REPLACE FUNCTION public.search_aica_users(p_query TEXT)
+RETURNS TABLE (
+  id UUID,
+  full_name TEXT,
+  avatar_url TEXT,
+  email TEXT
+) AS $$
+BEGIN
+  -- Require at least 2 characters to prevent scanning all users
+  IF length(trim(p_query)) < 2 THEN
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    p.id,
+    p.full_name,
+    p.avatar_url,
+    u.email::TEXT
+  FROM public.profiles p
+  INNER JOIN auth.users u ON u.id = p.id
+  WHERE
+    -- Exclude the caller (coach shouldn't add themselves)
+    p.id != auth.uid()
+    AND (
+      p.full_name ILIKE '%' || trim(p_query) || '%'
+      OR u.email ILIKE '%' || trim(p_query) || '%'
+    )
+  ORDER BY
+    -- Exact name matches first, then partial
+    CASE WHEN p.full_name ILIKE trim(p_query) THEN 0 ELSE 1 END,
+    p.full_name
+  LIMIT 10;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public;
+
+-- Grant execute to authenticated users
+GRANT EXECUTE ON FUNCTION public.search_aica_users(TEXT) TO authenticated;
+
+-- Add function comment
+COMMENT ON FUNCTION public.search_aica_users(TEXT) IS
+  'Search AICA users by name or email for athlete linking. Returns limited public info only.';


### PR DESCRIPTION
## Summary

Fixes 3 open Flux module issues reported via Callout:

- **#530** — "Pendente" badge overlapping "Ativo" status on AthleteCard: Separated `ConnectionStatusDot` from the name row into the secondary metadata row, added `flex-shrink-0` to status badge
- **#526** — Assessoria Esportiva created but not showing on FluxDashboard: Fixed `spaceService.createSpace()` to pass through caller-provided `settings` (was hardcoded `{}`), added fallback lookup by subtitle for pre-existing assessorias
- **#532** — Select existing AICA user as athlete: Added `UserSearchSection` component with debounced search via `search_aica_users` RPC, auto-fill form fields, manual entry fallback

### New files
- `src/modules/flux/components/forms/UserSearchSection.tsx` — Search UI component
- `src/modules/flux/hooks/useUserSearch.ts` — Debounced search hook
- `supabase/migrations/20260227120000_search_aica_users_rpc.sql` — SECURITY DEFINER RPC for safe user search

### Modified files
- `AthleteCard.tsx` — Layout fix for badge overlap
- `spaceService.ts` — Pass settings through to create
- `assessoriaService.ts` — Fallback lookup by subtitle
- `AthleteFormDrawer.tsx` — Integrate UserSearchSection
- `useAthleteForm.ts` — Add auth_user_id + invitation_status fields
- `athleteService.ts` — Pass auth_user_id in createAthlete

Closes #530, Closes #526, Closes #532

## Test plan

- [ ] `npm run build` passes
- [ ] `npm run typecheck` passes (no new errors)
- [ ] `/flux/crm` — verify "Pendente" and "Ativo" badges don't overlap on AthleteCard
- [ ] `/flux` — create Assessoria Esportiva and verify it shows immediately on dashboard
- [ ] `/flux/crm` — open "Novo Atleta" drawer, search for existing user, verify auto-fill
- [ ] `/flux/crm` — toggle to manual entry mode, verify form works normally
- [ ] Apply migration: `npx supabase db push` for search_aica_users RPC
- [ ] Test on mobile viewport (414px width)

> **Note**: The `search_aica_users` RPC migration needs to be applied via `npx supabase db push`. Until then, the search gracefully falls back to a message suggesting manual entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added user search functionality to streamline linking existing platform users when creating athletes, with optional manual entry mode.
  * Redesigned athlete card layout for improved visual organization and readability.
  * Made space settings configurable through the creation payload.

* **Bug Fixes**
  * Enhanced assessoria identification logic to recognize spaces created before configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->