### PR TITLE
fix(flux): resolve 6 exercise library issues (#536-#542)

### DIFF
--- a/src/modules/flux/components/coach/AdminDashboardSection.tsx
+++ b/src/modules/flux/components/coach/AdminDashboardSection.tsx
@@ -6,12 +6,14 @@
  */
 
 import React from 'react';
-import { Users, AlertTriangle, DollarSign, MessageSquare } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { Users, AlertTriangle, DollarSign, MessageSquare, BookOpen, Dumbbell } from 'lucide-react';
 import type { Athlete, TrainingModality, AthleteLevel } from '../../types/flux';
 import { MODALITY_CONFIG, LEVEL_LABELS } from '../../types/flux';
 
 interface AdminDashboardSectionProps {
   athletes: Athlete[];
+  templateCount?: number;
 }
 
 interface StatusGroup {
@@ -19,9 +21,11 @@ interface StatusGroup {
   count: number;
   icon: React.ReactNode;
   colorClasses: string;
+  filterKey: string;
 }
 
-export function AdminDashboardSection({ athletes }: AdminDashboardSectionProps) {
+export function AdminDashboardSection({ athletes, templateCount }: AdminDashboardSectionProps) {
+  const navigate = useNavigate();
   const activeAthletes = athletes.filter((a) => a.status === 'active' || a.status === 'trial');
 
   // --- Status groups ---
@@ -43,18 +47,21 @@ export function AdminDashboardSection({ athletes }: AdminDashboardSectionProps) 
       count: pendingHealthForm,
       icon: <AlertTriangle className="w-4 h-4" />,
       colorClasses: 'bg-ceramic-warning/10 text-ceramic-warning',
+      filterKey: 'health_pending',
     },
     {
       label: 'Financeiro pendente',
       count: pendingFinancial,
       icon: <DollarSign className="w-4 h-4" />,
       colorClasses: 'bg-ceramic-warning/10 text-ceramic-warning',
+      filterKey: 'financial_pending',
     },
     {
       label: 'Sem bloco ativo',
       count: needsFeedback,
       icon: <MessageSquare className="w-4 h-4" />,
       colorClasses: 'bg-ceramic-info/10 text-ceramic-info',
+      filterKey: 'no_block',
     },
   ];
 
@@ -87,6 +94,42 @@ export function AdminDashboardSection({ athletes }: AdminDashboardSectionProps) 
         <h2 className="text-lg font-bold text-ceramic-text-primary">Painel Administrativo</h2>
       </div>
 
+      {/* Resumo Geral */}
+      <div className="bg-ceramic-50 rounded-xl p-6 shadow-ceramic-emboss">
+        <h3 className="text-sm font-bold text-ceramic-text-secondary uppercase tracking-wider mb-4">
+          Resumo Geral
+        </h3>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <div className="flex items-center gap-3 p-3 rounded-lg bg-white border border-ceramic-border/30">
+            <div className="w-8 h-8 rounded-lg flex items-center justify-center bg-ceramic-success/10">
+              <Users className="w-4 h-4 text-ceramic-success" />
+            </div>
+            <div>
+              <p className="text-xl font-bold text-ceramic-text-primary">{activeAthletes.length}</p>
+              <p className="text-xs text-ceramic-text-secondary">Atletas ativos</p>
+            </div>
+          </div>
+          <div className="flex items-center gap-3 p-3 rounded-lg bg-white border border-ceramic-border/30">
+            <div className="w-8 h-8 rounded-lg flex items-center justify-center bg-amber-500/10">
+              <BookOpen className="w-4 h-4 text-amber-600" />
+            </div>
+            <div>
+              <p className="text-xl font-bold text-ceramic-text-primary">{templateCount ?? 0}</p>
+              <p className="text-xs text-ceramic-text-secondary">Exercicios na biblioteca</p>
+            </div>
+          </div>
+          <div className="flex items-center gap-3 p-3 rounded-lg bg-white border border-ceramic-border/30">
+            <div className="w-8 h-8 rounded-lg flex items-center justify-center bg-ceramic-info/10">
+              <Dumbbell className="w-4 h-4 text-ceramic-info" />
+            </div>
+            <div>
+              <p className="text-xl font-bold text-ceramic-text-primary">{activeAthletes.filter(a => a.current_block_id).length}</p>
+              <p className="text-xs text-ceramic-text-secondary">Com bloco ativo</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
       {/* Status groups */}
       <div className="bg-ceramic-50 rounded-xl p-6 shadow-ceramic-emboss">
         <h3 className="text-sm font-bold text-ceramic-text-secondary uppercase tracking-wider mb-4">
@@ -94,9 +137,10 @@ export function AdminDashboardSection({ athletes }: AdminDashboardSectionProps) 
         </h3>
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
           {statusGroups.map((group) => (
-            <div
+            <button
               key={group.label}
-              className="flex items-center gap-3 p-3 rounded-lg bg-white border border-ceramic-border/30"
+              onClick={() => navigate(`/flux/crm?filter=${group.filterKey}`)}
+              className="flex items-center gap-3 p-3 rounded-lg bg-white border border-ceramic-border/30 hover:shadow-md hover:border-ceramic-accent/30 transition-all cursor-pointer text-left"
             >
               <div className={`w-8 h-8 rounded-lg flex items-center justify-center ${group.colorClasses}`}>
                 {group.icon}
@@ -105,7 +149,7 @@ export function AdminDashboardSection({ athletes }: AdminDashboardSectionProps) 
                 <p className="text-xl font-bold text-ceramic-text-primary">{group.count}</p>
                 <p className="text-xs text-ceramic-text-secondary truncate">{group.label}</p>
               </div>
-            </div>
+            </button>
           ))}
         </div>
       </div>
@@ -124,7 +168,11 @@ export function AdminDashboardSection({ athletes }: AdminDashboardSectionProps) 
               const pct = Math.round((count / totalActive) * 100);
               const config = MODALITY_CONFIG[mod];
               return (
-                <div key={mod} className="flex items-center gap-3">
+                <button
+                  key={mod}
+                  onClick={() => navigate(`/flux/crm?modality=${mod}`)}
+                  className="flex items-center gap-3 w-full text-left hover:bg-white/50 rounded-lg p-1 -m-1 transition-colors cursor-pointer"
+                >
                   <span className="text-lg">{config.icon}</span>
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center justify-between mb-1">
@@ -138,7 +186,7 @@ export function AdminDashboardSection({ athletes }: AdminDashboardSectionProps) 
                       />
                     </div>
                   </div>
-                </div>
+                </button>
               );
             })}
             {Object.values(modalityCounts).every((c) => c === 0) && (
@@ -162,7 +210,11 @@ export function AdminDashboardSection({ athletes }: AdminDashboardSectionProps) 
                 avancado: 'bg-ceramic-error',
               };
               return (
-                <div key={lvl} className="flex items-center gap-3">
+                <button
+                  key={lvl}
+                  onClick={() => navigate(`/flux/crm?level=${lvl}`)}
+                  className="flex items-center gap-3 w-full text-left hover:bg-white/50 rounded-lg p-1 -m-1 transition-colors cursor-pointer"
+                >
                   <div className={`w-3 h-3 rounded-full ${colorMap[lvl]}`} />
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center justify-between mb-1">
@@ -176,7 +228,7 @@ export function AdminDashboardSection({ athletes }: AdminDashboardSectionProps) 
                       />
                     </div>
                   </div>
-                </div>
+                </button>
               );
             })}
           </div>

--- a/src/modules/flux/components/forms/TemplateFormDrawer.tsx
+++ b/src/modules/flux/components/forms/TemplateFormDrawer.tsx
@@ -256,7 +256,12 @@ export default function TemplateFormDrawer({
                   <label className="block text-sm font-medium text-ceramic-text-primary mb-2">
                     Modalidade
                   </label>
-                  <div className="grid grid-cols-3 sm:grid-cols-5 gap-2">
+                  <p className="text-xs text-ceramic-text-secondary mb-3">
+                    Clique na modalidade para iniciar a criacao do exercicio
+                  </p>
+                  <div className={`grid grid-cols-3 sm:grid-cols-5 gap-2 ${
+                    !formData.modality ? 'ring-2 ring-ceramic-accent/30 rounded-lg p-1' : ''
+                  }`}>
                     {MODALITY_OPTIONS.map((modality) => {
                       const config = MODALITY_CONFIG[modality];
                       return (
@@ -312,7 +317,7 @@ export default function TemplateFormDrawer({
                             <div className="text-left">
                               <span className="block">Privado</span>
                               <span className={`block text-xs font-normal ${!formData.is_public ? 'text-white/70' : 'text-ceramic-text-secondary/70'}`}>
-                                So para voce
+                                Voce e seus atletas
                               </span>
                             </div>
                           </button>
@@ -329,11 +334,16 @@ export default function TemplateFormDrawer({
                             <div className="text-left">
                               <span className="block">Publico</span>
                               <span className={`block text-xs font-normal ${formData.is_public ? 'text-white/70' : 'text-ceramic-text-secondary/70'}`}>
-                                Visivel para todos
+                                Marketplace da Aica
                               </span>
                             </div>
                           </button>
                         </div>
+                        <p className="text-xs text-ceramic-text-secondary mt-2">
+                          {formData.is_public
+                            ? 'Este exercicio ficara disponivel na biblioteca publica para outros treinadores.'
+                            : 'Apenas voce e seus atletas terao acesso a este exercicio.'}
+                        </p>
                       </div>
 
                       {/* Name & Description (#421: show in both modes for consistency) */}

--- a/src/modules/flux/services/workoutTemplateService.ts
+++ b/src/modules/flux/services/workoutTemplateService.ts
@@ -169,6 +169,17 @@ export class WorkoutTemplateService {
    */
   static async deleteTemplate(id: string): Promise<{ error: any }> {
     try {
+      // Log warning if deleting prescribed template
+      const { data: templateData } = await supabase
+        .from('workout_templates')
+        .select('usage_count, name')
+        .eq('id', id)
+        .single();
+
+      if (templateData && templateData.usage_count > 0) {
+        console.warn(`[WorkoutTemplateService] Deleting prescribed template "${templateData.name}" (usage_count: ${templateData.usage_count})`);
+      }
+
       const { error } = await supabase.from('workout_templates').delete().eq('id', id);
 
       return { error };
@@ -399,6 +410,17 @@ export class WorkoutTemplateService {
   ): Promise<{ data: WorkoutTemplate | null; error: any }> {
     try {
       const { id, ...updates } = input;
+
+      // Check if template has been prescribed (usage_count > 0)
+      const { data: existing } = await supabase
+        .from('workout_templates')
+        .select('usage_count')
+        .eq('id', id)
+        .single();
+
+      if (existing && existing.usage_count > 0) {
+        return { data: null, error: new Error('Este exercicio foi prescrito e nao pode ser editado. Duplique-o para criar uma versao editavel.') };
+      }
 
       const dbUpdates: Record<string, any> = {
         ...updates,

--- a/src/modules/flux/views/FluxDashboard.tsx
+++ b/src/modules/flux/views/FluxDashboard.tsx
@@ -95,19 +95,39 @@ export default function FluxDashboard() {
           <span className="text-xs font-bold uppercase tracking-wider">Voltar</span>
         </button>
 
-        <div data-tour="flux-header" className="flex items-center gap-4 mb-8">
-          <div className="w-16 h-16 ceramic-card flex items-center justify-center">
-            <span className="text-3xl">{hasAssessoria ? '🏢' : '🏋️'}</span>
+        {hasAssessoria ? (
+          <button
+            onClick={() => navigate(`/connections/${assessoria!.id}`)}
+            className="flex items-center gap-4 mb-8 text-left group"
+            data-tour="flux-header"
+          >
+            <div className="w-16 h-16 ceramic-card flex items-center justify-center group-hover:shadow-md transition-shadow">
+              <span className="text-3xl">🏢</span>
+            </div>
+            <div>
+              <p className="text-xs font-bold text-ceramic-text-secondary uppercase tracking-wider mb-0.5 group-hover:text-ceramic-accent transition-colors">
+                {assessoria!.name}
+              </p>
+              <h1 className="text-3xl font-black text-ceramic-text-primary text-etched">
+                Flux
+              </h1>
+            </div>
+          </button>
+        ) : (
+          <div data-tour="flux-header" className="flex items-center gap-4 mb-8">
+            <div className="w-16 h-16 ceramic-card flex items-center justify-center">
+              <span className="text-3xl">🏋️</span>
+            </div>
+            <div>
+              <p className="text-xs font-bold text-ceramic-text-secondary uppercase tracking-wider mb-0.5">
+                Gestao de Treinos
+              </p>
+              <h1 className="text-3xl font-black text-ceramic-text-primary text-etched">
+                Flux
+              </h1>
+            </div>
           </div>
-          <div>
-            <p className="text-xs font-bold text-ceramic-text-secondary uppercase tracking-wider mb-0.5">
-              {hasAssessoria ? assessoria!.name : 'Gestao de Treinos'}
-            </p>
-            <h1 className="text-3xl font-black text-ceramic-text-primary text-etched">
-              Flux
-            </h1>
-          </div>
-        </div>
+        )}
 
         {/* Navigation Cards */}
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
@@ -199,7 +219,7 @@ export default function FluxDashboard() {
       </div>
 
       {/* Admin Dashboard Section */}
-      <AdminDashboardSection athletes={allAthletes} />
+      <AdminDashboardSection athletes={allAthletes} templateCount={templates.length} />
 
       {/* Activity Toast Notifications */}
       {notifications.length > 0 && (

--- a/src/modules/flux/views/TemplateLibraryView.tsx
+++ b/src/modules/flux/views/TemplateLibraryView.tsx
@@ -2,8 +2,8 @@
  * TemplateLibraryView - Biblioteca de Templates de Treino
  *
  * Tela 1 do Flow Module: Grid filtrável de templates com drag support,
- * quick actions (duplicate/delete/favorite), e criação de novos templates.
- * #458: Templates are immutable — no edit action. Only clone + delete (own only).
+ * quick actions (edit/duplicate/delete/favorite), e criação de novos templates.
+ * #538: Own templates can be edited (if usage_count === 0). Prescribed templates are locked.
  */
 
 import React, { useState, useEffect } from 'react';
@@ -18,6 +18,8 @@ import {
   X,
   ArrowLeft,
   User as UserIcon,
+  Pencil,
+  Lock,
 } from 'lucide-react';
 import { WorkoutTemplateService } from '../services/workoutTemplateService';
 import { useWorkoutTemplates } from '../hooks';
@@ -85,8 +87,7 @@ export default function TemplateLibraryView() {
   const { templateId } = useParams();
   const location = useLocation();
 
-  // Determine mode based on URL
-  // #458: Edit mode removed — templates are immutable. Edit URLs redirect to list.
+  // Determine mode based on URL (edit is state-driven via handleEdit, not URL-driven)
   const mode: 'create' | 'list' = location.pathname.includes('/new')
     ? 'create'
     : 'list';
@@ -103,21 +104,25 @@ export default function TemplateLibraryView() {
   const [draggedTemplate, setDraggedTemplate] = useState<WorkoutTemplate | null>(null);
   const [isModalOpen, setModalOpen] = useState(mode !== 'list');
   const [editingTemplate, setEditingTemplate] = useState<WorkoutTemplate | null>(null);
+  const [favoritingIds, setFavoritingIds] = useState<Set<string>>(new Set());
 
   // Apply filters
   useEffect(() => {
     applyFilters();
   }, [templates, filters]);
 
-  // #458: Redirect legacy /edit URLs to list (templates are immutable)
+  // Sync drawer state with URL mode
   useEffect(() => {
     if (location.pathname.includes('/edit')) {
+      // Legacy /edit URLs redirect to list — editing is now state-driven via card actions
       navigate('/flux/templates', { replace: true });
       return;
     }
     if (mode === 'list') {
-      setEditingTemplate(null);
-      setModalOpen(false);
+      // Only reset if drawer isn't being opened by handleEdit (state-driven)
+      if (!editingTemplate) {
+        setModalOpen(false);
+      }
     } else if (mode === 'create') {
       setEditingTemplate(null);
       setModalOpen(true);
@@ -131,8 +136,15 @@ export default function TemplateLibraryView() {
   };
 
   const handleModalSave = (template: WorkoutTemplate) => {
-    // Optimistic update — prepend new template to grid (#458: no edit path)
-    setFilteredTemplates((prev) => [template, ...prev]);
+    if (editingTemplate) {
+      // Edit mode — update the existing template in the grid
+      setFilteredTemplates((prev) =>
+        prev.map((t) => (t.id === template.id ? template : t))
+      );
+    } else {
+      // Create mode — prepend new template to grid
+      setFilteredTemplates((prev) => [template, ...prev]);
+    }
 
     // Also refresh from DB to ensure consistency with real-time subscription
     refresh();
@@ -186,10 +198,14 @@ export default function TemplateLibraryView() {
 
   const handleToggleFavorite = async (template: WorkoutTemplate) => {
     // Guard: only the owner can favorite their own templates (RLS blocks PATCH on others)
-    if (user && template.user_id !== user.id) {
+    if (!user || template.user_id !== user.id) {
       console.warn('[TemplateLibraryView] Cannot favorite community template — not owner');
       return;
     }
+
+    // Debounce: prevent rapid-fire clicks
+    if (favoritingIds.has(template.id)) return;
+    setFavoritingIds((prev) => new Set(prev).add(template.id));
 
     const newFavorite = !template.is_favorite;
 
@@ -198,18 +214,24 @@ export default function TemplateLibraryView() {
       prev.map((t) => (t.id === template.id ? { ...t, is_favorite: newFavorite } : t))
     );
 
-    const { error: toggleError } = await WorkoutTemplateService.toggleFavorite(template.id, newFavorite);
-    if (toggleError) {
-      console.error('[TemplateLibraryView] Favorite toggle failed, reverting:', toggleError);
-      // Revert optimistic update on failure
-      setFilteredTemplates((prev) =>
-        prev.map((t) => (t.id === template.id ? { ...t, is_favorite: template.is_favorite } : t))
-      );
+    try {
+      const { error: toggleError } = await WorkoutTemplateService.toggleFavorite(template.id, newFavorite);
+      if (toggleError) {
+        console.error('[TemplateLibraryView] Favorite toggle failed, reverting:', toggleError);
+        // Revert optimistic update on failure
+        setFilteredTemplates((prev) =>
+          prev.map((t) => (t.id === template.id ? { ...t, is_favorite: template.is_favorite } : t))
+        );
+      }
+      // Always refresh from DB to ensure is_favorite state stays in sync
+      await refresh();
+    } finally {
+      setFavoritingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(template.id);
+        return next;
+      });
     }
-    // Always refresh from DB to ensure is_favorite state stays in sync
-    // This is critical: the DB is the source of truth for favorites,
-    // not local state. The refresh ensures consistency after toggling.
-    await refresh();
   };
 
   const handleDuplicate = async (template: WorkoutTemplate) => {
@@ -218,7 +240,10 @@ export default function TemplateLibraryView() {
   };
 
   const handleDelete = async (template: WorkoutTemplate) => {
-    if (!confirm(`Deletar template "${template.name}"?`)) return;
+    const message = template.usage_count > 0
+      ? `Este exercicio foi prescrito para ${template.usage_count} treino(s). Deletar removera o vinculo. Deseja continuar?`
+      : `Deletar template "${template.name}"?`;
+    if (!confirm(message)) return;
 
     const { error: deleteError } = await WorkoutTemplateService.deleteTemplate(template.id);
     if (deleteError) {
@@ -226,6 +251,11 @@ export default function TemplateLibraryView() {
     }
     // Always refresh to sync UI with DB state
     await refresh();
+  };
+
+  const handleEdit = (template: WorkoutTemplate) => {
+    setEditingTemplate(template);
+    setModalOpen(true);
   };
 
   const handleDragStart = (template: WorkoutTemplate) => {
@@ -397,11 +427,13 @@ export default function TemplateLibraryView() {
                 template={template}
                 currentUserId={user?.id}
                 onToggleFavorite={handleToggleFavorite}
+                onEdit={handleEdit}
                 onDuplicate={handleDuplicate}
                 onDelete={handleDelete}
                 onDragStart={handleDragStart}
                 onDragEnd={handleDragEnd}
                 isDragging={draggedTemplate?.id === template.id}
+                favoritingId={favoritingIds.has(template.id)}
               />
             ))}
           </div>
@@ -409,9 +441,8 @@ export default function TemplateLibraryView() {
       </div>
 
       {/* Template Form Drawer */}
-      {/* #458: Always create mode — templates are immutable */}
       <TemplateFormDrawer
-        mode="create"
+        mode={editingTemplate ? 'edit' : 'create'}
         initialData={editingTemplate || undefined}
         isOpen={isModalOpen}
         onClose={handleModalClose}
@@ -429,22 +460,26 @@ interface TemplateCardProps {
   template: WorkoutTemplate;
   currentUserId?: string;
   onToggleFavorite: (template: WorkoutTemplate) => void;
+  onEdit?: (template: WorkoutTemplate) => void;
   onDuplicate: (template: WorkoutTemplate) => void;
   onDelete: (template: WorkoutTemplate) => void;
   onDragStart: (template: WorkoutTemplate) => void;
   onDragEnd: () => void;
   isDragging: boolean;
+  favoritingId?: boolean;
 }
 
 function TemplateCard({
   template,
   currentUserId,
   onToggleFavorite,
+  onEdit,
   onDuplicate,
   onDelete,
   onDragStart,
   onDragEnd,
   isDragging,
+  favoritingId,
 }: TemplateCardProps) {
   const modalityConfig = MODALITY_CONFIG[template.modality as TrainingModality];
 
@@ -463,13 +498,16 @@ function TemplateCard({
       </div>
 
       {/* Favorite Button — only for own templates (RLS blocks PATCH on community templates) */}
-      {(!currentUserId || template.user_id === currentUserId) ? (
+      {(currentUserId && template.user_id === currentUserId) ? (
         <button
           onClick={(e) => {
             e.stopPropagation();
             onToggleFavorite(template);
           }}
-          className="absolute top-3 right-3 p-2 rounded-lg ceramic-inset hover:bg-white/50 transition-colors z-10"
+          disabled={favoritingId}
+          className={`absolute top-3 right-3 p-2 rounded-lg ceramic-inset hover:bg-white/50 transition-colors z-10 ${
+            favoritingId ? 'opacity-50 cursor-wait' : ''
+          }`}
         >
           <Star
             className={`w-4 h-4 ${
@@ -602,8 +640,30 @@ function TemplateCard({
           )}
         </div>
 
-        {/* Actions — #458: Templates are immutable (no Edit button) */}
+        {/* Actions */}
         <div className="flex items-center gap-2 pt-2 border-t border-ceramic-text-secondary/10">
+          {/* Edit — only for own templates that have NOT been prescribed */}
+          {currentUserId && template.user_id === currentUserId && !(template.usage_count > 0) && onEdit && (
+            <button
+              onClick={() => onEdit(template)}
+              className="flex items-center justify-center gap-2 px-3 py-2 ceramic-inset hover:bg-white/50 rounded-lg transition-colors"
+            >
+              <Pencil className="w-3.5 h-3.5 text-ceramic-text-secondary" />
+              <span className="text-xs font-medium text-ceramic-text-primary">Editar</span>
+            </button>
+          )}
+
+          {/* Lock badge — prescribed templates cannot be edited */}
+          {currentUserId && template.user_id === currentUserId && template.usage_count > 0 && (
+            <div
+              className="flex items-center gap-1 px-2 py-2 text-ceramic-text-secondary"
+              title="Prescrito — nao pode ser editado"
+            >
+              <Lock className="w-3.5 h-3.5" />
+              <span className="text-[10px] font-medium">Prescrito</span>
+            </div>
+          )}
+
           <button
             onClick={() => onDuplicate(template)}
             className="flex-1 flex items-center justify-center gap-2 px-3 py-2 ceramic-inset hover:bg-white/50 rounded-lg transition-colors"

--- a/supabase/migrations/20260227130000_flux_exercise_library_fixes.sql
+++ b/supabase/migrations/20260227130000_flux_exercise_library_fixes.sql
@@ -1,0 +1,40 @@
+-- Migration: flux_exercise_library_fixes
+-- Add usage_count tracking to workout_templates via trigger on workout_slots
+
+-- 1. Add usage_count column to workout_templates
+ALTER TABLE public.workout_templates
+  ADD COLUMN IF NOT EXISTS usage_count INTEGER NOT NULL DEFAULT 0;
+
+-- 2. Create trigger function to maintain usage_count
+CREATE OR REPLACE FUNCTION public.update_template_usage_count()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF TG_OP = 'INSERT' AND NEW.template_id IS NOT NULL THEN
+    UPDATE workout_templates SET usage_count = usage_count + 1 WHERE id = NEW.template_id;
+  ELSIF TG_OP = 'DELETE' AND OLD.template_id IS NOT NULL THEN
+    UPDATE workout_templates SET usage_count = GREATEST(0, usage_count - 1) WHERE id = OLD.template_id;
+  ELSIF TG_OP = 'UPDATE' THEN
+    IF OLD.template_id IS DISTINCT FROM NEW.template_id THEN
+      IF OLD.template_id IS NOT NULL THEN
+        UPDATE workout_templates SET usage_count = GREATEST(0, usage_count - 1) WHERE id = OLD.template_id;
+      END IF;
+      IF NEW.template_id IS NOT NULL THEN
+        UPDATE workout_templates SET usage_count = usage_count + 1 WHERE id = NEW.template_id;
+      END IF;
+    END IF;
+  END IF;
+  RETURN COALESCE(NEW, OLD);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 3. Create trigger on workout_slots
+DROP TRIGGER IF EXISTS trg_template_usage_count ON public.workout_slots;
+CREATE TRIGGER trg_template_usage_count
+  AFTER INSERT OR UPDATE OR DELETE ON public.workout_slots
+  FOR EACH ROW EXECUTE FUNCTION public.update_template_usage_count();
+
+-- 4. Backfill existing usage counts from workout_slots
+UPDATE public.workout_templates wt
+SET usage_count = (
+  SELECT COUNT(*) FROM public.workout_slots ws WHERE ws.template_id = wt.id
+);


### PR DESCRIPTION
## Summary
- **#537** Fix favoritar 406: guard handles null user, debounce rapid clicks, Star only active for owner
- **#538** Allow editing own templates where `usage_count === 0` via TemplateFormDrawer edit mode  
- **#539** Add modality instruction text + visual ring cue when no modality selected
- **#540** Clarify visibility copy: "Voce e seus atletas" / "Marketplace da Aica" + info text
- **#542** Add `usage_count` column + DB trigger on `workout_slots` + prescribed immutability rule
- **#536** Clickable dashboard groups (navigate to CRM with filters), "Resumo Geral" section, assessoria header clickable

## Changes

| File | Changes |
|------|---------|
| `supabase/migrations/20260227130000_flux_exercise_library_fixes.sql` | NEW: usage_count column + trigger + backfill |
| `src/modules/flux/services/workoutTemplateService.ts` | usage_count guard in updateTemplateV2, warning log in delete |
| `src/modules/flux/views/TemplateLibraryView.tsx` | Fix favorite guard, add Edit/Lock buttons, debounce, delete warning |
| `src/modules/flux/components/forms/TemplateFormDrawer.tsx` | Modality instruction, visibility copy, info text |
| `src/modules/flux/components/coach/AdminDashboardSection.tsx` | Clickable groups, summary section, useNavigate |
| `src/modules/flux/views/FluxDashboard.tsx` | Assessoria header clickable, templateCount prop |

## Test plan
- [ ] `npm run build` passes
- [ ] `npm run typecheck` passes (pre-existing errors only)
- [ ] Favorite toggle on own templates works without 406
- [ ] Star disabled on community templates (not owned)
- [ ] Duplicate → Edit flow: duplicated card has Edit button
- [ ] Prescribed template (usage_count > 0): Edit hidden, Lock icon shown
- [ ] "Novo Exercicio" form: modality instruction visible, ring cue
- [ ] Visibility copy updated: "Voce e seus atletas" / "Marketplace da Aica"
- [ ] Dashboard: clickable status/modality/level cards navigate to CRM with filters
- [ ] Dashboard: "Resumo Geral" section shows correct counts
- [ ] Assessoria header clickable → navigates to Connections
- [ ] Delete prescribed template shows warning with usage count

## Notes
- Firebase Storage logo upload (#536 partial) deferred — requires Firebase SDK installation
- Assessoria 1-per-user limit already implemented in service (verified, no change needed)
- Migration needs `npx supabase db push` after merge

Closes #536 #537 #538 #539 #540 #542

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Dashboard sections (status groups, modalities, levels) are now clickable for quick filtering.
  * Added General Summary panel displaying active athletes, exercises in library, and athletes in blocks.
  * Templates can now be edited if not actively prescribed; prescribed templates display a lock indicator.

* **Improvements**
  * Enhanced template visibility labels and added contextual hints for better clarity.
  * Improved template favoriting with smoother interactions.
  * System now tracks template usage to prevent editing of prescribed templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->