### PR TITLE
fix(flux): resolve 9 exercise library issues (#543-#552)

### DIFF
--- a/src/modules/flux/components/canvas/MicrocycleGrid.tsx
+++ b/src/modules/flux/components/canvas/MicrocycleGrid.tsx
@@ -63,11 +63,11 @@ interface MicrocycleGridProps {
 
 const WEEKDAYS_SHORT = ['S', 'T', 'Q', 'Q', 'S', 'S', 'D'] as const;
 
-const WEEK_LABELS: Record<number, string> = {
-  1: 'Base',
-  2: 'Progressao',
-  3: 'Intensidade',
-  4: 'Recuperacao',
+const MODALITY_ICONS: Record<string, string> = {
+  swimming: '\u{1F3CA}',
+  running: '\u{1F3C3}',
+  cycling: '\u{1F6B4}',
+  strength: '\u{1F4AA}',
 };
 
 /**
@@ -149,6 +149,7 @@ interface WorkoutPillProps {
 
 const WorkoutPill: React.FC<WorkoutPillProps> = ({ workout, onClick }) => {
   const style = MODALITY_PILL_STYLES[workout.modality];
+  const icon = MODALITY_ICONS[workout.modality] || '\u{1F3CB}\u{FE0F}';
 
   return (
     <motion.button
@@ -161,7 +162,7 @@ const WorkoutPill: React.FC<WorkoutPillProps> = ({ workout, onClick }) => {
         color: style.text,
       }}
     >
-      {workout.name}
+      {icon} {workout.name} <span className="opacity-70">{workout.duration}&prime;</span>
     </motion.button>
   );
 };
@@ -284,8 +285,6 @@ const WeekStrip: React.FC<WeekStripProps> = ({
     [workouts]
   );
 
-  const label = WEEK_LABELS[weekNumber] || `Semana ${weekNumber}`;
-
   return (
     <motion.div
       variants={staggerItem}
@@ -308,9 +307,6 @@ const WeekStrip: React.FC<WeekStripProps> = ({
           <h3 className="text-sm font-bold text-ceramic-text-primary">
             Semana {weekNumber}
           </h3>
-          <span className="text-[10px] font-medium text-ceramic-text-tertiary uppercase tracking-wider">
-            {label}
-          </span>
           {absoluteWeek && (
             <span className="text-[9px] font-medium text-ceramic-text-tertiary">
               ({getPeriodizationLabel(absoluteWeek)})

--- a/src/modules/flux/components/canvas/WeeklyGrid.tsx
+++ b/src/modules/flux/components/canvas/WeeklyGrid.tsx
@@ -90,14 +90,11 @@ const INTENSITY_LABELS: Record<string, string> = {
   high: 'Intenso',
 };
 
-const WEEK_FOCUS_LABELS: Record<number, string> = {
-  1: 'Base',
-  2: 'Progressao',
-  3: 'Recuperacao',
-};
-
-const PHASE_LABEL = (weekNumber: number): string => {
-  return WEEK_FOCUS_LABELS[weekNumber] || `Semana ${weekNumber}`;
+const MODALITY_ICONS: Record<string, string> = {
+  swimming: '\u{1F3CA}',
+  running: '\u{1F3C3}',
+  cycling: '\u{1F6B4}',
+  strength: '\u{1F4AA}',
 };
 
 // ============================================
@@ -174,6 +171,7 @@ interface PositionedWorkoutCardProps {
 const PositionedWorkoutCard = React.forwardRef<HTMLDivElement, PositionedWorkoutCardProps>(
   ({ workout, onClick, onDelete }, ref) => {
   const colors = MODALITY_COLORS[workout.modality] || MODALITY_COLORS.running;
+  const icon = MODALITY_ICONS[workout.modality] || '\u{1F3CB}\u{FE0F}';
   const top = workout.start_time ? timeToY(workout.start_time) : 0;
   const height = durationToHeight(workout.duration);
   const endTime = workout.start_time ? addMinutesToTime(workout.start_time, workout.duration) : '';
@@ -217,7 +215,7 @@ const PositionedWorkoutCard = React.forwardRef<HTMLDivElement, PositionedWorkout
             className="text-[11px] font-semibold leading-tight line-clamp-2"
             style={{ color: colors.text }}
           >
-            {workout.name}
+            {icon} {workout.name}
           </h5>
           <div className="flex items-center gap-0.5 flex-shrink-0">
             {onDelete && (
@@ -540,11 +538,8 @@ export const WeeklyGrid: React.FC<WeeklyGridProps> = ({
               <Calendar className="w-4 h-4 text-[#7B8FA2]" />
             </div>
             <div>
-              <p className="text-[10px] text-ceramic-text-secondary font-medium uppercase tracking-wider">
-                Semana {weekNumber}
-              </p>
               <h2 className="text-base font-bold text-ceramic-text-primary">
-                {PHASE_LABEL(weekNumber)}
+                Semana {weekNumber}
               </h2>
             </div>
           </div>

--- a/src/modules/flux/components/forms/SeriesEditor.tsx
+++ b/src/modules/flux/components/forms/SeriesEditor.tsx
@@ -258,17 +258,6 @@ function DistanceInput({
         <div className="flex rounded-lg overflow-hidden border border-ceramic-text-secondary/20">
           <button
             type="button"
-            onClick={() => setDisplayUnit('m')}
-            className={`px-2.5 py-1.5 text-xs font-medium transition-all ${
-              displayUnit === 'm'
-                ? 'bg-ceramic-accent text-white'
-                : 'bg-white/50 text-ceramic-text-secondary hover:bg-white/80'
-            }`}
-          >
-            M
-          </button>
-          <button
-            type="button"
             onClick={() => setDisplayUnit('km')}
             className={`px-2.5 py-1.5 text-xs font-medium transition-all ${
               displayUnit === 'km'
@@ -276,7 +265,18 @@ function DistanceInput({
                 : 'bg-white/50 text-ceramic-text-secondary hover:bg-white/80'
             }`}
           >
-            Km
+            km
+          </button>
+          <button
+            type="button"
+            onClick={() => setDisplayUnit('m')}
+            className={`px-2.5 py-1.5 text-xs font-medium transition-all ${
+              displayUnit === 'm'
+                ? 'bg-ceramic-accent text-white'
+                : 'bg-white/50 text-ceramic-text-secondary hover:bg-white/80'
+            }`}
+          >
+            m
           </button>
         </div>
       </div>
@@ -497,17 +497,6 @@ function IntervalInput({
           <div className="flex rounded-lg overflow-hidden border border-ceramic-text-secondary/20">
             <button
               type="button"
-              onClick={() => onDistUnitChange('m')}
-              className={`px-2.5 py-1.5 text-xs font-medium transition-all ${
-                intervalDistUnit === 'm'
-                  ? 'bg-ceramic-accent text-white'
-                  : 'bg-white/50 text-ceramic-text-secondary hover:bg-white/80'
-              }`}
-            >
-              M
-            </button>
-            <button
-              type="button"
               onClick={() => onDistUnitChange('km')}
               className={`px-2.5 py-1.5 text-xs font-medium transition-all ${
                 intervalDistUnit === 'km'
@@ -515,7 +504,18 @@ function IntervalInput({
                   : 'bg-white/50 text-ceramic-text-secondary hover:bg-white/80'
               }`}
             >
-              Km
+              km
+            </button>
+            <button
+              type="button"
+              onClick={() => onDistUnitChange('m')}
+              className={`px-2.5 py-1.5 text-xs font-medium transition-all ${
+                intervalDistUnit === 'm'
+                  ? 'bg-ceramic-accent text-white'
+                  : 'bg-white/50 text-ceramic-text-secondary hover:bg-white/80'
+              }`}
+            >
+              m
             </button>
           </div>
         </div>
@@ -686,15 +686,23 @@ function SwimmingFields({ series, onUpdate }: { series: SwimmingSeries; onUpdate
 // ============================================================================
 
 function CyclingFields({ series, onUpdate }: { series: CyclingSeries; onUpdate: (u: Partial<CyclingSeries>) => void }) {
+  const [estimationType, setEstimationType] = useState<'speed' | 'power'>('speed');
   const isTime = series.work_unit === 'time';
 
-  // Duration in min/seg for time mode
-  const durationMin = isTime && series.unit_detail === 'minutes'
-    ? Math.floor(series.work_value)
-    : isTime ? Math.floor(series.work_value / 60) : 0;
-  const durationSec = isTime && series.unit_detail === 'minutes'
-    ? 0
-    : isTime ? Math.round(series.work_value % 60) : 0;
+  // Convert work_value to h/min/seg for time mode (#545)
+  const totalSeconds = isTime && series.unit_detail === 'minutes'
+    ? series.work_value * 60
+    : isTime && series.unit_detail === 'seconds'
+      ? series.work_value
+      : 0;
+  const durationHours = Math.floor(totalSeconds / 3600);
+  const durationMin = Math.floor((totalSeconds % 3600) / 60);
+  const durationSec = Math.round(totalSeconds % 60);
+
+  const updateTimeFromParts = (h: number, m: number, s: number) => {
+    const total = h * 3600 + m * 60 + s;
+    onUpdate({ work_value: total, unit_detail: 'seconds' });
+  };
 
   // For distance mode: read cycling duration from extra fields (#427)
   const cyclingSeries = series as CyclingSeries;
@@ -709,7 +717,7 @@ function CyclingFields({ series, onUpdate }: { series: CyclingSeries; onUpdate: 
         <div className="flex gap-2">
           <button
             type="button"
-            onClick={() => onUpdate({ work_unit: 'time', unit_detail: 'minutes' })}
+            onClick={() => onUpdate({ work_value: 0, work_unit: 'time', unit_detail: 'minutes' })}
             className={`flex-1 flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-xs font-medium transition-all ${
               isTime
                 ? 'bg-ceramic-accent text-white'
@@ -721,7 +729,7 @@ function CyclingFields({ series, onUpdate }: { series: CyclingSeries; onUpdate: 
           </button>
           <button
             type="button"
-            onClick={() => onUpdate({ work_unit: 'distance', unit_detail: 'meters' })}
+            onClick={() => onUpdate({ work_value: 0, work_unit: 'distance', unit_detail: 'meters' })}
             className={`flex-1 flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-xs font-medium transition-all ${
               !isTime
                 ? 'bg-ceramic-accent text-white'
@@ -734,17 +742,48 @@ function CyclingFields({ series, onUpdate }: { series: CyclingSeries; onUpdate: 
         </div>
       </div>
 
-      {/* Time mode: only DurationInput. Distance mode: only DistanceInput + duration (#453) */}
+      {/* Time mode: h + min + seg (#545). Distance mode: only DistanceInput + duration (#453) */}
       {isTime && (
-        <DurationInput
-          label="Duração"
-          minutes={durationMin}
-          seconds={durationSec}
-          onMinutesChange={(min) => onUpdate({ work_value: min, unit_detail: 'minutes' })}
-          onSecondsChange={(sec) => {
-            onUpdate({ work_value: durationMin * 60 + sec, unit_detail: 'seconds' });
-          }}
-        />
+        <div>
+          <label className="block text-xs font-medium text-ceramic-text-secondary mb-1">Duração</label>
+          <div className="flex items-center gap-2">
+            <div className="flex items-center gap-1">
+              <input
+                type="number"
+                min="0"
+                step="1"
+                value={durationHours}
+                onChange={(e) => updateTimeFromParts(parseInt(e.target.value) || 0, durationMin, durationSec)}
+                className="w-16 px-2 py-2 rounded-lg border border-ceramic-text-secondary/20 bg-white/50 text-ceramic-text-primary focus:outline-none focus:ring-2 focus:ring-ceramic-accent/50 text-center"
+              />
+              <span className="text-xs text-ceramic-text-secondary font-medium">h</span>
+            </div>
+            <div className="flex items-center gap-1">
+              <input
+                type="number"
+                min="0"
+                max="59"
+                step="1"
+                value={durationMin}
+                onChange={(e) => updateTimeFromParts(durationHours, Math.min(59, parseInt(e.target.value) || 0), durationSec)}
+                className="w-16 px-2 py-2 rounded-lg border border-ceramic-text-secondary/20 bg-white/50 text-ceramic-text-primary focus:outline-none focus:ring-2 focus:ring-ceramic-accent/50 text-center"
+              />
+              <span className="text-xs text-ceramic-text-secondary font-medium">min</span>
+            </div>
+            <div className="flex items-center gap-1">
+              <input
+                type="number"
+                min="0"
+                max="59"
+                step="1"
+                value={durationSec}
+                onChange={(e) => updateTimeFromParts(durationHours, durationMin, Math.min(59, parseInt(e.target.value) || 0))}
+                className="w-16 px-2 py-2 rounded-lg border border-ceramic-text-secondary/20 bg-white/50 text-ceramic-text-primary focus:outline-none focus:ring-2 focus:ring-ceramic-accent/50 text-center"
+              />
+              <span className="text-xs text-ceramic-text-secondary font-medium">seg</span>
+            </div>
+          </div>
+        </div>
       )}
       {!isTime && (
         <>
@@ -764,6 +803,68 @@ function CyclingFields({ series, onUpdate }: { series: CyclingSeries; onUpdate: 
             onHoursChange={(h) => onUpdate({ cycling_duration_hours: h } as Partial<CyclingSeries>)}
             onMinutesChange={(m) => onUpdate({ cycling_duration_minutes: m } as Partial<CyclingSeries>)}
           />
+
+          {/* Estimated Speed/Power (#548) */}
+          <div>
+            <label className="block text-xs font-medium text-ceramic-text-secondary mb-1">Estimativas (opcional)</label>
+            <div className="flex gap-2 mb-2">
+              <button
+                type="button"
+                onClick={() => setEstimationType('speed')}
+                className={`flex-1 px-2 py-1.5 rounded-lg text-xs font-medium transition-all ${
+                  estimationType === 'speed'
+                    ? 'bg-ceramic-accent text-white'
+                    : 'ceramic-inset hover:bg-white/50 text-ceramic-text-primary'
+                }`}
+              >
+                Velocidade (km/h)
+              </button>
+              <button
+                type="button"
+                onClick={() => setEstimationType('power')}
+                className={`flex-1 px-2 py-1.5 rounded-lg text-xs font-medium transition-all ${
+                  estimationType === 'power'
+                    ? 'bg-ceramic-accent text-white'
+                    : 'ceramic-inset hover:bg-white/50 text-ceramic-text-primary'
+                }`}
+              >
+                Potência (W)
+              </button>
+            </div>
+            {estimationType === 'speed' ? (
+              <div className="flex items-center gap-2">
+                <input
+                  type="number"
+                  min="0"
+                  step="0.5"
+                  value={series.estimated_speed_kmh || ''}
+                  onChange={(e) => onUpdate({
+                    estimated_speed_kmh: parseFloat(e.target.value) || 0,
+                    estimated_power_watts: undefined,
+                  } as Partial<CyclingSeries>)}
+                  placeholder="0"
+                  className="w-28 px-3 py-2 rounded-lg border border-ceramic-text-secondary/20 bg-white/50 text-ceramic-text-primary focus:outline-none focus:ring-2 focus:ring-ceramic-accent/50 text-center"
+                />
+                <span className="text-xs text-ceramic-text-secondary font-medium">km/h</span>
+              </div>
+            ) : (
+              <div className="flex items-center gap-2">
+                <input
+                  type="number"
+                  min="0"
+                  step="5"
+                  value={series.estimated_power_watts || ''}
+                  onChange={(e) => onUpdate({
+                    estimated_power_watts: parseInt(e.target.value) || 0,
+                    estimated_speed_kmh: undefined,
+                  } as Partial<CyclingSeries>)}
+                  placeholder="0"
+                  className="w-28 px-3 py-2 rounded-lg border border-ceramic-text-secondary/20 bg-white/50 text-ceramic-text-primary focus:outline-none focus:ring-2 focus:ring-ceramic-accent/50 text-center"
+                />
+                <span className="text-xs text-ceramic-text-secondary font-medium">W</span>
+              </div>
+            )}
+          </div>
         </>
       )}
 

--- a/src/modules/flux/components/forms/TemplateFormDrawer.tsx
+++ b/src/modules/flux/components/forms/TemplateFormDrawer.tsx
@@ -219,8 +219,8 @@ export default function TemplateFormDrawer({
               </button>
             </div>
 
-            {/* Timeline Visual — sticky above form (#465) */}
-            {formData.exercise_structure?.series && formData.exercise_structure.series.length > 0 && (
+            {/* Timeline Visual — sticky above form (#465), hidden for strength (#551) */}
+            {formData.modality !== 'strength' && formData.exercise_structure?.series && formData.exercise_structure.series.length > 0 && (
               <div className="px-6 py-3 border-b border-ceramic-text-secondary/10 bg-ceramic-base/95 backdrop-blur-sm">
                 <TimelineVisual series={formData.exercise_structure.series} />
               </div>

--- a/src/modules/flux/types/series.ts
+++ b/src/modules/flux/types/series.ts
@@ -120,6 +120,8 @@ export interface CyclingSeries extends SeriesBase {
   zone: IntensityZone;
   cycling_duration_hours?: number; // Hours when in distance mode
   cycling_duration_minutes?: number; // Minutes when in distance mode
+  estimated_speed_kmh?: number; // Estimated speed in km/h (distance mode)
+  estimated_power_watts?: number; // Estimated power in watts (distance mode)
 }
 
 /**

--- a/src/modules/flux/views/TemplateLibraryView.tsx
+++ b/src/modules/flux/views/TemplateLibraryView.tsx
@@ -72,6 +72,39 @@ const ZONE_PILL_COLORS: Record<string, string> = {
   Z5: 'bg-red-600',
 };
 
+/** Format work value for display on library cards */
+function formatWorkValue(value: number, unit: string, unitDetail?: string): string {
+  if (unit === 'seconds' || unitDetail === 'seconds') {
+    const h = Math.floor(value / 3600);
+    const m = Math.floor((value % 3600) / 60);
+    const s = Math.round(value % 60);
+    const parts: string[] = [];
+    if (h > 0) parts.push(`${h}h`);
+    if (m > 0) parts.push(`${m}min`);
+    if (s > 0 && h === 0) parts.push(`${s}s`);
+    return parts.join(' ') || '0s';
+  }
+  if (unit === 'minutes' || unitDetail === 'minutes') {
+    const h = Math.floor(value / 60);
+    const m = Math.round(value % 60);
+    if (h > 0 && m > 0) return `${h}h ${m}min`;
+    if (h > 0) return `${h}h`;
+    return `${m}min`;
+  }
+  if (unit === 'meters' || unitDetail === 'meters') {
+    if (value >= 1000) return `${(value / 1000).toFixed(1).replace('.0', '')}km`;
+    return `${value}m`;
+  }
+  if (unit === 'time') {
+    // Cycling time mode - delegate to detail
+    return formatWorkValue(value, unitDetail || 'minutes');
+  }
+  if (unit === 'distance') {
+    return formatWorkValue(value, unitDetail || 'meters');
+  }
+  return `${value}`;
+}
+
 /** Extract unique zones from V2 exercise_structure */
 function getUniqueZones(es: any): string[] {
   if (!es?.series || !Array.isArray(es.series)) return [];
@@ -105,6 +138,7 @@ export default function TemplateLibraryView() {
   const [isModalOpen, setModalOpen] = useState(mode !== 'list');
   const [editingTemplate, setEditingTemplate] = useState<WorkoutTemplate | null>(null);
   const [favoritingIds, setFavoritingIds] = useState<Set<string>>(new Set());
+  const [groupByModality, setGroupByModality] = useState(false);
 
   // Apply filters
   useEffect(() => {
@@ -356,19 +390,33 @@ export default function TemplateLibraryView() {
             </div>
           </div>
 
-          {/* Favorites Toggle + Clear */}
+          {/* Favorites Toggle + Group by Modality + Clear */}
           <div className="flex items-center justify-between">
-            <label className="flex items-center gap-2 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={filters.favorites_only || false}
-                onChange={(e) => handleFilterChange('favorites_only', e.target.checked || undefined)}
-                className="w-4 h-4 rounded border-ceramic-text-secondary/20"
-              />
-              <span className="text-sm font-medium text-ceramic-text-primary">
-                Apenas favoritos
-              </span>
-            </label>
+            <div className="flex items-center gap-4">
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={filters.favorites_only || false}
+                  onChange={(e) => handleFilterChange('favorites_only', e.target.checked || undefined)}
+                  className="w-4 h-4 rounded border-ceramic-text-secondary/20"
+                />
+                <span className="text-sm font-medium text-ceramic-text-primary">
+                  Apenas favoritos
+                </span>
+              </label>
+
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={groupByModality}
+                  onChange={(e) => setGroupByModality(e.target.checked)}
+                  className="w-4 h-4 rounded border-ceramic-text-secondary/20"
+                />
+                <span className="text-sm font-medium text-ceramic-text-primary">
+                  Agrupar por modalidade
+                </span>
+              </label>
+            </div>
 
             {activeFiltersCount > 0 && (
               <button
@@ -418,6 +466,42 @@ export default function TemplateLibraryView() {
               <Plus className="w-4 h-4" />
               <span className="font-medium">Criar Exercício</span>
             </button>
+          </div>
+        ) : groupByModality ? (
+          <div className="space-y-8">
+            {(['swimming', 'running', 'cycling', 'strength', 'walking'] as TrainingModality[])
+              .map((mod) => {
+                const modTemplates = filteredTemplates.filter((t) => t.modality === mod);
+                if (modTemplates.length === 0) return null;
+                const config = MODALITY_CONFIG[mod];
+                return (
+                  <div key={mod}>
+                    <div className="flex items-center gap-2 mb-4">
+                      <span className="text-xl">{config?.icon}</span>
+                      <h3 className="text-lg font-bold text-ceramic-text-primary">{config?.label}</h3>
+                      <span className="text-sm text-ceramic-text-secondary">({modTemplates.length})</span>
+                    </div>
+                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                      {modTemplates.map((template) => (
+                        <TemplateCard
+                          key={template.id}
+                          template={template}
+                          currentUserId={user?.id}
+                          onToggleFavorite={handleToggleFavorite}
+                          onEdit={handleEdit}
+                          onDuplicate={handleDuplicate}
+                          onDelete={handleDelete}
+                          onDragStart={handleDragStart}
+                          onDragEnd={handleDragEnd}
+                          isDragging={draggedTemplate?.id === template.id}
+                          favoritingId={favoritingIds.has(template.id)}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                );
+              })
+              .filter(Boolean)}
           </div>
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
@@ -587,12 +671,10 @@ function TemplateCard({
                 </span>
                 <span className="line-clamp-2">
                   {es.series.map((s: any) => {
-                    if (s.reps) return `${s.reps} rep`;
-                    if (s.distance_meters) return `${s.distance_meters}m`;
-                    if (s.work_value) {
-                      const unit = s.work_unit === 'minutes' ? 'min' : s.work_unit === 'seconds' ? 's' : 'm';
-                      return `${s.work_value}${unit}`;
-                    }
+                    if (s.exercise_name) return s.exercise_name;
+                    if (s.reps) return `${s.reps} rep${s.load_kg ? ` ${s.load_kg}kg` : ''}`;
+                    if (s.distance_meters) return formatWorkValue(s.distance_meters, 'meters');
+                    if (s.work_value) return formatWorkValue(s.work_value, s.work_unit, s.unit_detail);
                     return 'série';
                   }).join(' + ')}
                 </span>


### PR DESCRIPTION
## Summary
- **#550**: Distance unit labels `M`→`m`, `Km`→`km`, button order swapped (`km` first)
- **#547**: Reset `work_value` to 0 on Cycling Time↔Distance toggle (prevents value leaking)
- **#545**: Add hours field to Cycling time mode (h/min/seg — matches Running pattern)
- **#548**: Add estimated speed (km/h) / power (W) toggle fields to Cycling distance mode
- **#543**: Format time display on library cards (`5min` instead of `300s`)
- **#551**: Hide timeline visual when modality is strength (FORÇA)
- **#544**: Add "Agrupar por modalidade" checkbox to template library — groups cards with section headers
- **#552**: Remove week phase labels (Base, Progressão...) from canvas grids, add modality icons + duration to workout pills/cards
- **#549**: Verified strength distance fields already exist — close after deployment

## Files Changed (6)
| File | Changes |
|------|---------|
| `SeriesEditor.tsx` | #550, #547, #545, #548 |
| `types/series.ts` | #548 (added `estimated_speed_kmh`, `estimated_power_watts`) |
| `TemplateLibraryView.tsx` | #543, #544 |
| `TemplateFormDrawer.tsx` | #551 |
| `MicrocycleGrid.tsx` | #552 |
| `WeeklyGrid.tsx` | #552 |

## Test plan
- [x] `npm run build` passes
- [ ] Cycling: toggle Time↔Distance, values reset to 0
- [ ] Cycling Time mode: hours field visible and functional
- [ ] Cycling Distance mode: Speed/Power toggle visible
- [ ] Strength: no timeline shown in form
- [ ] Library cards: time displayed as h/min (not raw seconds)
- [ ] Distance buttons: "km" first, then "m" (lowercase)
- [ ] Canvas: no week phase labels, clean week selectors
- [ ] Library: "Agrupar por modalidade" checkbox groups cards correctly

Closes #543, #544, #545, #547, #548, #549, #550, #551, #552

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workouts now display with modality icons for quick identification
  * Template library can be grouped and organized by training modality
  * Cycling exercises now support speed and power estimation inputs

* **Improvements**
  * Enhanced cycling form interface with improved time and distance mode handling
  * Template cards now display additional exercise details for better clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->