### PR TITLE
fix(multi): resolve 3 remaining bugs — Chat crash and Flux distance fields (#554-#556)

### DIFF
--- a/src/components/features/AicaChatFAB/ChatContextSidebar.tsx
+++ b/src/components/features/AicaChatFAB/ChatContextSidebar.tsx
@@ -138,7 +138,9 @@ function InsightCard({ insight }: { insight: LifeCouncilInsight }) {
       )}
       {insight.actionItems.length > 0 && (
         <ul className="aica-context-card__list">
-          {insight.actionItems.slice(0, 2).map((item, i) => <li key={i}>{item}</li>)}
+          {insight.actionItems.slice(0, 2).map((item, i) => (
+            <li key={i}>{typeof item === 'string' ? item : item.action}</li>
+          ))}
         </ul>
       )}
     </div>

--- a/src/modules/flux/components/forms/SeriesEditor.tsx
+++ b/src/modules/flux/components/forms/SeriesEditor.tsx
@@ -413,6 +413,8 @@ function IntervalInput({
 }) {
   // Determine step for distance based on modality
   const distStep = modality === 'swimming' ? 25 : 100;
+  // Strength athletes are stationary — interval is time-only (#554)
+  const showDistanceToggle = modality !== 'strength';
 
   const distDisplayValue = intervalDistUnit === 'km' ? distanceMeters / 1000 : distanceMeters;
   const distDisplayStep = intervalDistUnit === 'km' ? 0.1 : distStep;
@@ -422,11 +424,15 @@ function IntervalInput({
     onDistanceChange(inMeters);
   };
 
+  // For strength, force time mode
+  const effectiveMode = showDistanceToggle ? intervalMode : 'time';
+
   return (
     <div>
       <label className="block text-xs font-medium text-ceramic-text-secondary mb-1">Intervalo</label>
 
-      {/* Mode toggle */}
+      {/* Mode toggle — hidden for strength (#554) */}
+      {showDistanceToggle && (
       <div className="flex gap-2 mb-2">
         <button
           type="button"
@@ -453,9 +459,10 @@ function IntervalInput({
           Distância
         </button>
       </div>
+      )}
 
       {/* Time mode */}
-      {intervalMode === 'time' ? (
+      {effectiveMode === 'time' ? (
         <div className="flex items-center gap-2">
           <div className="flex items-center gap-1">
             <input
@@ -907,13 +914,6 @@ function StrengthFields({ series, onUpdate }: { series: StrengthSeries; onUpdate
           <span className="text-xs text-ceramic-text-secondary font-medium">kg</span>
         </div>
       </div>
-      {/* Distance for strength exercises like farmer's walks, sled pushes (#454) */}
-      <DistanceInput
-        label="Distância (opcional)"
-        meters={series.distance_meters || 0}
-        onChange={(meters) => onUpdate({ distance_meters: meters } as Partial<StrengthSeries>)}
-        stepMeters={10}
-      />
     </>
   );
 }

--- a/src/services/userAIContextService.ts
+++ b/src/services/userAIContextService.ts
@@ -24,11 +24,13 @@ export interface UserPattern {
   confidence: number
 }
 
+export type ActionItem = string | { action: string; module: string; priority: string }
+
 export interface LifeCouncilInsight {
   overallStatus: string
   headline: string
   synthesis: string
-  actionItems: string[]
+  actionItems: ActionItem[]
   createdAt: string
 }
 


### PR DESCRIPTION
## Summary
- **#555/#556**: Fix Chat `InsightCard` crash — `actionItems` from `daily_council_insights` can be objects `{action, module, priority}`, not just strings. Updated type + render to handle both.
- **#554**: Remove "Distância" field from strength exercises in Flux. Strength athletes stay stationary. Also hide time/distance toggle in interval section for strength modality.

## Test plan
- [ ] `npm run build` passes
- [ ] Open Chat, type "Tirar carteira de identidade" → no crash, insight card renders correctly
- [ ] Flux: create strength exercise → no "Distância" field visible
- [ ] Flux: create interval for running → "Distância" field available
- [ ] Flux: create interval for strength → only time inputs, no distance toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced action items to support structured data with action, module, and priority fields.

* **Improvements**
  * Simplified strength interval configuration by removing distance mode toggle; strength intervals now operate in time-only mode.
  * Improved action items rendering to display up to two items with better type handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->