### PR TITLE
feat(vida,privacy): daily questions carousel + infra region audit (#560, #564)

### DIFF
--- a/src/components/features/VidaUniversalInput/DailyQuestionsCarousel.tsx
+++ b/src/components/features/VidaUniversalInput/DailyQuestionsCarousel.tsx
@@ -1,0 +1,180 @@
+/**
+ * DailyQuestionsCarousel — Swipeable question carousel for VidaPage
+ *
+ * Uses CSS scroll-snap for smooth native-feel swiping.
+ * Auto-advances every 8 seconds. Dot indicators show position.
+ * Tapping a question sends it to the chat input.
+ */
+
+import { useRef, useState, useEffect, useCallback } from 'react'
+import { useDailyQuestions, type DailyQuestionItem } from './useDailyQuestions'
+import {
+  QUESTION_CATEGORY_COLORS,
+  type QuestionCategory,
+} from '@/modules/journey/types/dailyQuestion'
+
+const AUTO_ADVANCE_MS = 8000
+
+interface DailyQuestionsCarouselProps {
+  onSelectQuestion: (text: string) => void
+}
+
+export function DailyQuestionsCarousel({ onSelectQuestion }: DailyQuestionsCarouselProps) {
+  const { questions, isLoading } = useDailyQuestions()
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const [activeIndex, setActiveIndex] = useState(0)
+  const autoAdvanceRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const userInteractedRef = useRef(false)
+
+  // Track active index from scroll position
+  const handleScroll = useCallback(() => {
+    const el = scrollRef.current
+    if (!el) return
+    const scrollLeft = el.scrollLeft
+    const itemWidth = el.offsetWidth
+    if (itemWidth === 0) return
+    const index = Math.round(scrollLeft / itemWidth)
+    setActiveIndex(Math.min(index, questions.length - 1))
+  }, [questions.length])
+
+  // Scroll to a specific index
+  const scrollToIndex = useCallback((index: number) => {
+    const el = scrollRef.current
+    if (!el) return
+    const targetIndex = index % questions.length
+    el.scrollTo({
+      left: targetIndex * el.offsetWidth,
+      behavior: 'smooth',
+    })
+  }, [questions.length])
+
+  // Auto-advance timer
+  useEffect(() => {
+    if (questions.length <= 1) return
+
+    const startAutoAdvance = () => {
+      if (autoAdvanceRef.current) clearInterval(autoAdvanceRef.current)
+      autoAdvanceRef.current = setInterval(() => {
+        if (!userInteractedRef.current) {
+          setActiveIndex(prev => {
+            const next = (prev + 1) % questions.length
+            scrollToIndex(next)
+            return next
+          })
+        }
+      }, AUTO_ADVANCE_MS)
+    }
+
+    startAutoAdvance()
+
+    return () => {
+      if (autoAdvanceRef.current) clearInterval(autoAdvanceRef.current)
+    }
+  }, [questions.length, scrollToIndex])
+
+  // Pause auto-advance on user interaction, resume after 15s
+  const handleUserInteraction = useCallback(() => {
+    userInteractedRef.current = true
+    const timeout = setTimeout(() => {
+      userInteractedRef.current = false
+    }, 15000)
+    return () => clearTimeout(timeout)
+  }, [])
+
+  // Handle touch/pointer events
+  const handleTouchStart = useCallback(() => {
+    handleUserInteraction()
+  }, [handleUserInteraction])
+
+  // Dot click handler
+  const handleDotClick = useCallback((index: number) => {
+    handleUserInteraction()
+    scrollToIndex(index)
+  }, [handleUserInteraction, scrollToIndex])
+
+  if (isLoading) {
+    return (
+      <div className="h-8 flex items-center justify-center">
+        <div className="w-32 h-3 bg-ceramic-cool rounded-full animate-pulse" />
+      </div>
+    )
+  }
+
+  if (questions.length === 0) return null
+
+  return (
+    <div className="relative">
+      {/* Scrollable carousel */}
+      <div
+        ref={scrollRef}
+        onScroll={handleScroll}
+        onTouchStart={handleTouchStart}
+        onMouseDown={handleTouchStart}
+        className="flex overflow-x-auto snap-x snap-mandatory scrollbar-hide"
+        style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}
+      >
+        {questions.map((q, i) => (
+          <CarouselItem
+            key={q.id}
+            question={q}
+            isActive={i === activeIndex}
+            onSelect={() => onSelectQuestion(q.text)}
+          />
+        ))}
+      </div>
+
+      {/* Dot indicators */}
+      {questions.length > 1 && (
+        <div className="flex items-center justify-center gap-1.5 mt-2">
+          {questions.map((_, i) => (
+            <button
+              key={i}
+              onClick={() => handleDotClick(i)}
+              aria-label={`Pergunta ${i + 1}`}
+              className={`rounded-full transition-all duration-300 ${
+                i === activeIndex
+                  ? 'w-4 h-1.5 bg-amber-500'
+                  : 'w-1.5 h-1.5 bg-ceramic-border hover:bg-ceramic-text-secondary/40'
+              }`}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/** Individual carousel item */
+function CarouselItem({
+  question,
+  isActive,
+  onSelect,
+}: {
+  question: DailyQuestionItem
+  isActive: boolean
+  onSelect: () => void
+}) {
+  const categoryColor = QUESTION_CATEGORY_COLORS[question.category as QuestionCategory] || '#f59e0b'
+
+  return (
+    <button
+      onClick={onSelect}
+      className="w-full shrink-0 snap-center px-1 text-left group"
+      aria-label={question.text}
+    >
+      <div
+        className={`flex items-center gap-2 py-1 transition-opacity duration-300 ${
+          isActive ? 'opacity-100' : 'opacity-60'
+        }`}
+      >
+        <div
+          className="w-1 h-4 rounded-full shrink-0 transition-transform duration-300"
+          style={{ backgroundColor: categoryColor }}
+        />
+        <p className="text-xs text-ceramic-text-secondary group-hover:text-ceramic-text-primary transition-colors line-clamp-1">
+          {question.text}
+        </p>
+      </div>
+    </button>
+  )
+}

--- a/src/components/features/VidaUniversalInput/VidaUniversalInput.tsx
+++ b/src/components/features/VidaUniversalInput/VidaUniversalInput.tsx
@@ -11,13 +11,14 @@
  * 4. Quick chips allow explicit action selection
  */
 
-import { useRef } from 'react'
+import { useRef, useCallback } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import {
   Mic, MicOff, Send, ClipboardList, CalendarPlus,
   Sparkles, MessageCircle, CheckCircle2, Loader2, AlertCircle,
 } from 'lucide-react'
 import { useVidaInputActions, type ActionType } from './useVidaInputActions'
+import { DailyQuestionsCarousel } from './DailyQuestionsCarousel'
 
 const ACTION_ICONS: Record<string, typeof ClipboardList> = {
   clipboard: ClipboardList,
@@ -70,8 +71,20 @@ export function VidaUniversalInput() {
   const isSuccess = actionStatus === 'success'
   const isError = actionStatus === 'error'
 
+  const handleSelectQuestion = useCallback((text: string) => {
+    setInput(text)
+    inputRef.current?.focus()
+  }, [setInput])
+
   return (
     <div className="ceramic-card overflow-hidden">
+      {/* Daily Questions Carousel — above input */}
+      {!input.trim() && (
+        <div className="px-3 pt-3 pb-1">
+          <DailyQuestionsCarousel onSelectQuestion={handleSelectQuestion} />
+        </div>
+      )}
+
       {/* Success / Error flash */}
       <AnimatePresence>
         {isSuccess && (

--- a/src/components/features/VidaUniversalInput/index.ts
+++ b/src/components/features/VidaUniversalInput/index.ts
@@ -1,1 +1,3 @@
 export { VidaUniversalInput } from './VidaUniversalInput'
+export { DailyQuestionsCarousel } from './DailyQuestionsCarousel'
+export { useDailyQuestions } from './useDailyQuestions'

--- a/src/components/features/VidaUniversalInput/useDailyQuestions.ts
+++ b/src/components/features/VidaUniversalInput/useDailyQuestions.ts
@@ -1,0 +1,137 @@
+/**
+ * useDailyQuestions — Hook for carousel daily questions
+ *
+ * Fetches a shuffled batch of daily questions from:
+ * 1. Supabase `daily_questions` table (if user is authenticated)
+ * 2. Fallback to the local pool from dailyQuestionService
+ *
+ * Returns a stable list of questions that rotates daily.
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { supabase } from '@/services/supabaseClient'
+import { useAuth } from '@/hooks/useAuth'
+import { createNamespacedLogger } from '@/lib/logger'
+import type { DailyQuestion } from '@/modules/journey/types/dailyQuestion'
+
+const log = createNamespacedLogger('useDailyQuestions')
+
+/** How many questions to display in the carousel */
+const CAROUSEL_SIZE = 8
+
+/**
+ * Local fallback pool — a curated subset of questions for when DB is unavailable.
+ * These match the dailyQuestionService pool but are kept minimal for the carousel.
+ */
+const FALLBACK_QUESTIONS: Pick<DailyQuestion, 'id' | 'question_text' | 'category'>[] = [
+  { id: 'fb-1', question_text: 'O que voce quer conquistar hoje?', category: 'change' },
+  { id: 'fb-2', question_text: 'Como voce esta se sentindo neste momento?', category: 'reflection' },
+  { id: 'fb-3', question_text: 'Qual area da sua vida precisa de mais atencao?', category: 'reflection' },
+  { id: 'fb-4', question_text: 'O que te deixaria orgulhoso hoje?', category: 'gratitude' },
+  { id: 'fb-5', question_text: 'Como voce pode se cuidar melhor agora?', category: 'energy' },
+  { id: 'fb-6', question_text: 'Qual foi a melhor parte do seu dia?', category: 'gratitude' },
+  { id: 'fb-7', question_text: 'O que voce aprendeu recentemente?', category: 'learning' },
+  { id: 'fb-8', question_text: 'Como voce quer se sentir nesta semana?', category: 'energy' },
+  { id: 'fb-9', question_text: 'Com quem voce gostaria de se reconectar?', category: 'connection' },
+  { id: 'fb-10', question_text: 'O que da sentido ao seu dia a dia?', category: 'purpose' },
+  { id: 'fb-11', question_text: 'Que ideia tem ocupado sua mente?', category: 'creativity' },
+  { id: 'fb-12', question_text: 'Voce tem se movimentado o suficiente?', category: 'health' },
+]
+
+/**
+ * Fisher-Yates shuffle with a daily seed so the order is stable per day
+ * but changes each new day.
+ */
+function shuffleWithDailySeed<T>(array: T[]): T[] {
+  const copy = [...array]
+  // Use day-of-year as seed for deterministic daily shuffle
+  const now = new Date()
+  let seed = now.getFullYear() * 1000 + Math.floor(
+    (now.getTime() - new Date(now.getFullYear(), 0, 0).getTime()) / (1000 * 60 * 60 * 24)
+  )
+
+  // Simple seeded PRNG (mulberry32)
+  function nextRandom(): number {
+    seed |= 0
+    seed = (seed + 0x6d2b79f5) | 0
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = Math.floor(nextRandom() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]]
+  }
+  return copy
+}
+
+export interface DailyQuestionItem {
+  id: string
+  text: string
+  category: string
+}
+
+export function useDailyQuestions() {
+  const { user } = useAuth()
+  const [questions, setQuestions] = useState<DailyQuestionItem[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const fetchedRef = useRef(false)
+
+  const fetchQuestions = useCallback(async () => {
+    try {
+      setIsLoading(true)
+
+      if (user?.id) {
+        // Try fetching from Supabase
+        const { data, error } = await supabase
+          .from('daily_questions')
+          .select('id, question_text, category')
+          .eq('active', true)
+          .limit(30)
+
+        if (!error && data && data.length > 0) {
+          const shuffled = shuffleWithDailySeed(data).slice(0, CAROUSEL_SIZE)
+          setQuestions(shuffled.map(q => ({
+            id: q.id,
+            text: q.question_text,
+            category: q.category,
+          })))
+          return
+        }
+
+        if (error) {
+          log.warn('Failed to fetch daily questions from DB, using fallback:', error.message)
+        }
+      }
+
+      // Fallback: use local pool
+      const shuffled = shuffleWithDailySeed(FALLBACK_QUESTIONS).slice(0, CAROUSEL_SIZE)
+      setQuestions(shuffled.map(q => ({
+        id: q.id,
+        text: q.question_text,
+        category: q.category,
+      })))
+    } catch (err) {
+      log.error('Error in useDailyQuestions:', err)
+      // Ultimate fallback
+      const shuffled = shuffleWithDailySeed(FALLBACK_QUESTIONS).slice(0, CAROUSEL_SIZE)
+      setQuestions(shuffled.map(q => ({
+        id: q.id,
+        text: q.question_text,
+        category: q.category,
+      })))
+    } finally {
+      setIsLoading(false)
+    }
+  }, [user?.id])
+
+  useEffect(() => {
+    if (!fetchedRef.current) {
+      fetchedRef.current = true
+      fetchQuestions()
+    }
+  }, [fetchQuestions])
+
+  return { questions, isLoading }
+}

--- a/src/pages/PrivacyPolicyPage.tsx
+++ b/src/pages/PrivacyPolicyPage.tsx
@@ -278,7 +278,7 @@ export function PrivacyPolicyPage() {
                     <td className="border border-[#E8E6E0] px-4 py-3">Supabase</td>
                     <td className="border border-[#E8E6E0] px-4 py-3">Todos os dados da plataforma</td>
                     <td className="border border-[#E8E6E0] px-4 py-3">Banco de dados, autenticacao, armazenamento</td>
-                    <td className="border border-[#E8E6E0] px-4 py-3">EUA</td>
+                    <td className="border border-[#E8E6E0] px-4 py-3">Brasil (Sao Paulo)</td>
                   </tr>
                   <tr className="bg-[#F8F7F5]">
                     <td className="border border-[#E8E6E0] px-4 py-3">Google Cloud</td>
@@ -352,8 +352,11 @@ export function PrivacyPolicyPage() {
           <section>
             <h2 className="text-2xl font-bold text-[#2B1B17] mb-4">9. Transferencia Internacional de Dados</h2>
             <p className="text-[#5C554B] leading-relaxed mb-4">
-              Seus dados podem ser transferidos para e processados em servidores localizados fora do Brasil,
-              especialmente nos Estados Unidos, onde estao hospedados nossos provedores de infraestrutura.
+              Seus dados primarios sao armazenados e processados em servidores localizados no Brasil
+              (Sao Paulo), onde estao hospedados nosso banco de dados (Supabase) e servidor de aplicacao
+              (Google Cloud Run). Alguns dados podem ser transferidos para servidores nos Estados Unidos
+              para processamento por servicos auxiliares, como inteligencia artificial (Google Gemini API)
+              e autenticacao (Google OAuth).
             </p>
             <p className="text-[#5C554B] leading-relaxed mb-4">
               Para garantir a protecao adequada dos seus dados em transferencias internacionais, adotamos


### PR DESCRIPTION
## Summary
- **#560**: Add swipeable daily questions carousel to Vida page — replaces static "o que você quer fazer" text with a CSS scroll-snap carousel that auto-advances every 8s, has dot indicators, and populates the chat input on tap. Questions come from Supabase `daily_questions` table with local fallback.
- **#564**: Full infrastructure region audit — confirmed Supabase in `sa-east-1` (São Paulo), Cloud Run prod in `southamerica-east1`. Fixed privacy policy page: Supabase location corrected from "EUA" to "Brasil (São Paulo)" and section 9 rewritten to accurately reflect data residency.

## Test plan
- [ ] `npm run build` passes
- [ ] Vida page shows carousel above input when input is empty
- [ ] Carousel auto-advances and responds to swipe/tap
- [ ] Tapping a question fills the input and hides carousel
- [ ] Privacy policy at `/privacy` section 7.1 shows "Brasil (São Paulo)" for Supabase
- [ ] Privacy policy section 9 mentions primary data in Brazil

Closes #560, Closes #564

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Daily Questions Carousel: An interactive swipeable carousel displaying daily questions with automatic advancement and navigation controls. Users can select from curated questions when the input field is empty.

* **Documentation**
  * Updated Privacy Policy to clarify primary data storage locations and data handling practices for auxiliary services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->