### PR TITLE
fix(chat): connect context sidebar to real data sources

### DIFF
--- a/src/components/features/AicaChatFAB/ChatContextSidebar.tsx
+++ b/src/components/features/AicaChatFAB/ChatContextSidebar.tsx
@@ -147,6 +147,28 @@ function InsightCard({ insight }: { insight: LifeCouncilInsight }) {
   )
 }
 
+function ContextSummaryCard({ context }: { context: UserAIContext }) {
+  const summaryParts: string[] = []
+  if (context.pendingTasks > 0) summaryParts.push(`${context.pendingTasks} tarefa${context.pendingTasks > 1 ? 's' : ''} pendente${context.pendingTasks > 1 ? 's' : ''}`)
+  if (context.completedTasksToday > 0) summaryParts.push(`${context.completedTasksToday} concluida${context.completedTasksToday > 1 ? 's' : ''} hoje`)
+  if (context.recentMoments.length > 0) summaryParts.push(`${context.recentMoments.length} momento${context.recentMoments.length > 1 ? 's' : ''} recente${context.recentMoments.length > 1 ? 's' : ''}`)
+  if (context.financeSummary) summaryParts.push(`saldo ${context.financeSummary.balance >= 0 ? 'positivo' : 'negativo'}`)
+
+  if (summaryParts.length === 0) return null
+
+  return (
+    <div className="aica-context-card">
+      <p className="aica-context-card__title text-cyan-600">Resumo do Dia</p>
+      <p style={{ fontSize: 12, margin: '4px 0 2px' }}>
+        Voce tem {summaryParts.join(', ')}.
+      </p>
+      <p className="aica-context-card__label">
+        Pergunte ao AICA para analisar seu dia
+      </p>
+    </div>
+  )
+}
+
 function renderCards(module: string, context: UserAIContext): React.ReactNode {
   switch (module) {
     case 'atlas':
@@ -172,7 +194,7 @@ function renderCards(module: string, context: UserAIContext): React.ReactNode {
       return (
         <>
           <ListCard title="Momentos Recentes" items={context.recentMoments} accentColor="text-teal-500" />
-          {context.latestInsight && <InsightCard insight={context.latestInsight} />}
+          {context.latestInsight ? <InsightCard insight={context.latestInsight} /> : <ContextSummaryCard context={context} />}
           <PatternsCard patterns={context.patterns.filter(p => ['emotional', 'trigger', 'strength'].includes(p.patternType))} />
         </>
       )
@@ -195,13 +217,19 @@ function renderCards(module: string, context: UserAIContext): React.ReactNode {
     default: // coordinator overview
       return (
         <>
-          {context.latestInsight && <InsightCard insight={context.latestInsight} />}
+          {context.latestInsight ? <InsightCard insight={context.latestInsight} /> : <ContextSummaryCard context={context} />}
           <StatCard title="Tarefas Pendentes" value={context.pendingTasks} label="no Atlas" accentColor="text-blue-500" />
           {context.financeSummary && (
             <StatCard title="Saldo do Mes" value={formatCurrency(context.financeSummary.balance)} accentColor="text-amber-500" />
           )}
           <StatCard title="Momentos" value={context.recentMoments.length} label="registrados recentemente" accentColor="text-teal-500" />
-          <StatCard title="Proximos Eventos" value={context.upcomingEvents?.length ?? 0} label="na agenda" accentColor="text-indigo-500" />
+          {(context.upcomingEvents?.length ?? 0) > 0 && (
+            <ListCard
+              title="Proximos Eventos"
+              items={(context.upcomingEvents || []).slice(0, 3).map(e => `${formatEventTime(e.startTime)} — ${e.title}`)}
+              accentColor="text-indigo-500"
+            />
+          )}
           <PatternsCard patterns={context.patterns} />
         </>
       )

--- a/src/services/userAIContextService.ts
+++ b/src/services/userAIContextService.ts
@@ -15,6 +15,7 @@
 
 import { supabase } from './supabaseClient'
 import { createNamespacedLogger } from '@/lib/logger'
+import { fetchCalendarEvents } from './googleCalendarService'
 
 const log = createNamespacedLogger('userAIContextService')
 
@@ -130,9 +131,29 @@ export async function getUserAIContext(forceRefresh = false): Promise<UserAICont
         .limit(1),
     ])
 
-    // TODO: Re-enable when calendar_events table is created
-    // calendar_events table not yet migrated — skip query to avoid 404 noise
-    const eventsRes = { data: null as any, error: null }
+    // Fetch upcoming events from Google Calendar (best-effort)
+    let eventsRes: { data: any; error: any } = { data: null, error: null }
+    try {
+      const now = new Date()
+      const weekFromNow = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000)
+      const events = await fetchCalendarEvents('primary', {
+        timeMin: now.toISOString(),
+        timeMax: weekFromNow.toISOString(),
+        maxResults: 5,
+        singleEvents: true,
+        orderBy: 'startTime',
+      })
+      eventsRes = {
+        data: events.map(e => ({
+          title: e.summary || 'Sem titulo',
+          start_time: e.start.dateTime || e.start.date || '',
+        })),
+        error: null,
+      }
+    } catch {
+      // Google Calendar not connected or token expired — graceful fallback
+      eventsRes = { data: null, error: null }
+    }
 
     // Calculate finance summary
     let financeSummary: UserAIContext['financeSummary'] = null


### PR DESCRIPTION
## Summary
- Replace disabled calendar_events table query with live Google Calendar API call
- Add ContextSummaryCard fallback when no Life Council insight exists
- Coordinator view shows upcoming events as rich list (not just count)
- Calendar fetch is best-effort: gracefully handles disconnected state

Closes #587

## Test plan
- [x] npm run build passes
- [ ] Open chat in expanded mode, context sidebar loads real data
- [ ] With Google Calendar connected, upcoming events appear
- [ ] Without Google Calendar, no error, events section hidden
- [ ] Without Life Council insight, Resumo do Dia card appears

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Daily summary card now displays pending tasks, completed items today, recent moments, and finance balance
* Google Calendar integration provides upcoming events for the next 7 days (up to 5 events)
* Upcoming events display conditionally, appearing only when scheduled

<!-- end of auto-generated comment: release notes by coderabbit.ai -->