### PR TITLE
fix(vida): replace passive fallback questions with actionable CTAs

### DIFF
--- a/src/components/features/VidaUniversalInput/ContextualCTACarousel.tsx
+++ b/src/components/features/VidaUniversalInput/ContextualCTACarousel.tsx
@@ -1,12 +1,11 @@
 /**
- * ContextualCTACarousel — Swipeable contextual CTA cards
+ * ContextualCTACarousel — Horizontal scrollable CTA chips
  *
- * Uses CSS scroll-snap for smooth native-feel swiping (same pattern as DailyQuestionsCarousel).
- * NO auto-advance — CTAs are actionable, user controls navigation.
+ * Shows compact, actionable chips that are all partially visible.
  * Click dispatches based on action type (navigate, chat, input).
  */
 
-import { useRef, useState, useCallback } from 'react'
+import { useCallback } from 'react'
 import {
   CheckSquare,
   DollarSign,
@@ -14,6 +13,7 @@ import {
   Calendar,
   HelpCircle,
   Search,
+  MessageCircle,
 } from 'lucide-react'
 import type { ContextualCTA } from '@/hooks/useContextualCTAs'
 
@@ -24,6 +24,7 @@ const ICON_MAP: Record<string, typeof CheckSquare> = {
   Calendar,
   HelpCircle,
   Search,
+  MessageCircle,
 }
 
 interface ContextualCTACarouselProps {
@@ -41,28 +42,6 @@ export function ContextualCTACarousel({
   onChatAction,
   onInputAction,
 }: ContextualCTACarouselProps) {
-  const scrollRef = useRef<HTMLDivElement>(null)
-  const [activeIndex, setActiveIndex] = useState(0)
-
-  const handleScroll = useCallback(() => {
-    const el = scrollRef.current
-    if (!el) return
-    const scrollLeft = el.scrollLeft
-    const itemWidth = el.offsetWidth
-    if (itemWidth === 0) return
-    const index = Math.round(scrollLeft / itemWidth)
-    setActiveIndex(Math.min(index, ctas.length - 1))
-  }, [ctas.length])
-
-  const handleDotClick = useCallback((index: number) => {
-    const el = scrollRef.current
-    if (!el) return
-    el.scrollTo({
-      left: index * el.offsetWidth,
-      behavior: 'smooth',
-    })
-  }, [])
-
   const handleCtaClick = useCallback((cta: ContextualCTA) => {
     switch (cta.action) {
       case 'navigate':
@@ -79,8 +58,10 @@ export function ContextualCTACarousel({
 
   if (isLoading) {
     return (
-      <div className="h-8 flex items-center justify-center">
-        <div className="w-32 h-3 bg-ceramic-cool rounded-full animate-pulse" />
+      <div className="flex items-center gap-2 overflow-hidden">
+        {[1, 2, 3].map(i => (
+          <div key={i} className="h-7 w-28 bg-ceramic-cool rounded-full animate-pulse shrink-0" />
+        ))}
       </div>
     )
   }
@@ -88,57 +69,24 @@ export function ContextualCTACarousel({
   if (ctas.length === 0) return null
 
   return (
-    <div className="relative">
-      {/* Scrollable carousel */}
-      <div
-        ref={scrollRef}
-        onScroll={handleScroll}
-        className="flex overflow-x-auto snap-x snap-mandatory scrollbar-hide"
-        style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}
-      >
-        {ctas.map((cta, i) => {
-          const Icon = ICON_MAP[cta.icon] || HelpCircle
-          return (
-            <button
-              key={cta.id}
-              onClick={() => handleCtaClick(cta)}
-              className="w-full shrink-0 snap-center px-1 text-left group"
-              aria-label={cta.label}
-            >
-              <div
-                className={`flex items-center gap-2 py-1 transition-opacity duration-300 ${
-                  i === activeIndex ? 'opacity-100' : 'opacity-60'
-                }`}
-              >
-                <div className={`w-5 h-5 rounded-md flex items-center justify-center shrink-0 ${cta.color}`}>
-                  <Icon className="w-3 h-3" />
-                </div>
-                <p className="text-xs text-ceramic-text-secondary group-hover:text-ceramic-text-primary transition-colors line-clamp-1">
-                  {cta.label}
-                </p>
-              </div>
-            </button>
-          )
-        })}
-      </div>
-
-      {/* Dot indicators */}
-      {ctas.length > 1 && (
-        <div className="flex items-center justify-center gap-1.5 mt-2">
-          {ctas.map((_, i) => (
-            <button
-              key={i}
-              onClick={() => handleDotClick(i)}
-              aria-label={`CTA ${i + 1}`}
-              className={`rounded-full transition-all duration-300 ${
-                i === activeIndex
-                  ? 'w-4 h-1.5 bg-amber-500'
-                  : 'w-1.5 h-1.5 bg-ceramic-border hover:bg-ceramic-text-secondary/40'
-              }`}
-            />
-          ))}
-        </div>
-      )}
+    <div
+      className="flex items-center gap-2 overflow-x-auto pb-1 scrollbar-hide"
+      style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}
+    >
+      {ctas.map((cta) => {
+        const Icon = ICON_MAP[cta.icon] || HelpCircle
+        return (
+          <button
+            key={cta.id}
+            onClick={() => handleCtaClick(cta)}
+            className={`shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium transition-all duration-200 hover:scale-[1.03] active:scale-95 ${cta.color} hover:shadow-sm`}
+            aria-label={cta.label}
+          >
+            <Icon className="w-3.5 h-3.5 shrink-0" />
+            <span className="whitespace-nowrap">{cta.label}</span>
+          </button>
+        )
+      })}
     </div>
   )
 }

--- a/src/hooks/useContextualCTAs.ts
+++ b/src/hooks/useContextualCTAs.ts
@@ -6,7 +6,7 @@
  * 2. Finance alert (negative balance) -> "Revisar financas do mes"
  * 3. Streak at risk (no recent moments) -> "Registrar momento do dia"
  * 4. Upcoming event soon -> "Preparar para: {event}"
- * 5. Daily question fallback -> random question from FALLBACK pool
+ * 5. Module CTAs fallback -> actionable shortcuts to AICA modules
  */
 
 import { useState, useEffect, useRef } from 'react'
@@ -29,21 +29,59 @@ export interface ContextualCTA {
   color: string
 }
 
-/** Fallback questions used when no contextual data is available */
-const FALLBACK_QUESTIONS = [
-  'O que voce quer conquistar hoje?',
-  'Como voce esta se sentindo neste momento?',
-  'Qual area da sua vida precisa de mais atencao?',
-  'O que te deixaria orgulhoso hoje?',
-  'Como voce pode se cuidar melhor agora?',
-  'Qual foi a melhor parte do seu dia?',
-  'O que voce aprendeu recentemente?',
-  'Com quem voce gostaria de se reconectar?',
+/** Actionable module CTAs used to fill remaining slots */
+const MODULE_CTAS: ContextualCTA[] = [
+  {
+    id: 'mod-moment',
+    label: 'Registrar um momento',
+    icon: 'Sparkles',
+    action: 'chat',
+    actionPayload: 'Quero registrar um momento do meu dia',
+    category: 'journey',
+    color: 'text-amber-600 bg-amber-500/10',
+  },
+  {
+    id: 'mod-task',
+    label: 'Criar nova tarefa',
+    icon: 'CheckSquare',
+    action: 'navigate',
+    actionPayload: 'atlas',
+    category: 'task',
+    color: 'text-blue-600 bg-blue-500/10',
+  },
+  {
+    id: 'mod-agenda',
+    label: 'Ver agenda de hoje',
+    icon: 'Calendar',
+    action: 'navigate',
+    actionPayload: 'agenda',
+    category: 'agenda',
+    color: 'text-purple-600 bg-purple-500/10',
+  },
+  {
+    id: 'mod-finance',
+    label: 'Revisar financas',
+    icon: 'DollarSign',
+    action: 'navigate',
+    actionPayload: 'finance',
+    category: 'finance',
+    color: 'text-emerald-600 bg-emerald-500/10',
+  },
+  {
+    id: 'mod-chat',
+    label: 'Falar com AICA',
+    icon: 'MessageCircle',
+    action: 'chat',
+    actionPayload: '',
+    category: 'chat',
+    color: 'text-ceramic-info bg-ceramic-info/10',
+  },
 ]
 
-function pickRandomQuestions(count: number): string[] {
-  const shuffled = [...FALLBACK_QUESTIONS].sort(() => Math.random() - 0.5)
-  return shuffled.slice(0, count)
+function pickModuleCTAs(count: number, existingIds: Set<string>): ContextualCTA[] {
+  return MODULE_CTAS
+    .filter(cta => !existingIds.has(cta.category))
+    .slice(0, count)
 }
 
 interface PendingTask {
@@ -145,21 +183,12 @@ function buildCTAs(context: UserAIContext, pendingTasks: PendingTask[]): Context
     })
   }
 
-  // 5. Fill remaining slots with daily question fallbacks
+  // 5. Fill remaining slots with actionable module CTAs
   const remaining = MAX_CTAS - ctas.length
   if (remaining > 0) {
-    const questions = pickRandomQuestions(remaining)
-    for (const q of questions) {
-      ctas.push({
-        id: `question-${ctas.length}`,
-        label: q,
-        icon: 'HelpCircle',
-        action: 'input',
-        actionPayload: q,
-        category: 'question',
-        color: 'text-ceramic-text-secondary bg-ceramic-cool',
-      })
-    }
+    const existingCategories = new Set(ctas.map(c => c.category))
+    const moduleCtas = pickModuleCTAs(remaining, existingCategories)
+    ctas.push(...moduleCtas)
   }
 
   return ctas.slice(0, MAX_CTAS)


### PR DESCRIPTION
## Summary
- Remove generic reflective questions ("O que te deixaria orgulhoso hoje?", "O que voce aprendeu recentemente?") that users never interact with
- Replace with actionable module CTAs: "Registrar um momento", "Criar nova tarefa", "Ver agenda de hoje", "Revisar financas", "Falar com AICA"
- Redesign carousel from full-width scroll-snap slides to compact horizontal chips visible side-by-side

## Test plan
- [x] `npm run build` passes
- [x] `npm run typecheck` passes (no new errors)
- [ ] Manual: VIDA page shows actionable chips instead of passive questions
- [ ] Manual: Each chip navigates to correct module or opens chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added icons to call-to-action buttons for improved visual identification
  * Introduced module-focused suggestions for recommended actions

* **UI/UX Updates**
  * Simplified call-to-action carousel interface with a horizontal scrollable chip layout
  * Updated loading skeleton appearance with compact pill-style placeholders

<!-- end of auto-generated comment: release notes by coderabbit.ai -->