### PR TITLE
fix(vida): remove duplicate WeatherInsightCard import

### DIFF
--- a/src/pages/VidaPage.tsx
+++ b/src/pages/VidaPage.tsx
@@ -17,7 +17,6 @@ import { GrantsCard } from '../modules/grants/components/GrantsCard';
 import { JourneyHeroCard } from '../modules/journey';
 import { WeatherInsightCard } from '@/modules/atlas/components';
 import { FluxCard } from '../modules/flux';
-import { WeatherInsightCard } from '@/modules/atlas/components';
 import { useConsciousnessPoints } from '../modules/journey/hooks/useConsciousnessPoints';
 import { LEVEL_COLORS } from '../modules/journey/types/consciousnessPoints';
 // #440: useLifeCouncil and useUserPatterns removed from /vida


### PR DESCRIPTION
## Summary
- Closes #629
- Remove duplicate `import { WeatherInsightCard }` on line 20 of VidaPage.tsx (already imported on line 18)
- The duplicate caused a Babel parse error that completely broke the Vida page

## Context
Issue: #629 — Duplicate import introduced during squash merge of PR #625

## Test plan
- [x] `npm run build` passes
- [ ] VidaPage loads without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up redundant import statements in the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->