### PR TITLE
fix(connections): remove Telegram card from main view and fix graph sizing

### DIFF
--- a/src/modules/connections/components/DunbarLayerMap.tsx
+++ b/src/modules/connections/components/DunbarLayerMap.tsx
@@ -103,8 +103,11 @@ export function DunbarLayerMap({
       </div>
 
       {/* SVG Visualization */}
-      <div className="flex justify-center">
-        <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+      <div className="flex justify-center max-w-full overflow-hidden">
+        <svg
+          className="max-w-full max-h-[400px] w-auto h-auto"
+          viewBox={`0 0 ${size} ${size}`}
+        >
           {/* Render rings from outermost to innermost */}
           {([500, 150, 50, 15, 5] as DunbarLayer[]).map((layer) => {
             const radius = layerRadii[layer];

--- a/src/modules/connections/views/ConnectionsView.tsx
+++ b/src/modules/connections/views/ConnectionsView.tsx
@@ -3,7 +3,6 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { Plus, Users, Sparkles, TrendingUp } from 'lucide-react';
 import { useConnectionSpaces } from '../hooks/useConnectionSpaces';
 import { SpaceCard } from '../components/SpaceCard';
-import TelegramLinkCard from '../components/telegram/TelegramLinkCard';
 import { CeramicTabSelector } from '@/components';
 import { staggerContainer, staggerItem } from '../../../lib/animations/ceramic-motion';
 import type { ArchetypeType } from '../types';
@@ -116,9 +115,6 @@ export function ConnectionsView({
         </header>
 
         <div className="flex-1 px-6 pb-40 space-y-6">
-          {/* Telegram Integration */}
-          <TelegramLinkCard />
-
           <div className="flex items-center justify-center">
           <motion.div
             className="ceramic-tray p-12 text-center max-w-md"
@@ -188,9 +184,6 @@ export function ConnectionsView({
       </header>
 
       <main className="flex-1 overflow-y-auto px-6 pb-40 space-y-6">
-        {/* Telegram Integration */}
-        <TelegramLinkCard />
-
         {/* Favorites Section */}
         {favorites.length > 0 && (
           <motion.section


### PR DESCRIPTION
## Summary
- Remove TelegramLinkCard from ConnectionsView main page (both empty state and populated state) — it remains in the dedicated WhatsApp/Telegram tab
- Constrain DunbarLayerMap SVG with `max-w-full`, `max-h-[400px]`, and `overflow-hidden` to prevent oversized rendering

Closes #619
Closes #634

## Test plan
- [ ] `npm run build` passes
- [ ] `npm run typecheck` passes  
- [ ] Open /connections — Telegram card should NOT appear on main view
- [ ] Open /connections WhatsApp tab — Telegram card should still appear there
- [ ] DunbarLayerMap SVG should be contained within its card, not overflow

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Dunbar Layer Map now renders responsively to adapt to different screen sizes and available space.

* **Removed Features**
  * Removed Telegram link card integration from the Connections view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->