### PR TITLE
fix(flux): fix layout overflow, training labels, and month summary

### DIFF
--- a/src/modules/flux/components/athlete/ProgressTimeline.tsx
+++ b/src/modules/flux/components/athlete/ProgressTimeline.tsx
@@ -79,13 +79,8 @@ export function ProgressTimeline({
         )}
       </div>
 
-      {/* Section label */}
-      <p className="text-[10px] font-bold text-ceramic-text-secondary uppercase tracking-wider">
-        Treinos Cumpridos
-      </p>
-
       {/* Week pills */}
-      <div className="flex gap-2">
+      <div className="flex gap-2 overflow-hidden max-w-full">
         {weeks.map((week, i) => {
           const isCurrent = week.weekNumber === currentWeek;
           const isSelected = week.weekNumber === activeSelected;
@@ -124,9 +119,9 @@ export function ProgressTimeline({
                 </div>
               )}
 
-              {/* Week date range or number */}
+              {/* Week label */}
               <p
-                className={`text-[10px] font-bold uppercase tracking-wider mb-1 ${
+                className={`text-[10px] font-bold uppercase tracking-wider mb-0.5 ${
                   isCurrent && isSelected
                     ? 'text-amber-600'
                     : isSelected
@@ -136,8 +131,13 @@ export function ProgressTimeline({
                         : 'text-ceramic-text-secondary'
                 }`}
               >
-                {week.dateRange || `Sem ${week.weekNumber}`}
+                Semana {week.weekNumber}
               </p>
+              {week.dateRange && (
+                <p className="text-[9px] text-ceramic-text-secondary/70 mb-0.5">
+                  {week.dateRange}
+                </p>
+              )}
 
               {/* Progress bar */}
               <div className="h-1.5 bg-ceramic-cool rounded-full overflow-hidden mb-1.5">

--- a/src/modules/flux/components/athlete/ScheduleEditor.tsx
+++ b/src/modules/flux/components/athlete/ScheduleEditor.tsx
@@ -35,7 +35,7 @@ export function ScheduleEditor({
   return (
     <div className="bg-ceramic-cool/50 rounded-xl p-3 space-y-3">
       {/* Day selector */}
-      <div className="flex items-center justify-between gap-1">
+      <div className="flex items-center justify-between gap-1 overflow-hidden max-w-full">
         {DAY_LABELS.map((label, idx) => {
           const dayValue = idx + 1; // 1=Mon ... 7=Sun
           const isSelected = day === dayValue;

--- a/src/modules/flux/components/canvas/MicrocycleGrid.tsx
+++ b/src/modules/flux/components/canvas/MicrocycleGrid.tsx
@@ -50,7 +50,6 @@ interface MicrocycleGridProps {
   workoutsByWeek: Record<number, WeekWorkout[]>; // week 1-4 -> workouts
   calendarEvents?: BusySlot[];
   currentWeek: number; // Which week is "active" (1-4)
-  startWeekOffset?: number; // Absolute week number of first week (for periodization labels)
   onWorkoutClick?: (workoutId: string) => void;
   onDropWorkout?: (weekNumber: number, dayOfWeek: number, templateData: string) => void;
   onWeekClick?: (weekNumber: number) => void;
@@ -70,17 +69,7 @@ const MODALITY_ICONS: Record<string, string> = {
   strength: '\u{1F4AA}',
 };
 
-/**
- * Periodization context helper.
- * Business rules: Microciclo = 1 week, Mesociclo = 4 weeks, Macrociclo = 12 weeks
- * Given an absolute week number (1-based from training start), returns context labels.
- */
-function getPeriodizationLabel(absoluteWeek: number): string {
-  const mesocycleNum = Math.ceil(absoluteWeek / 4);
-  const weekInMesocycle = ((absoluteWeek - 1) % 4) + 1;
-  const macrocycleNum = Math.ceil(absoluteWeek / 12);
-  return `Semana ${weekInMesocycle} / Mesociclo ${mesocycleNum}`;
-}
+// getPeriodizationLabel removed — redundant with WeekStrip header (#626)
 
 const MODALITY_PILL_STYLES: Record<WeekWorkout['modality'], { bg: string; text: string }> = {
   swimming: { bg: 'rgba(96,165,250,0.15)', text: '#1e3a5f' },
@@ -239,7 +228,6 @@ const MiniDayCell: React.FC<MiniDayCellProps> = ({
 
 interface WeekStripProps {
   weekNumber: number;
-  absoluteWeek?: number; // Absolute week number for periodization labels
   workouts: WeekWorkout[];
   calendarEvents: BusySlot[];
   isCurrent: boolean;
@@ -250,7 +238,6 @@ interface WeekStripProps {
 
 const WeekStrip: React.FC<WeekStripProps> = ({
   weekNumber,
-  absoluteWeek,
   workouts,
   calendarEvents,
   isCurrent,
@@ -307,11 +294,6 @@ const WeekStrip: React.FC<WeekStripProps> = ({
           <h3 className="text-sm font-bold text-ceramic-text-primary">
             Semana {weekNumber}
           </h3>
-          {absoluteWeek && (
-            <span className="text-[9px] font-medium text-ceramic-text-tertiary">
-              ({getPeriodizationLabel(absoluteWeek)})
-            </span>
-          )}
           {isCurrent && (
             <span className="px-1.5 py-0.5 rounded-md bg-[#7B8FA2]/15 text-[9px] font-bold text-[#5F7185] uppercase">
               Atual
@@ -330,7 +312,7 @@ const WeekStrip: React.FC<WeekStripProps> = ({
       </div>
 
       {/* Day Headers */}
-      <div className="flex gap-1.5 mb-1.5">
+      <div className="flex gap-1.5 mb-1.5 overflow-hidden max-w-full">
         {WEEKDAYS_SHORT.map((label, idx) => (
           <div key={idx} className="flex-1 min-w-0 text-center">
             <span className="text-[9px] font-bold text-ceramic-text-tertiary uppercase">
@@ -341,7 +323,7 @@ const WeekStrip: React.FC<WeekStripProps> = ({
       </div>
 
       {/* Day Cells */}
-      <div className="flex gap-1.5 min-h-[48px]">
+      <div className="flex gap-1.5 min-h-[48px] overflow-hidden max-w-full">
         {[1, 2, 3, 4, 5, 6, 7].map((dayNum) => (
           <MiniDayCell
             key={dayNum}
@@ -367,7 +349,6 @@ export const MicrocycleGrid: React.FC<MicrocycleGridProps> = ({
   workoutsByWeek,
   calendarEvents = [],
   currentWeek,
-  startWeekOffset = 1,
   onWorkoutClick,
   onDropWorkout,
   onWeekClick,
@@ -407,7 +388,6 @@ export const MicrocycleGrid: React.FC<MicrocycleGridProps> = ({
           <WeekStrip
             key={weekNum}
             weekNumber={weekNum}
-            absoluteWeek={startWeekOffset + weekNum - 1}
             workouts={workoutsByWeek[weekNum] || []}
             calendarEvents={calendarEvents}
             isCurrent={weekNum === currentWeek}

--- a/src/modules/flux/views/MicrocycleEditorView.tsx
+++ b/src/modules/flux/views/MicrocycleEditorView.tsx
@@ -506,7 +506,7 @@ export default function MicrocycleEditorView() {
                   </div>
 
                   {/* Day Grid */}
-                  <div className="grid grid-cols-7 gap-2">
+                  <div className="grid grid-cols-7 gap-2 overflow-hidden max-w-full">
                     {[1, 2, 3, 4, 5, 6, 7].map((day) => {
                       const cellSlots = getSlotsForCell(week, day);
 


### PR DESCRIPTION
## Summary
- Add `overflow-hidden` and `max-w-full` to day cell containers in MicrocycleGrid, MicrocycleEditorView, and ScheduleEditor to prevent mobile overflow (#639)
- Replace date range labels with "Semana N" in ProgressTimeline and remove redundant "Treinos Cumpridos" section label (#608)
- Remove redundant periodization labels ("Semana X / Mesociclo Y") from MicrocycleGrid WeekStrip headers (#626)

## Test plan
- [ ] `npm run build` passes
- [ ] `npm run typecheck` passes
- [ ] On mobile viewport (462px), day squares stay within container bounds
- [ ] ProgressTimeline shows "Semana 1", "Semana 2", etc. instead of date ranges as primary label
- [ ] MicrocycleGrid no longer shows redundant "Semana X / Mesociclo Y" labels

Closes #639
Closes #608
Closes #626

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved overflow handling and layout constraints in schedule and timeline views for better display on smaller screens.
  * Fixed inconsistent week label display to show a standardized format with optional date range information.

* **Style**
  * Removed redundant periodization and section labels from UI for a cleaner interface.
  * Adjusted spacing and container widths for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->