### PR TITLE
fix(agenda): fix task undo/restore and handle holidays API gracefully

### DIFF
--- a/src/components/domain/CompletedTasksSection.tsx
+++ b/src/components/domain/CompletedTasksSection.tsx
@@ -11,7 +11,7 @@ import type { Task } from '@/types';
 
 interface CompletedTasksSectionProps {
   tasks: Task[];
-  onUncomplete: (taskId: string) => void;
+  onUncomplete: (taskId: string) => void | Promise<void>;
   isLoading?: boolean;
 }
 

--- a/src/hooks/useHolidays.ts
+++ b/src/hooks/useHolidays.ts
@@ -22,6 +22,7 @@ export function useHolidays(year?: number) {
     queryFn: () => getHolidays(targetYear),
     staleTime: ONE_DAY_MS,
     gcTime: SEVEN_DAYS_MS,
+    retry: 1,
   })
 
   const nextHoliday = useMemo(

--- a/src/hooks/useTaskCompletion.ts
+++ b/src/hooks/useTaskCompletion.ts
@@ -140,20 +140,23 @@ export function useTaskCompletion({ onRefresh }: UseTaskCompletionOptions) {
 
   /**
    * Undo a task completion: clear completed_at, remove from completedToday list.
+   * Returns true on success so callers can show feedback.
    */
-  const handleUncomplete = useCallback(async (taskId: string) => {
-    const { error } = await supabase
+  const handleUncomplete = useCallback(async (taskId: string): Promise<boolean> => {
+    const { data: restored, error } = await supabase
       .from('work_items')
       .update({
         completed_at: null,
         is_completed: false,
         status: 'pending',
       })
-      .eq('id', taskId);
+      .eq('id', taskId)
+      .select('id')
+      .single();
 
-    if (error) {
-      log.error('Error uncompleting task:', { error });
-      return;
+    if (error || !restored) {
+      log.error('Error uncompleting task:', { error, taskId });
+      return false;
     }
 
     log.debug('Task uncompleted:', taskId);
@@ -161,7 +164,22 @@ export function useTaskCompletion({ onRefresh }: UseTaskCompletionOptions) {
     // Remove from completedToday list
     setCompletedTodayTasks(prev => prev.filter(t => t.id !== taskId));
 
+    // Clear any lingering completing animation for this task
+    setCompletingTaskIds(prev => {
+      const next = new Set(prev);
+      next.delete(taskId);
+      return next;
+    });
+
+    // Cancel the animation timer if still pending
+    const timer = completingTimers.current.get(taskId);
+    if (timer) {
+      clearTimeout(timer);
+      completingTimers.current.delete(taskId);
+    }
+
     onRefresh();
+    return true;
   }, [onRefresh]);
 
   /**

--- a/src/services/holidayService.ts
+++ b/src/services/holidayService.ts
@@ -11,17 +11,23 @@ import type { HolidayData } from '@/lib/external-api'
 const client = ExternalApiClient.getInstance()
 
 /**
- * Fetches public holidays for a given year (defaults to current year)
+ * Fetches public holidays for a given year (defaults to current year).
+ * Returns empty array on any failure so callers always get a safe value.
  */
 export async function getHolidays(year?: number): Promise<HolidayData[]> {
   const targetYear = year ?? new Date().getFullYear()
-  const response = await client.call<HolidayData[]>('holidays', { year: targetYear })
 
-  if (!response.success || !response.data) {
+  try {
+    const response = await client.call<HolidayData[]>('holidays', { year: targetYear })
+
+    if (!response.success || !response.data) {
+      return []
+    }
+
+    return response.data
+  } catch {
     return []
   }
-
-  return response.data
 }
 
 /**

--- a/src/views/AgendaView.tsx
+++ b/src/views/AgendaView.tsx
@@ -926,14 +926,31 @@ export const AgendaView: React.FC<AgendaViewProps> = ({ userId, userEmail, onLog
             <section className="w-full">
                 <CompletedTasksSection
                     tasks={completedTodayTasks}
-                    onUncomplete={(taskId: string) => {
+                    onUncomplete={async (taskId: string) => {
                         // Cancel pending removal timer if user uncompletes within animation window
                         const pendingTimer = completionTimers.current.get(taskId);
                         if (pendingTimer) {
                             clearTimeout(pendingTimer);
                             completionTimers.current.delete(taskId);
                         }
-                        handleUncomplete(taskId);
+                        const success = await handleUncomplete(taskId);
+                        if (success) {
+                            notificationService.show({
+                                type: 'success',
+                                title: 'Tarefa restaurada',
+                                message: 'A tarefa voltou para sua lista ativa',
+                                icon: '↩️',
+                                duration: 3000,
+                            });
+                        } else {
+                            notificationService.show({
+                                type: 'error',
+                                title: 'Erro ao restaurar',
+                                message: 'Nao foi possivel desfazer a conclusao. Tente novamente.',
+                                icon: '❌',
+                                duration: 5000,
+                            });
+                        }
                     }}
                     isLoading={isLoadingCompleted}
                 />


### PR DESCRIPTION
## Summary
- **#618 — Task undo/restore**: `handleUncomplete` now uses `.select('id').single()` to confirm the DB update succeeded, returns boolean success, clears animation state/timers on undo, and shows user notification (success/error) via `notificationService`
- **#632 — Holidays API graceful degradation**: `getHolidays()` now catches thrown errors from `ExternalApiClient` (CORS/404 when Edge Function not deployed) and returns empty array. `useHolidays` hook uses `retry: 1` to reduce console noise
- **Note**: `external-holidays` Edge Function exists at `supabase/functions/external-holidays/` and needs deployment: `npx supabase functions deploy external-holidays --no-verify-jwt`

Closes #618
Closes #632

## Files changed
- `src/hooks/useTaskCompletion.ts` — robust uncomplete with `.select().single()`, animation cleanup
- `src/views/AgendaView.tsx` — async undo handler with user notification
- `src/components/domain/CompletedTasksSection.tsx` — accept async onUncomplete prop
- `src/services/holidayService.ts` — try/catch around ExternalApiClient call
- `src/hooks/useHolidays.ts` — reduce retry count to 1

## Test plan
- [x] `npm run build` passes
- [ ] Manual: complete a task, expand "Completed" section, click Undo — task should reappear with success notification
- [ ] Manual: if `external-holidays` is not deployed, calendar/task views should still render without errors

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for holiday data fetching with safe automatic fallback to prevent data loss.
  * Added automatic retry mechanism for holiday queries to enhance reliability and resilience.

* **New Features**
  * Added user-visible success and error notifications for task uncomplete actions.
  * Enhanced cleanup and state management when uncompleting tasks, including animation cancellation and timer clearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->