### PR TITLE
feat(admin): wire Admin Portal and Pricing Simulator routes

### DIFF
--- a/src/modules/billing/index.ts
+++ b/src/modules/billing/index.ts
@@ -13,6 +13,8 @@
 export { PricingPage } from './pages/PricingPage';
 export { ManageSubscriptionPage } from './pages/ManageSubscriptionPage';
 export { AdminCouponsPage } from './pages/AdminCouponsPage';
+export { AdminPortalPage } from './pages/AdminPortalPage';
+export { PricingSimulatorPage } from './pages/PricingSimulatorPage';
 
 // ============================================
 // COMPONENTS


### PR DESCRIPTION
## Summary
- Add `AdminPortalPage` and `PricingSimulatorPage` barrel exports to `billing/index.ts`
- Add lazy imports for both pages in `AppRouter.tsx`
- Wire `/admin` route → `AdminPortalPage` (hub with links to Coupons, Simulator, Asaas)
- Wire `/admin/simulator` route → `PricingSimulatorPage` (interactive P&L + unit economics dashboard)
- Both routes protected by `AdminGuard` (requires `user_metadata.is_admin === true`)

## Context
The page components (`AdminPortalPage`, `PricingSimulatorPage`, and 11 simulator sub-components) were added in PR #648. This PR wires them into the router and barrel exports so they are actually accessible.

## Test plan
- [ ] `npm run build` passes
- [ ] `npm run typecheck` passes
- [ ] Navigate to `/admin` — shows Admin Portal hub (admin only)
- [ ] Navigate to `/admin/simulator` — shows Pricing Simulator (admin only)
- [ ] Navigate to `/admin/coupons` — still works (pre-existing route)
- [ ] Non-admin users cannot access any `/admin/*` routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>