### PR TITLE
feat(flux): triathlon modality, accordion groups, edit link, WhatsApp preview

### DIFF
--- a/src/modules/flux/components/canvas/CanvasEditorDrawer.tsx
+++ b/src/modules/flux/components/canvas/CanvasEditorDrawer.tsx
@@ -30,6 +30,7 @@ const MODALITY_PT_LABELS: Record<string, string> = {
   cycling: 'Ciclismo',
   strength: 'Musculacao',
   walking: 'Caminhada',
+  triathlon: 'Triatleta',
 };
 
 const AVATAR_COLORS = [

--- a/src/modules/flux/components/canvas/CanvasLibrarySidebar.tsx
+++ b/src/modules/flux/components/canvas/CanvasLibrarySidebar.tsx
@@ -21,6 +21,7 @@ const MODALITY_ICONS: Record<string, string> = {
   cycling: '\u{1F6B4}',
   strength: '\u{1F4AA}',
   walking: '\u{1F6B6}',
+  triathlon: '\u{1F3C5}',
 };
 
 const MODALITY_PT_LABELS: Record<string, string> = {
@@ -29,6 +30,7 @@ const MODALITY_PT_LABELS: Record<string, string> = {
   cycling: 'Ciclismo',
   strength: 'Musculacao',
   walking: 'Caminhada',
+  triathlon: 'Triatleta',
 };
 
 const ZONE_OPTIONS = [

--- a/src/modules/flux/components/canvas/MicrocycleGrid.tsx
+++ b/src/modules/flux/components/canvas/MicrocycleGrid.tsx
@@ -67,15 +67,19 @@ const MODALITY_ICONS: Record<string, string> = {
   running: '\u{1F3C3}',
   cycling: '\u{1F6B4}',
   strength: '\u{1F4AA}',
+  walking: '\u{1F6B6}',
+  triathlon: '\u{1F3C5}',
 };
 
 // getPeriodizationLabel removed — redundant with WeekStrip header (#626)
 
-const MODALITY_PILL_STYLES: Record<WeekWorkout['modality'], { bg: string; text: string }> = {
+const MODALITY_PILL_STYLES: Record<string, { bg: string; text: string }> = {
   swimming: { bg: 'rgba(96,165,250,0.15)', text: '#1e3a5f' },
   running: { bg: 'rgba(251,146,60,0.15)', text: '#7c2d12' },
   cycling: { bg: 'rgba(52,211,153,0.15)', text: '#064e3b' },
   strength: { bg: 'rgba(192,132,252,0.15)', text: '#581c87' },
+  walking: { bg: 'rgba(56,189,248,0.15)', text: '#0c4a6e' },
+  triathlon: { bg: 'rgba(251,113,133,0.15)', text: '#881337' },
 };
 
 // ============================================

--- a/src/modules/flux/components/canvas/PublishWhatsAppButton.tsx
+++ b/src/modules/flux/components/canvas/PublishWhatsAppButton.tsx
@@ -194,9 +194,22 @@ export const PublishWhatsAppButton: React.FC<PublishWhatsAppButtonProps> = ({
                   Previa da Mensagem
                 </label>
                 <div className="ceramic-inset p-4 rounded-xl max-h-64 overflow-y-auto">
-                  <pre className="text-xs text-ceramic-text-primary whitespace-pre-wrap font-sans">
-                    {messagePreview}
-                  </pre>
+                  <div className="text-xs text-ceramic-text-primary whitespace-pre-wrap font-sans leading-relaxed">
+                    {messagePreview.split('\n').map((line, i) => (
+                      <span key={i}>
+                        {line.split(/(\*[^*]+\*)/).map((part, j) =>
+                          part.startsWith('*') && part.endsWith('*') && part.length > 2 ? (
+                            <strong key={j} className="font-bold">{part.slice(1, -1)}</strong>
+                          ) : part.startsWith('_') && part.endsWith('_') && part.length > 2 ? (
+                            <em key={j} className="italic text-ceramic-text-secondary">{part.slice(1, -1)}</em>
+                          ) : (
+                            <span key={j}>{part}</span>
+                          )
+                        )}
+                        {'\n'}
+                      </span>
+                    ))}
+                  </div>
                 </div>
               </div>
 

--- a/src/modules/flux/components/canvas/WeeklyGrid.tsx
+++ b/src/modules/flux/components/canvas/WeeklyGrid.tsx
@@ -23,7 +23,7 @@ export interface WeekWorkout {
   name: string;
   duration: number;
   intensity: 'low' | 'medium' | 'high';
-  modality: 'swimming' | 'running' | 'cycling' | 'strength';
+  modality: 'swimming' | 'running' | 'cycling' | 'strength' | 'walking' | 'triathlon';
   type?: string;
   templateId?: string;
 }
@@ -76,6 +76,8 @@ const MODALITY_COLORS: Record<string, { bg: string; border: string; text: string
   running:  { bg: 'rgba(251,146,60,0.12)', border: 'rgb(251,146,60)', text: '#7c2d12' },
   cycling:  { bg: 'rgba(52,211,153,0.12)', border: 'rgb(52,211,153)', text: '#064e3b' },
   strength: { bg: 'rgba(192,132,252,0.12)', border: 'rgb(192,132,252)', text: '#581c87' },
+  walking:  { bg: 'rgba(56,189,248,0.12)', border: 'rgb(56,189,248)', text: '#0c4a6e' },
+  triathlon: { bg: 'rgba(251,113,133,0.12)', border: 'rgb(251,113,133)', text: '#881337' },
 };
 
 const INTENSITY_DOTS: Record<string, string> = {
@@ -95,6 +97,8 @@ const MODALITY_ICONS: Record<string, string> = {
   running: '\u{1F3C3}',
   cycling: '\u{1F6B4}',
   strength: '\u{1F4AA}',
+  walking: '\u{1F6B6}',
+  triathlon: '\u{1F3C5}',
 };
 
 // ============================================

--- a/src/modules/flux/components/canvas/WorkoutBlock.tsx
+++ b/src/modules/flux/components/canvas/WorkoutBlock.tsx
@@ -14,6 +14,7 @@ import type { TrainingModality } from '../../types';
 import type { WorkoutIntensity } from '../../mockData/workoutTemplates';
 
 export interface WorkoutBlockData {
+  templateId?: string;
   id: string;
   name: string;
   duration: number; // minutes
@@ -43,6 +44,7 @@ const MODALITY_COLORS: Record<TrainingModality, string> = {
   cycling: 'bg-emerald-400',
   strength: 'bg-purple-400',
   walking: 'bg-sky-400',
+  triathlon: 'bg-rose-400',
 };
 
 const MODALITY_LABELS: Record<TrainingModality, string> = {
@@ -51,6 +53,7 @@ const MODALITY_LABELS: Record<TrainingModality, string> = {
   cycling: 'Ciclismo',
   strength: 'Musculacao',
   walking: 'Caminhada',
+  triathlon: 'Triatleta',
 };
 
 const INTENSITY_LABELS: Record<WorkoutIntensity, string> = {

--- a/src/modules/flux/components/canvas/WorkoutBlockEditor.tsx
+++ b/src/modules/flux/components/canvas/WorkoutBlockEditor.tsx
@@ -8,7 +8,8 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { X, Save, Activity, Target, MessageSquare, Loader2, CheckCircle } from 'lucide-react';
+import { X, Save, Activity, Target, MessageSquare, Loader2, CheckCircle, ExternalLink } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
 import type { WorkoutBlockData } from './WorkoutBlock';
 import type { WorkoutIntensity } from '../../mockData/workoutTemplates';
 
@@ -25,6 +26,7 @@ export const WorkoutBlockEditor: React.FC<WorkoutBlockEditorProps> = ({
   onClose,
   onSave,
 }) => {
+  const navigate = useNavigate();
   const [formData, setFormData] = useState<WorkoutBlockData | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const [saveStatus, setSaveStatus] = useState<'idle' | 'success' | 'error'>('idle');
@@ -258,6 +260,25 @@ export const WorkoutBlockEditor: React.FC<WorkoutBlockEditorProps> = ({
               placeholder="Instrucoes especificas, dicas tecnicas, ajustes personalizados..."
             />
           </Section>
+
+          {/* Link to full template editor */}
+          {formData.templateId && (
+            <div className="ceramic-inset p-4 rounded-xl">
+              <p className="text-xs text-ceramic-text-secondary mb-2">
+                Este treino foi criado a partir de um exercicio da biblioteca.
+              </p>
+              <button
+                onClick={() => {
+                  onClose();
+                  navigate(`/flux/templates/edit/${formData.templateId}`);
+                }}
+                className="flex items-center gap-2 text-sm font-bold text-ceramic-accent hover:text-ceramic-accent/80 transition-colors"
+              >
+                <ExternalLink className="w-4 h-4" />
+                Editar exercicio completo
+              </button>
+            </div>
+          )}
         </div>
 
         {/* Footer Actions */}

--- a/src/modules/flux/components/forms/TemplateFormDrawer.tsx
+++ b/src/modules/flux/components/forms/TemplateFormDrawer.tsx
@@ -17,7 +17,7 @@ import type { WorkoutTemplate, TrainingModality } from '../../types/flow';
 import type { WorkoutSeries } from '../../types/series';
 import { MODALITY_CONFIG } from '../../types/flux';
 
-const MODALITY_OPTIONS: TrainingModality[] = ['swimming', 'running', 'cycling', 'strength', 'walking'];
+const MODALITY_OPTIONS: TrainingModality[] = ['swimming', 'running', 'cycling', 'strength', 'walking', 'triathlon'];
 
 interface TemplateFormDrawerProps {
   mode: 'create' | 'edit';

--- a/src/modules/flux/hooks/useAthleteForm.ts
+++ b/src/modules/flux/hooks/useAthleteForm.ts
@@ -83,6 +83,7 @@ export const MODALITY_OPTIONS: { value: TrainingModality; label: string; icon: s
   { value: 'cycling', label: 'Ciclismo', icon: '\u{1F6B4}' },
   { value: 'strength', label: 'Musculacao', icon: '\u{1F3CB}\uFE0F' },
   { value: 'walking', label: 'Caminhada', icon: '\u{1F6B6}' },
+  { value: 'triathlon', label: 'Triatleta', icon: '\u{1F3C5}' },
 ];
 
 export const LEVEL_OPTIONS: { value: SimpleAthleteLevel; label: string }[] = [

--- a/src/modules/flux/types/flux.ts
+++ b/src/modules/flux/types/flux.ts
@@ -65,7 +65,7 @@ export type ExerciseCategory = 'warmup' | 'main' | 'technique' | 'cooldown' | 'd
 /**
  * Training modalities supported by Flux
  */
-export type TrainingModality = 'swimming' | 'running' | 'cycling' | 'strength' | 'walking';
+export type TrainingModality = 'swimming' | 'running' | 'cycling' | 'strength' | 'walking' | 'triathlon';
 
 // ============================================
 // DATABASE MODELS
@@ -553,9 +553,10 @@ export const MODALITY_CONFIG: Record<TrainingModality, { label: string; icon: st
   cycling: { label: 'Ciclismo', icon: '🚴', color: 'amber' },
   strength: { label: 'Forca', icon: '🏋️', color: 'purple' },
   walking: { label: 'Caminhada', icon: '🚶', color: 'blue' },
+  triathlon: { label: 'Triatleta', icon: '🏅', color: 'rose' },
 };
 
 /**
  * All available training modalities
  */
-export const TRAINING_MODALITIES: TrainingModality[] = ['swimming', 'running', 'cycling', 'strength', 'walking'];
+export const TRAINING_MODALITIES: TrainingModality[] = ['swimming', 'running', 'cycling', 'strength', 'walking', 'triathlon'];

--- a/src/modules/flux/views/CanvasEditorView.tsx
+++ b/src/modules/flux/views/CanvasEditorView.tsx
@@ -47,6 +47,7 @@ const MODALITY_ICONS: Record<string, string> = {
   cycling: '\u{1F6B4}',
   strength: '\u{1F4AA}',
   walking: '\u{1F6B6}',
+  triathlon: '\u{1F3C5}',
 };
 
 interface AthletePickerProps {
@@ -163,6 +164,7 @@ const MODALITY_PT_LABELS: Record<string, string> = {
   cycling: 'Ciclismo',
   strength: 'Musculacao',
   walking: 'Caminhada',
+  triathlon: 'Triatleta',
 };
 
 function slotToWeekWorkout(slot: WorkoutSlot): WeekWorkout {
@@ -191,6 +193,7 @@ function slotToWorkoutBlockData(slot: WorkoutSlot): WorkoutBlockData {
     ftp_percentage: slot.ftp_percentage,
     pace_zone: slot.pace_zone,
     css_percentage: slot.css_percentage,
+    templateId: slot.template_id,
   };
 }
 

--- a/src/modules/flux/views/TemplateLibraryView.tsx
+++ b/src/modules/flux/views/TemplateLibraryView.tsx
@@ -20,6 +20,7 @@ import {
   User as UserIcon,
   Pencil,
   Lock,
+  ChevronDown,
 } from 'lucide-react';
 import { WorkoutTemplateService } from '../services/workoutTemplateService';
 import { useWorkoutTemplates } from '../hooks';
@@ -139,6 +140,7 @@ export default function TemplateLibraryView() {
   const [editingTemplate, setEditingTemplate] = useState<WorkoutTemplate | null>(null);
   const [favoritingIds, setFavoritingIds] = useState<Set<string>>(new Set());
   const [groupByModality, setGroupByModality] = useState(false);
+  const [expandedModality, setExpandedModality] = useState<TrainingModality | null>(null);
 
   // Apply filters
   useEffect(() => {
@@ -347,7 +349,7 @@ export default function TemplateLibraryView() {
               Modalidade
             </p>
             <div className="flex flex-wrap gap-2">
-              {(['swimming', 'running', 'cycling', 'strength', 'walking'] as TrainingModality[]).map(
+              {(['swimming', 'running', 'cycling', 'strength', 'walking', 'triathlon'] as TrainingModality[]).map(
                 (modality) => (
                   <button
                     key={modality}
@@ -468,35 +470,48 @@ export default function TemplateLibraryView() {
             </button>
           </div>
         ) : groupByModality ? (
-          <div className="space-y-8">
-            {(['swimming', 'running', 'cycling', 'strength', 'walking'] as TrainingModality[])
+          <div className="space-y-3">
+            {(['swimming', 'running', 'cycling', 'strength', 'walking', 'triathlon'] as TrainingModality[])
               .map((mod) => {
                 const modTemplates = filteredTemplates.filter((t) => t.modality === mod);
                 if (modTemplates.length === 0) return null;
                 const config = MODALITY_CONFIG[mod];
+                const isExpanded = expandedModality === mod;
                 return (
-                  <div key={mod}>
-                    <div className="flex items-center gap-2 mb-4">
-                      <span className="text-xl">{config?.icon}</span>
-                      <h3 className="text-lg font-bold text-ceramic-text-primary">{config?.label}</h3>
-                      <span className="text-sm text-ceramic-text-secondary">({modTemplates.length})</span>
-                    </div>
-                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                      {modTemplates.map((template) => (
-                        <TemplateCard
-                          key={template.id}
-                          template={template}
-                          currentUserId={user?.id}
-                          onToggleFavorite={handleToggleFavorite}
-                          onEdit={handleEdit}
-                          onDuplicate={handleDuplicate}
-                          onDelete={handleDelete}
-                          onDragStart={handleDragStart}
-                          onDragEnd={handleDragEnd}
-                          isDragging={draggedTemplate?.id === template.id}
-                          favoritingId={favoritingIds.has(template.id)}
-                        />
-                      ))}
+                  <div key={mod} className="rounded-xl overflow-hidden ceramic-card">
+                    <button
+                      onClick={() => setExpandedModality(isExpanded ? null : mod)}
+                      className="w-full flex items-center justify-between p-4 hover:bg-white/30 transition-colors"
+                    >
+                      <div className="flex items-center gap-3">
+                        <span className="text-xl">{config?.icon}</span>
+                        <h3 className="text-lg font-bold text-ceramic-text-primary">{config?.label}</h3>
+                        <span className="text-sm text-ceramic-text-secondary">({modTemplates.length})</span>
+                      </div>
+                      <ChevronDown
+                        className={`w-5 h-5 text-ceramic-text-secondary transition-transform duration-200 ${isExpanded ? 'rotate-180' : ''}`}
+                      />
+                    </button>
+                    <div
+                      className={`transition-all duration-200 overflow-hidden ${isExpanded ? 'max-h-[2000px] opacity-100' : 'max-h-0 opacity-0'}`}
+                    >
+                      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 p-4 pt-0">
+                        {modTemplates.map((template) => (
+                          <TemplateCard
+                            key={template.id}
+                            template={template}
+                            currentUserId={user?.id}
+                            onToggleFavorite={handleToggleFavorite}
+                            onEdit={handleEdit}
+                            onDuplicate={handleDuplicate}
+                            onDelete={handleDelete}
+                            onDragStart={handleDragStart}
+                            onDragEnd={handleDragEnd}
+                            isDragging={draggedTemplate?.id === template.id}
+                            favoritingId={favoritingIds.has(template.id)}
+                          />
+                        ))}
+                      </div>
                     </div>
                   </div>
                 );


### PR DESCRIPTION
## Summary

Closes #610, #611, #623, #624

- **#610 Triathlon modality**: Added `'triathlon'` to `TrainingModality` type and all 12 related config/icon/label/color maps across the Flux module (icon: medal, color: rose)
- **#623 Accordion groups**: Replaced flat modality group rendering in TemplateLibraryView with collapsible accordion sections using ChevronDown + CSS max-height transitions
- **#611 Edit training link**: Added "Editar exercicio completo" button in WorkoutBlockEditor that navigates to the full TemplateFormDrawer when a slot has a template_id
- **#624 WhatsApp preview**: Fixed message preview rendering in PublishWhatsAppButton to parse and display `*bold*` and `_italic_` WhatsApp formatting instead of showing raw markers

## Files Changed (12)

| File | Changes |
|------|---------|
| `types/flux.ts` | TrainingModality type, MODALITY_CONFIG, TRAINING_MODALITIES |
| `hooks/useAthleteForm.ts` | MODALITY_OPTIONS |
| `forms/TemplateFormDrawer.tsx` | MODALITY_OPTIONS |
| `views/TemplateLibraryView.tsx` | Accordion + triathlon in filter/group arrays |
| `views/CanvasEditorView.tsx` | MODALITY_ICONS, MODALITY_PT_LABELS, templateId mapping |
| `canvas/CanvasEditorDrawer.tsx` | MODALITY_PT_LABELS |
| `canvas/CanvasLibrarySidebar.tsx` | MODALITY_ICONS, MODALITY_PT_LABELS |
| `canvas/MicrocycleGrid.tsx` | MODALITY_ICONS, MODALITY_PILL_STYLES |
| `canvas/WeeklyGrid.tsx` | WeekWorkout type, MODALITY_COLORS, MODALITY_ICONS |
| `canvas/WorkoutBlock.tsx` | MODALITY_COLORS, MODALITY_LABELS, templateId field |
| `canvas/WorkoutBlockEditor.tsx` | ExternalLink import, navigate hook, edit link UI |
| `canvas/PublishWhatsAppButton.tsx` | WhatsApp formatting parser |

## Test plan

- [x] `npm run build` passes
- [x] Pre-existing TS errors only (unrelated to Flux module)
- [ ] Verify triathlon option appears in athlete form modality selection
- [ ] Verify triathlon option appears in template form modality pills
- [ ] Verify accordion opens/closes for each modality group on /flux/templates
- [ ] Verify "Editar exercicio completo" link appears when editing a slot with template_id
- [ ] Verify WhatsApp preview renders bold text properly

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>