### PR TITLE
fix(telegram): use valid moments type for mood entries (#640)

### DIFF
--- a/supabase/functions/_shared/telegram-ai-router.ts
+++ b/supabase/functions/_shared/telegram-ai-router.ts
@@ -501,15 +501,25 @@ async function executeLogMood(
     ? (params.emotions as string[]).join(', ')
     : '';
 
+  // moments table CHECK constraint only allows type IN ('audio','text','both')
+  // Store mood data using emotion + sentiment_data columns (see migration 20260302050000)
+  const emotionLabel = score >= 4 ? 'feliz' : score === 3 ? 'neutro' : 'triste';
+
   const { data, error } = await supabase
     .from('moments')
     .insert({
       user_id: userId,
-      type: 'mood',
-      content: String(params.note || '').substring(0, 200),
-      quality_score: score,
-      emotion: emotionText,
-      tags: ['telegram'],
+      type: 'text',
+      content: String(params.note || `Check-in de humor via Telegram: ${score}/5`).substring(0, 200),
+      emotion: emotionText || emotionLabel,
+      sentiment_data: {
+        mood_score: score,
+        source: 'telegram',
+        type: 'mood_checkin',
+        emotions: Array.isArray(params.emotions) ? params.emotions : [],
+      },
+      quality_score: score / 5, // DECIMAL(3,2): normalize 1-5 to 0.20-1.00
+      tags: ['telegram', 'mood_checkin'],
     })
     .select('id, quality_score')
     .single();
@@ -717,9 +727,12 @@ async function executeGetMomentsSummary(
   lines.push(`📊 <b>${totalMoments} momento(s)</b> registrado(s)`);
 
   if (avgQuality !== null) {
+    // quality_score is stored as 0-1 in DB (DECIMAL(3,2)); convert to 1-5 for display
     const qualNum = parseFloat(avgQuality);
-    const qualEmoji = qualNum >= 4 ? '😄' : qualNum >= 3 ? '🙂' : qualNum >= 2 ? '😕' : '😔';
-    lines.push(`${qualEmoji} Qualidade media: <b>${avgQuality}/5</b>`);
+    const displayScore = qualNum <= 1 ? (qualNum * 5).toFixed(1) : parseFloat(avgQuality).toFixed(1);
+    const displayNum = parseFloat(displayScore);
+    const qualEmoji = displayNum >= 4 ? '😄' : displayNum >= 3 ? '🙂' : displayNum >= 2 ? '😕' : '😔';
+    lines.push(`${qualEmoji} Qualidade media: <b>${displayScore}/5</b>`);
   }
 
   // Top emotions

--- a/supabase/functions/telegram-webhook/index.ts
+++ b/supabase/functions/telegram-webhook/index.ts
@@ -544,14 +544,23 @@ async function handleCallbackQuery(
         .rpc('get_telegram_user', { p_telegram_id: telegramId })
       const userId = userData?.[0]?.user_id
       if (userId) {
+        // moments table CHECK constraint only allows type IN ('audio','text','both')
+        // Store mood data using emotion + sentiment_data columns (see migration 20260302050000)
+        const emotionLabel = score >= 4 ? 'feliz' : score === 3 ? 'neutro' : 'triste'
         await supabase
           .from('moments')
           .insert({
             user_id: userId,
-            type: 'mood',
-            quality_score: score,
-            content: '',
-            tags: ['telegram'],
+            type: 'text',
+            content: `Check-in de humor via Telegram: ${score}/5`,
+            emotion: emotionLabel,
+            sentiment_data: {
+              mood_score: score,
+              source: 'telegram',
+              type: 'mood_checkin',
+            },
+            quality_score: score / 5, // DECIMAL(3,2): normalize 1-5 to 0.20-1.00
+            tags: ['telegram', 'mood_checkin'],
           })
         const moodEmojis: Record<number, string> = { 1: '😔', 2: '😕', 3: '😐', 4: '🙂', 5: '😄' }
         await reply(tg, msg,


### PR DESCRIPTION
## Summary
- **Root cause**: The `moments` table has a CHECK constraint `type IN ('audio','text','both')`, but Telegram mood creation was inserting `type='mood'`, causing all mood/moment inserts to fail with a constraint violation
- Fixed `executeLogMood` in `telegram-ai-router.ts`: uses `type='text'`, stores mood data in `emotion` + `sentiment_data` columns, normalizes `quality_score` to 0-1 scale (DECIMAL(3,2))
- Fixed `mood_rating` callback handler in `telegram-webhook/index.ts`: same fix pattern
- Fixed `executeGetMomentsSummary` display: converts 0-1 quality_score back to 1-5 scale for human-readable output
- Aligned with existing migration `20260302050000_telegram_notifications_fixes.sql` which already fixed the same issue in the `handle_telegram_mood_response` RPC

## Test plan
- [ ] Deploy Edge Functions: `telegram-webhook` and verify mood creation via Telegram bot
- [ ] Send a mood message (e.g., "To me sentindo bem hoje") and verify moment is created in `moments` table with `type='text'`
- [ ] Click mood rating inline keyboard (1-5) and verify moment is created correctly
- [ ] Ask "como tenho me sentido?" and verify moments summary displays quality correctly

Closes #640

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>