### PR TITLE
feat(admin): add navigation to admin module pages

### DIFF
--- a/src/modules/billing/pages/AdminCouponsPage.tsx
+++ b/src/modules/billing/pages/AdminCouponsPage.tsx
@@ -1,9 +1,12 @@
 import React, { useState } from 'react';
-import { Loader2, Plus, Coins, Ticket, ToggleLeft, ToggleRight } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { ArrowLeft, Loader2, Plus, Coins, Ticket, ToggleLeft, ToggleRight } from 'lucide-react';
 import { PageShell } from '@/components/ui';
+import { Logo } from '@/components/ui/Logo';
 import { useAdminCoupons } from '@/hooks/useAdminCoupons';
 
 export function AdminCouponsPage() {
+  const navigate = useNavigate();
   const { coupons, isLoading, createCoupon, toggleCoupon, topUp } = useAdminCoupons();
 
   // Top-up form
@@ -78,7 +81,19 @@ export function AdminCouponsPage() {
   };
 
   return (
-    <PageShell title="Admin — Cupons">
+    <PageShell>
+      <div className="flex items-center gap-3 mb-6">
+        <Logo width={36} onClick={() => navigate('/vida')} className="rounded-lg" />
+        <button
+          onClick={() => navigate('/admin')}
+          className="w-9 h-9 ceramic-card-flat flex items-center justify-center rounded-full"
+          aria-label="Voltar"
+        >
+          <ArrowLeft className="w-4 h-4 text-ceramic-text-secondary" />
+        </button>
+        <h1 className="text-2xl font-bold text-ceramic-text-primary">Admin — Cupons</h1>
+      </div>
+
       <div className="space-y-6">
         {/* Section 1: Top-Up Manual */}
         <div className="bg-ceramic-50 rounded-xl p-6 shadow-ceramic-emboss">

--- a/src/modules/billing/pages/AdminPortalPage.tsx
+++ b/src/modules/billing/pages/AdminPortalPage.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import { PageShell } from '@/components/ui/PageShell';
-import { Gift, Calculator, CreditCard } from 'lucide-react';
+import { Logo } from '@/components/ui/Logo';
+import { ArrowLeft, Gift, Calculator, CreditCard } from 'lucide-react';
 
 interface AdminCard {
   title: string;
@@ -42,7 +43,19 @@ export function AdminPortalPage() {
   const navigate = useNavigate();
 
   return (
-    <PageShell title="Admin Portal">
+    <PageShell>
+      <div className="flex items-center gap-3 mb-6">
+        <Logo width={36} onClick={() => navigate('/vida')} className="rounded-lg" />
+        <button
+          onClick={() => navigate('/vida')}
+          className="w-9 h-9 ceramic-card-flat flex items-center justify-center rounded-full"
+          aria-label="Voltar"
+        >
+          <ArrowLeft className="w-4 h-4 text-ceramic-text-secondary" />
+        </button>
+        <h1 className="text-2xl font-bold text-ceramic-text-primary">Admin Portal</h1>
+      </div>
+
       <div className="max-w-4xl mx-auto">
         <p className="text-sm text-ceramic-text-secondary mb-8">
           Ferramentas administrativas para gestao de pricing, cupons e pagamentos.

--- a/src/modules/billing/pages/PricingSimulatorPage.tsx
+++ b/src/modules/billing/pages/PricingSimulatorPage.tsx
@@ -1,4 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ArrowLeft } from 'lucide-react';
+import { Logo } from '@/components/ui/Logo';
 import { VariablePanel } from '../components/simulator/VariablePanel';
 import { PLTab } from '../components/simulator/PLTab';
 import { UnitEconomicsTab } from '../components/simulator/UnitEconomicsTab';
@@ -11,6 +14,7 @@ import type { SimulationInput } from '../components/simulator/types';
 const TABS = ['P&L Mensal', 'Unit Economics', 'Cenarios'] as const;
 
 export function PricingSimulatorPage() {
+  const navigate = useNavigate();
   const { input: baselineInput, isLoading } = useBaselineData();
   const [input, setInput] = useState<SimulationInput>(DEFAULT_SIMULATION);
   const [activeTab, setActiveTab] = useState<typeof TABS[number]>('P&L Mensal');
@@ -49,10 +53,22 @@ export function PricingSimulatorPage() {
 
       <main className="flex-1 p-6 overflow-y-auto">
         <div className="max-w-6xl mx-auto">
-          <h1 className="text-2xl font-bold text-ceramic-text-primary mb-1">Simulador de Pricing</h1>
-          <p className="text-sm text-ceramic-text-secondary mb-6">
-            Ajuste as variaveis na barra lateral e veja o impacto em tempo real.
-          </p>
+          <div className="flex items-center gap-3 mb-6">
+            <Logo width={36} onClick={() => navigate('/vida')} className="rounded-lg" />
+            <button
+              onClick={() => navigate('/admin')}
+              className="w-9 h-9 ceramic-card-flat flex items-center justify-center rounded-full"
+              aria-label="Voltar"
+            >
+              <ArrowLeft className="w-4 h-4 text-ceramic-text-secondary" />
+            </button>
+            <div>
+              <h1 className="text-2xl font-bold text-ceramic-text-primary leading-tight">Simulador de Pricing</h1>
+              <p className="text-sm text-ceramic-text-secondary">
+                Ajuste as variaveis na barra lateral e veja o impacto em tempo real.
+              </p>
+            </div>
+          </div>
 
           {/* Tab bar */}
           <div className="flex gap-1 mb-6 bg-ceramic-base rounded-lg p-1">


### PR DESCRIPTION
## Summary
- Add AICA Logo (left) + back button to all 3 admin pages
- AdminPortalPage: back → /vida (home)
- AdminCouponsPage: back → /admin (portal hub)
- PricingSimulatorPage: back → /admin (portal hub)
- Logo click navigates to /vida on all pages

## Test plan
- [ ] `npm run typecheck` passes
- [ ] Navigate /admin → logo and back arrow visible, back goes to /vida
- [ ] Navigate /admin/coupons → back goes to /admin
- [ ] Navigate /admin/simulator → back goes to /admin
- [ ] Logo click goes to /vida from all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>