### PR TITLE
fix(studio): remove duplicate timeline, keep only HorizontalTimeline (#669)

### DIFF
--- a/src/components/features/visualizations/HorizontalTimeline.tsx
+++ b/src/components/features/visualizations/HorizontalTimeline.tsx
@@ -33,6 +33,8 @@ export interface HorizontalTimelineProps {
   phases: TimelinePhase[];
   /** Optional title displayed above the timeline */
   title?: string;
+  /** Optional callback when a phase node is clicked (enables navigation) */
+  onPhaseClick?: (phaseId: string) => void;
   className?: string;
 }
 
@@ -81,6 +83,7 @@ function getConnectorClass(leftStatus: TimelinePhaseStatus): string {
 export function HorizontalTimeline({
   phases,
   title,
+  onPhaseClick,
   className = '',
 }: HorizontalTimelineProps) {
   if (phases.length === 0) return null;
@@ -102,12 +105,17 @@ export function HorizontalTimeline({
           return (
             <React.Fragment key={phase.id}>
               {/* Phase node + label */}
-              <div className="flex flex-col items-center gap-1.5 flex-shrink-0">
+              <div
+                className={`flex flex-col items-center gap-1.5 flex-shrink-0 ${onPhaseClick ? 'cursor-pointer' : ''}`}
+                onClick={onPhaseClick ? () => onPhaseClick(phase.id) : undefined}
+                role={onPhaseClick ? 'button' : 'listitem'}
+                tabIndex={onPhaseClick ? 0 : undefined}
+                onKeyDown={onPhaseClick ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onPhaseClick(phase.id); } } : undefined}
+                aria-label={`${phase.label}: ${phase.status === 'completed' ? 'concluído' : phase.status === 'active' ? 'em andamento' : 'pendente'}`}
+              >
                 {/* Circle node */}
                 <div
-                  className={`w-10 h-10 rounded-full flex items-center justify-center transition-all ${outer}`}
-                  role="listitem"
-                  aria-label={`${phase.label}: ${phase.status === 'completed' ? 'concluído' : phase.status === 'active' ? 'em andamento' : 'pendente'}`}
+                  className={`w-10 h-10 rounded-full flex items-center justify-center transition-all ${outer} ${onPhaseClick ? 'hover:scale-110' : ''}`}
                 >
                   <span className={`text-lg leading-none select-none ${inner}`}>
                     {phase.icon}

--- a/src/modules/studio/components/workspace/PodcastWorkspace.tsx
+++ b/src/modules/studio/components/workspace/PodcastWorkspace.tsx
@@ -21,7 +21,7 @@
  * - useAutoSave: Hook for auto-saving changes with 2s debounce
  * - WorkspaceContent: Inner component that uses workspace context
  * - WorkspaceHeader: Header with breadcrumb and save status
- * - StageStepper: Stage navigation with completion indicators
+ * - HorizontalTimeline: Pipeline display with clickable stage navigation
  * - StageRenderer: Lazy-loads and renders active stage component
  *
  * Accessibility Features:
@@ -45,9 +45,8 @@ import { PodcastWorkspaceProvider, usePodcastWorkspace } from '@/modules/studio/
 import { useWorkspaceState } from '@/modules/studio/hooks/useWorkspaceState';
 import { useAutoSave } from '@/modules/studio/hooks/useAutoSave';
 import WorkspaceHeader from './WorkspaceHeader';
-import StageStepper from './StageStepper';
 import StageRenderer from './StageRenderer';
-import type { Dossier, WorkspaceCustomSource } from '@/modules/studio/types';
+import type { Dossier, PodcastStageId, WorkspaceCustomSource } from '@/modules/studio/types';
 import { createNamespacedLogger } from '@/lib/logger';
 import { AlertCircle } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
@@ -145,7 +144,7 @@ interface PodcastWorkspaceProps {
  * Separated to ensure context is available
  */
 function WorkspaceContent({ onBack }: { onBack: () => void }) {
-  const { state, actions, stageCompletions } = usePodcastWorkspace();
+  const { state, actions } = usePodcastWorkspace();
   const [isSaving, setIsSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
 
@@ -265,13 +264,12 @@ function WorkspaceContent({ onBack }: { onBack: () => void }) {
       <HorizontalTimeline
         phases={timelinePhases}
         title="Pipeline de Produção"
-      />
-
-      {/* Stage Navigation */}
-      <StageStepper
-        currentStage={state.currentStage}
-        completions={stageCompletions}
-        onStageChange={actions.setStage}
+        onPhaseClick={(phaseId) => {
+          // Only navigate to phases that are tracked in the workspace FSM
+          if (WORKSPACE_STAGE_ORDER.includes(phaseId as (typeof WORKSPACE_STAGE_ORDER)[number])) {
+            actions.setStage(phaseId as PodcastStageId);
+          }
+        }}
       />
 
       {/* Auto-save Error Banner */}


### PR DESCRIPTION
## Summary
- Closes #669
- Removed `StageStepper` from `PodcastWorkspace` — it duplicated the `HorizontalTimeline` pipeline display
- Added `onPhaseClick` prop to `HorizontalTimeline` so stage navigation is preserved (click any phase to jump to it)
- Cleaned up unused `stageCompletions` destructure

## Context
Issue: #669 — "[STUDIO] Tem que manter apenas a timeline de cima"

The Studio workspace had two timeline components stacked:
1. `HorizontalTimeline` — 6-phase pipeline with emojis (top)
2. `StageStepper` — 4-stage nav with icons (bottom)

User reported the duplication. Fix keeps the top one and merges navigation into it.

## Test plan
- [x] `npm run build` passes
- [x] No new TypeScript errors
- [ ] Manual: Studio workspace shows single timeline
- [ ] Manual: Clicking timeline phases navigates between stages
- [ ] Manual: Postproduction/Distribution phases are visible but not clickable (no workspace FSM stage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Timeline phases are now interactive and clickable for direct navigation.
  * Enhanced keyboard accessibility for timeline navigation with keyboard support (Enter/Space keys).
  * Added visual feedback (hover scaling) on timeline nodes to indicate they are clickable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->