### PR TITLE
fix(auth): proactive JWT refresh prevents 401 on Edge Functions (#681)

### DIFF
--- a/src/lib/gemini/client.ts
+++ b/src/lib/gemini/client.ts
@@ -6,7 +6,7 @@
  */
 
 import { supabase } from '@/services/supabaseClient'
-import { getCachedSession } from '@/services/authCacheService'
+import { getCachedSession, invalidateAuthCache } from '@/services/authCacheService'
 import { callWithRetry, type RetryOptions } from './retry'
 import { getModelForUseCase } from './models'
 import { GeminiError } from './types'
@@ -220,13 +220,50 @@ export class GeminiClient {
 
   /**
    * Faz request HTTP ao backend
+   * Retries once on 401 with a fresh token (defense-in-depth for expired JWTs, #681)
    */
   private async makeRequest(
     endpoint: string,
     request: GeminiChatRequest
   ): Promise<GeminiChatResponse> {
     const token = await this.getAuthToken()
+    const response = await this.doFetch(endpoint, request, token)
 
+    // If 401, try refreshing the token once and retry
+    if (response.status === 401) {
+      log.debug('Received 401, attempting token refresh and retry...')
+      invalidateAuthCache()
+      try {
+        const { data, error } = await supabase.auth.refreshSession()
+        if (!error && data.session?.access_token && data.session.access_token !== token) {
+          const retryResponse = await this.doFetch(endpoint, request, data.session.access_token)
+          if (!retryResponse.ok) {
+            throw await this.handleError(retryResponse)
+          }
+          return retryResponse.json()
+        }
+      } catch (retryErr) {
+        if (retryErr instanceof GeminiError) throw retryErr
+        // Refresh failed — throw original 401 error
+      }
+      throw await this.handleError(response)
+    }
+
+    if (!response.ok) {
+      throw await this.handleError(response)
+    }
+
+    return response.json()
+  }
+
+  /**
+   * Execute fetch with given auth token
+   */
+  private async doFetch(
+    endpoint: string,
+    request: GeminiChatRequest,
+    token: string
+  ): Promise<Response> {
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
       'Authorization': `Bearer ${token}`,
@@ -238,22 +275,17 @@ export class GeminiClient {
       headers['apikey'] = anonKey
     }
 
-    const response = await fetch(endpoint, {
+    return fetch(endpoint, {
       method: 'POST',
       headers,
       body: JSON.stringify(request)
     })
-
-    if (!response.ok) {
-      throw await this.handleError(response)
-    }
-
-    return response.json()
   }
 
   /**
    * Obtém token de autenticação do Supabase
    * Uses getCachedSession() to avoid auth lock contention (#660, #665)
+   * Proactively refreshes expired/expiring tokens to prevent 401 from Edge Functions (#681)
    */
   private async getAuthToken(): Promise<string> {
     const { session, error } = await getCachedSession()
@@ -266,7 +298,37 @@ export class GeminiClient {
       throw new GeminiError('User not authenticated', 'UNAUTHORIZED', 401)
     }
 
+    // Check if token is expired or expiring within 60s — refresh proactively
+    // This prevents 401 from Edge Functions with verify_jwt = true
+    if (this.isTokenExpiringSoon(session.access_token)) {
+      log.debug('Access token expired or expiring soon, refreshing...')
+      invalidateAuthCache()
+      try {
+        const { data, error: refreshError } = await supabase.auth.refreshSession()
+        if (!refreshError && data.session?.access_token) {
+          return data.session.access_token
+        }
+      } catch {
+        // Refresh failed — fall through with current token, let server decide
+      }
+    }
+
     return session.access_token
+  }
+
+  /**
+   * Check if JWT access token is expired or expiring within threshold
+   */
+  private isTokenExpiringSoon(token: string, thresholdSeconds = 60): boolean {
+    try {
+      const payloadB64 = token.split('.')[1]
+      if (!payloadB64) return false
+      const payload = JSON.parse(atob(payloadB64))
+      const expiresAtMs = (payload.exp || 0) * 1000
+      return Date.now() > expiresAtMs - (thresholdSeconds * 1000)
+    } catch {
+      return false
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary
- Closes #681
- GeminiClient now proactively checks JWT expiry and refreshes token before sending requests to Edge Functions
- Adds 401 retry with fresh token as defense-in-depth fallback

## Context
Issue: #681 — Microphone transcription in Flux feedback fails with "Erro na transcricao. Use o campo de texto"

**Root cause:** `gemini-chat` Edge Function has `verify_jwt = true`. When the user's access token expires and Supabase SDK auto-refresh hasn't fired, `GeminiClient` sends the expired token → Supabase middleware rejects with 401 → retry logic doesn't consider 401 retryable → immediate failure.

**Fix (2 layers):**
1. `getAuthToken()` — decodes JWT `exp` claim, proactively calls `refreshSession()` if token expires within 60s
2. `makeRequest()` — on 401 response, invalidates auth cache, refreshes session, retries once with fresh token

## Test plan
- [ ] `npm run build` passes
- [ ] `npm run typecheck` passes
- [ ] Manual: open Flux → Meu Atleta → feedback → record voice → transcription succeeds
- [ ] Manual: let session idle 1h+ → try voice transcription → should auto-refresh and succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authentication resilience with proactive token refresh checks to prevent expiration during requests.
  * Improved error recovery by automatically retrying failed API calls with refreshed credentials.
  * More reliable token management with better handling of expired authentication sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->