### PR TITLE
feat(flux): make athlete level/modality nullable for demo seed

### DIFF
--- a/src/modules/flux/types/flow.ts
+++ b/src/modules/flux/types/flow.ts
@@ -260,8 +260,8 @@ export interface FlowAthleteProfile {
   phone?: string;
 
   // Training Profile
-  modality: TrainingModality;
-  level: AthleteLevel;
+  modality?: TrainingModality;
+  level?: AthleteLevel;
 
   // Performance Thresholds
   ftp?: number; // watts

--- a/src/modules/flux/types/flux.ts
+++ b/src/modules/flux/types/flux.ts
@@ -80,9 +80,9 @@ export interface Athlete {
   name: string;
   email?: string;
   phone: string; // WhatsApp format: +5511987654321
-  level: AthleteLevel;
+  level?: AthleteLevel;
   status: AthleteStatus;
-  modality: TrainingModality; // Primary training modality
+  modality?: TrainingModality; // Primary training modality
   trial_expires_at?: string; // ISO 8601
   onboarding_data?: Record<string, unknown>; // AI onboarding responses
   anamnesis?: AnamnesisData;

--- a/supabase/migrations/20260303150000_make_athlete_level_modality_nullable.sql
+++ b/supabase/migrations/20260303150000_make_athlete_level_modality_nullable.sql
@@ -1,0 +1,4 @@
+-- Allow athletes to be created without level/modality
+-- Coach assigns these when prescribing workouts
+ALTER TABLE athletes ALTER COLUMN level DROP NOT NULL;
+ALTER TABLE athletes ALTER COLUMN modality DROP NOT NULL;


### PR DESCRIPTION
## Summary
- Make `level` and `modality` columns nullable on `athletes` table so coaches can create athletes without pre-assigning these fields
- Inserted 10 realistic seed athletes in Supabase for early adopter testing and first client demo
- Updated TypeScript types (`flux.ts`, `flow.ts`) to reflect nullable fields

## Context
The early adopter needs athletes in the system to test workout prescriptions with a realistic feel. Athletes are created "from scratch" — the coach assigns modality and level when prescribing exercises.

## Test plan
- [x] `npm run typecheck` passes (no new errors)
- [x] Migration applied on Supabase (`level`/`modality` DROP NOT NULL)
- [x] 10 athletes visible in Flux dashboard for coach `ea2fb115-...`
- [ ] Verify on staging (dev.aica.guru) after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Athlete profiles can now be created without specifying training modality and level. These fields are now optional and can be configured later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->