### PR TITLE
fix(weather): add fallback geolocation provider + timezone estimation (#701)

### DIFF
--- a/src/hooks/useUserLocation.ts
+++ b/src/hooks/useUserLocation.ts
@@ -11,7 +11,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { useAuth } from '@/hooks/useAuth'
 import { supabase } from '@/services/supabaseClient'
-import { detectLocationFromIp } from '@/services/geolocationService'
+import { detectLocationFromIp, estimateLocationFromTimezone } from '@/services/geolocationService'
 import type { GeolocationData } from '@/lib/external-api'
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000
@@ -41,7 +41,10 @@ async function resolveLocation(userId: string): Promise<GeolocationData | null> 
 
   // 2. Fall back to IP-based detection
   const ipLocation = await detectLocationFromIp()
-  return ipLocation
+  if (ipLocation) return ipLocation
+
+  // 3. Last resort: estimate from browser timezone
+  return estimateLocationFromTimezone()
 }
 
 export function useUserLocation() {

--- a/src/lib/external-api/types.ts
+++ b/src/lib/external-api/types.ts
@@ -51,7 +51,7 @@ export interface GeolocationData {
   city: string
   latitude: number
   longitude: number
-  source: 'ipapi' | 'browser' | 'cep' | 'manual'
+  source: 'ipapi' | 'ip-api' | 'browser' | 'cep' | 'manual' | 'timezone'
 }
 
 export interface CepData {

--- a/src/services/geolocationService.ts
+++ b/src/services/geolocationService.ts
@@ -47,6 +47,44 @@ export function detectLocationFromBrowser(): Promise<GeolocationCoordinates | nu
 }
 
 /**
+ * Estimates approximate location from the browser's timezone.
+ * Last-resort fallback when IP-based and browser geolocation both fail.
+ * Maps common Brazilian timezones to their major city coordinates.
+ */
+export function estimateLocationFromTimezone(): GeolocationData | null {
+  const tz = Intl.DateTimeFormat().resolvedOptions().timeZone
+
+  const TIMEZONE_MAP: Record<string, { city: string; latitude: number; longitude: number }> = {
+    'America/Sao_Paulo': { city: 'São Paulo', latitude: -23.55, longitude: -46.63 },
+    'America/Fortaleza': { city: 'Fortaleza', latitude: -3.72, longitude: -38.52 },
+    'America/Manaus': { city: 'Manaus', latitude: -3.12, longitude: -60.02 },
+    'America/Recife': { city: 'Recife', latitude: -8.05, longitude: -34.87 },
+    'America/Bahia': { city: 'Salvador', latitude: -12.97, longitude: -38.51 },
+    'America/Cuiaba': { city: 'Cuiabá', latitude: -15.60, longitude: -56.10 },
+    'America/Belem': { city: 'Belém', latitude: -1.46, longitude: -48.50 },
+    'America/Porto_Velho': { city: 'Porto Velho', latitude: -8.76, longitude: -63.90 },
+    'America/Rio_Branco': { city: 'Rio Branco', latitude: -9.97, longitude: -67.81 },
+    'America/Araguaina': { city: 'Palmas', latitude: -10.18, longitude: -48.33 },
+    'America/Campo_Grande': { city: 'Campo Grande', latitude: -20.44, longitude: -54.65 },
+    'America/Maceio': { city: 'Maceió', latitude: -9.67, longitude: -35.74 },
+    'America/Noronha': { city: 'Fernando de Noronha', latitude: -3.85, longitude: -32.42 },
+    'America/Boa_Vista': { city: 'Boa Vista', latitude: 2.82, longitude: -60.67 },
+    'America/Santarem': { city: 'Santarém', latitude: -2.44, longitude: -54.71 },
+  }
+
+  const match = TIMEZONE_MAP[tz]
+  if (!match) return null
+
+  return {
+    city: match.city,
+    latitude: match.latitude,
+    longitude: match.longitude,
+    timezone: tz,
+    source: 'timezone',
+  }
+}
+
+/**
  * Saves a manually-entered or auto-detected location to the user's profile.
  */
 export async function saveManualLocation(

--- a/supabase/functions/external-geolocation/index.ts
+++ b/supabase/functions/external-geolocation/index.ts
@@ -1,8 +1,9 @@
 /**
- * External Geolocation Edge Function — ipapi.co
+ * External Geolocation Edge Function — ipapi.co + ip-api.com fallback
  *
  * Resolves user location (timezone, city, lat/lng) from IP address.
  * Caches result in user's profile to avoid redundant lookups.
+ * Falls back to ip-api.com when ipapi.co fails.
  *
  * @endpoint POST /external-geolocation
  * @auth Required (JWT)
@@ -29,6 +30,14 @@ const GEO_CONFIG: ExternalApiConfig = {
   rateLimitPerDay: 900,
 };
 
+const IP_API_CONFIG: ExternalApiConfig = {
+  name: 'ip-api',
+  baseUrl: 'http://ip-api.com',
+  cacheTtlSeconds: 86400, // 24 hours
+  maxRetries: 1,
+  rateLimitPerDay: 900,
+};
+
 interface IpApiResponse {
   ip: string;
   city: string;
@@ -40,6 +49,18 @@ interface IpApiResponse {
   utc_offset: string;
   error?: boolean;
   reason?: string;
+}
+
+interface IpApiComResponse {
+  status: string;
+  message?: string;
+  city: string;
+  regionName: string;
+  country: string;
+  lat: number;
+  lon: number;
+  timezone: string;
+  offset: number;
 }
 
 interface GeoData {
@@ -102,7 +123,7 @@ serve(async (req) => {
             longitude: profile.detected_longitude,
             source: profile.location_source || 'cached',
           } as GeoData,
-          source: 'ipapi',
+          source: profile.location_source || 'cached',
           cached: true,
           latencyMs: 0,
         }),
@@ -114,7 +135,7 @@ serve(async (req) => {
     const forwarded = req.headers.get('x-forwarded-for');
     const clientIp = forwarded ? forwarded.split(',')[0].trim() : '';
 
-    // 4. Fetch from ipapi.co
+    // 4. Try ipapi.co first
     const path = clientIp ? `/${clientIp}/json/` : '/json/';
     const apiResult: ExternalApiResponse<IpApiResponse> = await fetchExternalApi<IpApiResponse>(
       GEO_CONFIG,
@@ -122,68 +143,92 @@ serve(async (req) => {
       { cacheKey: `geo:${user.id}` },
     );
 
-    if (!apiResult.success || !apiResult.data) {
+    let geoData: GeoData | null = null;
+    let totalLatencyMs = apiResult.latencyMs;
+
+    if (apiResult.success && apiResult.data && !apiResult.data.error) {
+      // ipapi.co succeeded
+      const geo = apiResult.data;
+      geoData = {
+        timezone: geo.timezone,
+        city: geo.city,
+        latitude: geo.latitude,
+        longitude: geo.longitude,
+        source: 'ipapi',
+      };
+    } else {
+      // 5. ipapi.co failed — try ip-api.com as fallback
+      const ipapiError = apiResult.data?.reason || apiResult.error || 'ipapi.co failed';
+      console.warn(TAG, `ipapi.co failed: ${ipapiError} — trying ip-api.com fallback`);
+
+      const fallbackPath = clientIp
+        ? `/json/${clientIp}?fields=status,message,city,regionName,country,lat,lon,timezone,offset`
+        : '/json?fields=status,message,city,regionName,country,lat,lon,timezone,offset';
+
+      const fallbackResult: ExternalApiResponse<IpApiComResponse> =
+        await fetchExternalApi<IpApiComResponse>(
+          IP_API_CONFIG,
+          fallbackPath,
+          { cacheKey: `geo-fallback:${user.id}` },
+        );
+
+      totalLatencyMs += fallbackResult.latencyMs;
+
+      if (fallbackResult.success && fallbackResult.data && fallbackResult.data.status === 'success') {
+        const fb = fallbackResult.data;
+        geoData = {
+          timezone: fb.timezone,
+          city: fb.city,
+          latitude: fb.lat,
+          longitude: fb.lon,
+          source: 'ip-api',
+        };
+        console.log(TAG, `ip-api.com fallback succeeded for user ${user.id}`);
+      } else {
+        const fbError = fallbackResult.data?.message || fallbackResult.error || 'ip-api.com failed';
+        console.error(TAG, `Both providers failed. ipapi: ${ipapiError}, ip-api: ${fbError}`);
+      }
+    }
+
+    // Both providers failed — return 502
+    if (!geoData) {
       return new Response(
         JSON.stringify({
           success: false,
-          error: apiResult.error || 'Failed to resolve geolocation',
-          source: 'ipapi',
+          error: 'All geolocation providers failed',
+          source: 'ipapi+ip-api',
           cached: false,
-          latencyMs: apiResult.latencyMs,
+          latencyMs: totalLatencyMs,
         }),
         { status: 502, headers: jsonHeaders },
       );
     }
 
-    const geo = apiResult.data;
-
-    // ipapi returns error as part of the JSON body
-    if (geo.error) {
-      return new Response(
-        JSON.stringify({
-          success: false,
-          error: geo.reason || 'ipapi returned an error',
-          source: 'ipapi',
-          cached: false,
-          latencyMs: apiResult.latencyMs,
-        }),
-        { status: 502, headers: jsonHeaders },
-      );
-    }
-
-    // 5. Save to profiles table
+    // 6. Save to profiles table
     const { error: updateError } = await supabase
       .from('profiles')
       .update({
-        detected_timezone: geo.timezone,
-        detected_city: geo.city,
-        detected_latitude: geo.latitude,
-        detected_longitude: geo.longitude,
-        location_source: 'ipapi',
+        detected_timezone: geoData.timezone,
+        detected_city: geoData.city,
+        detected_latitude: geoData.latitude,
+        detected_longitude: geoData.longitude,
+        location_source: geoData.source,
       })
       .eq('id', user.id);
 
     if (updateError) {
       console.warn(TAG, `Failed to update profile geo data: ${updateError.message}`);
     } else {
-      console.log(TAG, `Saved geo data for user ${user.id}: ${geo.city}, ${geo.timezone}`);
+      console.log(TAG, `Saved geo data for user ${user.id}: ${geoData.city}, ${geoData.timezone} (via ${geoData.source})`);
     }
-
-    const result: GeoData = {
-      timezone: geo.timezone,
-      city: geo.city,
-      latitude: geo.latitude,
-      longitude: geo.longitude,
-      source: 'ipapi',
-    };
 
     return new Response(
       JSON.stringify({
         success: true,
-        data: result,
-        source: 'ipapi',
+        data: geoData,
+        source: geoData.source,
         cached: false,
-        latencyMs: apiResult.latencyMs,
+        latencyMs: totalLatencyMs,
       }),
       { status: 200, headers: jsonHeaders },
     );


### PR DESCRIPTION
## Summary
- **Edge Function**: Added `ip-api.com` as fallback when `ipapi.co` fails (502), only returning 502 when both providers fail
- **Frontend**: Added browser timezone estimation as last-resort fallback — maps 15 Brazilian timezones to approximate city coordinates
- **Types**: Extended `GeolocationData.source` union with `'ip-api'` and `'timezone'`

## Resolution Chain
```
1. profiles table cache (instant) ✅
2. ipapi.co API call ✅
3. ip-api.com fallback (NEW) ✅
4. Browser timezone estimation (NEW) ✅
5. Error state (only if all above fail)
```

## Files Changed
| File | Change |
|------|--------|
| `supabase/functions/external-geolocation/index.ts` | Add ip-api.com fallback provider |
| `src/services/geolocationService.ts` | Add `estimateLocationFromTimezone()` |
| `src/hooks/useUserLocation.ts` | Wire timezone fallback into resolution cascade |
| `src/lib/external-api/types.ts` | Add `'ip-api'` and `'timezone'` to source union |

## Test plan
- [ ] `npm run build` passes
- [ ] `npm run typecheck` passes (no new errors)
- [ ] Weather card loads on Vida page when ipapi.co is down
- [ ] Timezone fallback shows approximate city for Brazilian users
- [ ] Deploy Edge Function to staging and verify

Closes #701

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added timezone-based location detection as a fallback when IP detection fails
  * Introduced secondary IP geolocation provider for improved coverage
  * Location source tracking now visible in responses for better transparency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->