### PR TITLE
fix(billing): reconnect AI Cost Dashboard to Settings menu

### DIFF
--- a/src/components/layout/SettingsMenu.tsx
+++ b/src/components/layout/SettingsMenu.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useMemo } from 'react';
-import { Settings, LogOut, FileSearch, Crown, LayoutGrid, Ticket, Shield, FileText, Activity } from 'lucide-react';
+import { Settings, LogOut, FileSearch, Crown, LayoutGrid, Ticket, Shield, FileText, Activity, DollarSign } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { supabase } from '@/services/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
@@ -172,6 +172,22 @@ export const SettingsMenu: React.FC<SettingsMenuProps> = ({
                             </div>
                             <span className="font-bold text-sm transition-colors">
                                 Meu Plano
+                            </span>
+                        </button>
+
+                        {/* AI Cost Dashboard Button */}
+                        <button
+                            onClick={() => {
+                                navigate('/ai-cost');
+                                setIsOpen(false);
+                            }}
+                            className="w-full flex items-center gap-3 px-4 py-3 rounded-xl text-ceramic-text-primary hover:bg-white/40 transition-all group mb-1"
+                        >
+                            <div className="w-8 h-8 rounded-full ceramic-inset flex items-center justify-center group-hover:scale-110 transition-transform">
+                                <DollarSign className="w-4 h-4 text-ceramic-text-secondary group-hover:text-amber-500" />
+                            </div>
+                            <span className="font-bold text-sm transition-colors">
+                                Custos de IA
                             </span>
                         </button>
 

--- a/src/router/AppRouter.tsx
+++ b/src/router/AppRouter.tsx
@@ -100,6 +100,9 @@ const AdminPortalPage = lazy(() => import('../modules/billing').then(m => ({ def
 const AdminCouponsPage = lazy(() => import('../modules/billing').then(m => ({ default: m.AdminCouponsPage })));
 const PricingSimulatorPage = lazy(() => import('../modules/billing').then(m => ({ default: m.PricingSimulatorPage })));
 
+// AI Cost Dashboard - Usage and cost monitoring
+const AICostDashboard = lazy(() => import('../components/aiCost/AICostDashboard').then(m => ({ default: m.AICostDashboard })));
+
 // Invites Dashboard - Manage sent invites
 const InvitesPage = lazy(() => import('../pages/InvitesPage'));
 
@@ -840,6 +843,12 @@ export function AppRouter() {
                <Route
                   path="/manage-subscription"
                   element={<ProtectedRoute><ManageSubscriptionPage /></ProtectedRoute>}
+               />
+
+               {/* AI Cost Dashboard - Usage monitoring */}
+               <Route
+                  path="/ai-cost"
+                  element={<ProtectedRoute><AICostDashboard userId={userId || ''} onBack={() => navigate(-1)} /></ProtectedRoute>}
                />
 
                {/* Admin Portal — admin-only routes */}


### PR DESCRIPTION
## Summary
- Reconnects the orphaned `AICostDashboard` component to the app
- Adds "Custos de IA" button in SettingsMenu (with DollarSign icon)
- Adds `/ai-cost` protected route in AppRouter

The dashboard components (`AICostDashboard`, `CostTrendChart`, `ModelBreakdownChart`, etc.) and services (`aiCostAnalyticsService`, `aiUsageTrackingService`) already existed but had no route or menu entry pointing to them.

## Test plan
- [x] `npm run build` passes
- [ ] Navigate to Settings → "Custos de IA" opens the dashboard
- [ ] Back button returns to previous page

🤖 Generated with [Claude Code](https://claude.com/claude-code)