### PR TITLE
fix(flux): hoist useMemo hooks before early returns in AthletePortalView

### DIFF
--- a/src/modules/flux/views/AthletePortalView.tsx
+++ b/src/modules/flux/views/AthletePortalView.tsx
@@ -176,6 +176,35 @@ export default function AthletePortalView() {
     finally { setUpdating(null); }
   }, [refetch]);
 
+  // ── Hooks that must run before early returns (Rules of Hooks) ──
+
+  const micro = profile?.active_microcycle;
+
+  const pastWorkoutDays = useMemo(() => {
+    if (!micro?.slots?.length || !micro.start_date) return 0;
+    const today = new Date();
+    today.setHours(23, 59, 59, 999);
+    const startDate = new Date(micro.start_date);
+    let count = 0;
+    for (const slot of micro.slots) {
+      const weekOffset = (slot.week_number - 1) * 7;
+      const dayOffset = slot.day_of_week - 1;
+      const slotDate = new Date(startDate);
+      slotDate.setDate(startDate.getDate() + weekOffset + dayOffset);
+      if (slotDate <= today) count++;
+    }
+    return count;
+  }, [micro?.slots, micro?.start_date]);
+
+  const prescribedModalities = useMemo((): Array<keyof typeof MODALITY_CONFIG> => {
+    const mod = profile?.modality as keyof typeof MODALITY_CONFIG;
+    if (!mod) return ['strength'];
+    if (mod === 'triathlon') {
+      return ['triathlon', 'swimming', 'running', 'cycling'];
+    }
+    return MODALITY_CONFIG[mod] ? [mod] : ['strength'];
+  }, [profile?.modality]);
+
   // ── Early returns ──
 
   if (isLoading) {
@@ -253,39 +282,10 @@ export default function AthletePortalView() {
     );
   }
 
-  // ── Data processing ──
+  // ── Data processing (micro, pastWorkoutDays, prescribedModalities hoisted above early returns) ──
 
-  const micro = profile.active_microcycle;
   const modalityConfig = MODALITY_CONFIG[profile.modality];
-
-  // Count past workout days (days that have already passed) instead of manual completions
-  const pastWorkoutDays = useMemo(() => {
-    if (!micro?.slots?.length || !micro.start_date) return 0;
-    const today = new Date();
-    today.setHours(23, 59, 59, 999);
-    const startDate = new Date(micro.start_date);
-    let count = 0;
-    for (const slot of micro.slots) {
-      const weekOffset = (slot.week_number - 1) * 7;
-      const dayOffset = slot.day_of_week - 1;
-      const slotDate = new Date(startDate);
-      slotDate.setDate(startDate.getDate() + weekOffset + dayOffset);
-      if (slotDate <= today) count++;
-    }
-    return count;
-  }, [micro?.slots, micro?.start_date]);
   const completionPct = micro ? Math.round((pastWorkoutDays / Math.max(micro.total_slots, 1)) * 100) : 0;
-
-  // Derive athlete modalities from profile.modality
-  // Template categories (warmup, main, cooldown) don't map to training modalities,
-  // so we use the athlete's declared modality and expand triathlon to its components.
-  const prescribedModalities = useMemo((): Array<keyof typeof MODALITY_CONFIG> => {
-    const mod = profile.modality as keyof typeof MODALITY_CONFIG;
-    if (mod === 'triathlon') {
-      return ['triathlon', 'swimming', 'running', 'cycling'];
-    }
-    return MODALITY_CONFIG[mod] ? [mod] : ['strength'];
-  }, [profile.modality]);
 
   const weeks = micro
     ? [1, 2, 3, 4].map((wk) => {


### PR DESCRIPTION
## Summary
- Moves `pastWorkoutDays` and `prescribedModalities` `useMemo` hooks before early return blocks in `AthletePortalView.tsx`
- Fixes React "Rendered more hooks than during the previous render" error (#719)
- Root cause: early returns (loading, error, no-profile states) caused hook count mismatch when component transitioned from loading to loaded state

## Test plan
- [ ] `npm run build` passes
- [ ] `npm run typecheck` passes (no new errors in changed file)
- [ ] Navigate to Flux > Meu Treino — no hook order crash
- [ ] Loading state renders correctly before profile loads

Closes #719

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code organization improvements for better maintainability and consistency with development best practices. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->