### PR TITLE
fix(flux): use 8-question questionnaire for daily feedback

### DIFF
--- a/src/modules/flux/components/athlete/WeeklyFeedbackCard.tsx
+++ b/src/modules/flux/components/athlete/WeeklyFeedbackCard.tsx
@@ -320,10 +320,17 @@ export function useDailyFeedback({
     }
   }, [dayEntries, userId, athleteId, microcycleId, weekNumber]);
 
+  const markDaySubmitted = useCallback((day: number) => {
+    setDayEntries((prev) => ({
+      ...prev,
+      [day]: { ...prev[day], isSubmitted: true },
+    }));
+  }, []);
+
   return {
     dayEntries, expandedDay, submittingDay, isFutureWeek, daysToShow,
     getDateForDay, isDayFuture, handleSetRating, handleSetNotes, handleSubmitDay,
-    setExpandedDay,
+    setExpandedDay, markDaySubmitted,
   };
 }
 

--- a/src/modules/flux/views/AthletePortalView.tsx
+++ b/src/modules/flux/views/AthletePortalView.tsx
@@ -16,7 +16,8 @@ import { useCanvasCalendar } from '../hooks/useCanvasCalendar';
 import { WorkoutSlotService } from '../services/workoutSlotService';
 import { AthleteWelcome } from '../components/AthleteWelcome';
 import { ParQWizard } from '../components/parq/ParQWizard';
-import { ProgressTimeline, WorkoutCard, AthleteFeedbackView, DayFeedbackCard, useDailyFeedback } from '../components/athlete';
+import { ProgressTimeline, WorkoutCard, AthleteFeedbackView, useDailyFeedback } from '../components/athlete';
+import { ExerciseQuestionnaireSheet } from '../components/athlete/ExerciseQuestionnaireSheet';
 import { WeeklyGrid, type WeekWorkout } from '../components/canvas/WeeklyGrid';
 import type { FeedbackData } from '../components/athlete';
 import { useAuth } from '@/hooks/useAuth';
@@ -83,6 +84,8 @@ export default function AthletePortalView() {
   const [updating, setUpdating] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<'treinos' | 'feedback'>('treinos');
   const [feedbackSlotId, setFeedbackSlotId] = useState<string | null>(null);
+  const [questionnaireDay, setQuestionnaireDay] = useState<number | null>(null);
+  const [questionnaireSubmitting, setQuestionnaireSubmitting] = useState(false);
   const [selectedWeek, setSelectedWeek] = useState<number>(1);
   const [viewMode, setViewMode] = useState<'list' | 'canvas'>(() => {
     try { return (localStorage.getItem('flux_athlete_view_mode') as 'list' | 'canvas') || 'list'; }
@@ -546,18 +549,22 @@ export default function AthletePortalView() {
                               isUpdating={updating === slot.id} modality={profile.modality} />
                           ))}
                           {/* Inline daily feedback below exercises */}
-                          {feedbackEntry && user && (
-                            <DayFeedbackCard
-                              entry={feedbackEntry}
-                              dayDate={dailyFeedback.getDateForDay(day)}
-                              isFuture={dailyFeedback.isDayFuture(day)}
-                              isExpanded={dailyFeedback.expandedDay === day}
-                              isSubmitting={dailyFeedback.submittingDay === day}
-                              onToggleExpand={() => dailyFeedback.setExpandedDay(dailyFeedback.expandedDay === day ? null : day)}
-                              onSetRating={(rating) => dailyFeedback.handleSetRating(day, rating)}
-                              onSetNotes={(notes) => dailyFeedback.handleSetNotes(day, notes)}
-                              onSubmit={() => dailyFeedback.handleSubmitDay(day)}
-                            />
+                          {feedbackEntry && user && !dailyFeedback.isDayFuture(day) && (
+                            feedbackEntry.isSubmitted ? (
+                              <div className="flex items-center gap-2 px-4 py-2.5 rounded-xl bg-ceramic-success/10 border border-ceramic-success/20">
+                                <CheckCircle className="w-3.5 h-3.5 text-ceramic-success flex-shrink-0" />
+                                <span className="text-xs font-bold text-ceramic-success">Feedback enviado</span>
+                              </div>
+                            ) : (
+                              <button
+                                type="button"
+                                onClick={() => setQuestionnaireDay(day)}
+                                className="w-full flex items-center gap-2 px-4 py-2.5 rounded-xl bg-amber-50 border border-amber-200/50 hover:bg-amber-100 transition-colors"
+                              >
+                                <MessageSquare className="w-3.5 h-3.5 text-amber-600 flex-shrink-0" />
+                                <span className="text-xs font-bold text-amber-700">Dar Feedback do Dia</span>
+                              </button>
+                            )
                           )}
                         </div>
                       ) : (
@@ -586,6 +593,44 @@ export default function AthletePortalView() {
           <AthleteFeedbackView profile={profile} onRefetch={refetch} highlightSlotId={feedbackSlotId} selectedWeek={selectedWeek} />
         </motion.section>
       )}
+
+      {/* 8-question feedback sheet */}
+      {questionnaireDay != null && micro && user && (() => {
+        const daySlots = slotsByDay.get(questionnaireDay) || [];
+        const slotName = daySlots.map(s => s.template?.name || 'Treino').join(' + ');
+        const qDate = getDateForDay(questionnaireDay);
+        const dayLabel = `${DAY_NAMES[questionnaireDay]}${qDate ? ` - ${qDate.getDate().toString().padStart(2, '0')}/${(qDate.getMonth() + 1).toString().padStart(2, '0')}` : ''}`;
+        return (
+          <ExerciseQuestionnaireSheet
+            slotId={`day-${questionnaireDay}-week-${selectedWeek}`}
+            slotName={slotName}
+            dayLabel={dayLabel}
+            isSubmitting={questionnaireSubmitting}
+            onClose={() => setQuestionnaireDay(null)}
+            onSubmit={async ({ questionnaire, notes }) => {
+              setQuestionnaireSubmitting(true);
+              try {
+                await supabase.from('athlete_feedback_entries').insert({
+                  user_id: user.id,
+                  athlete_id: profile.athlete_id,
+                  microcycle_id: micro.id,
+                  feedback_type: 'daily',
+                  week_number: selectedWeek,
+                  day_of_week: questionnaireDay,
+                  questionnaire,
+                  notes: notes.trim() || null,
+                });
+                dailyFeedback.markDaySubmitted(questionnaireDay);
+                setQuestionnaireDay(null);
+              } catch (err) {
+                log.error('Failed to submit daily questionnaire:', err);
+              } finally {
+                setQuestionnaireSubmitting(false);
+              }
+            }}
+          />
+        );
+      })()}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replaces simple emoji-rating DayFeedbackCard with full 8-question ExerciseQuestionnaireSheet for daily feedback
- Each training day shows "Dar Feedback do Dia" button → opens questionnaire sheet overlay
- Submitted days show "Feedback enviado" badge
- Adds `markDaySubmitted` to `useDailyFeedback` hook

## Test plan
- [ ] `npm run build` passes
- [ ] Navigate to Flux > Meu Treino
- [ ] Click "Dar Feedback do Dia" on a training day
- [ ] 8-question questionnaire sheet opens with auto-advance
- [ ] Submit feedback → badge shows "Feedback enviado"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Daily feedback collection is now integrated inline within the athlete portal alongside workouts
  * Added visual feedback status indicators for each day
  * 8-question daily feedback questionnaire is now accessible directly within the workout view
<!-- end of auto-generated comment: release notes by coderabbit.ai -->