### PR TITLE
fix(gemini): serialized refresh + circuit breaker to prevent 401 cascade (#723)

### DIFF
--- a/src/lib/gemini/client.ts
+++ b/src/lib/gemini/client.ts
@@ -60,9 +60,20 @@ const DEDICATED_EDGE_FUNCTIONS: Record<string, string> = {
 
 /**
  * Cliente Gemini singleton
+ *
+ * Auth protection (#723):
+ * - Serialized refresh: only one refreshSession() at a time to prevent TOKEN_REFRESHED cascade
+ * - Circuit breaker: after auth failure, fail fast for 10s to prevent 401 flood
  */
 export class GeminiClient {
   private static instance: GeminiClient
+
+  // Serialized refresh — only one refreshSession() runs at a time (#723)
+  private static refreshPromise: Promise<string | null> | null = null
+
+  // Circuit breaker — after auth failure, fail fast for cooldown period (#723)
+  private static authFailedAt = 0
+  private static readonly AUTH_COOLDOWN_MS = 10_000
 
   private constructor() { }
 
@@ -92,6 +103,15 @@ export class GeminiClient {
     request: GeminiChatRequest,
     options?: RetryOptions
   ): Promise<GeminiChatResponse> {
+    // Circuit breaker: fail fast if auth recently failed (#723)
+    if (GeminiClient.authFailedAt && Date.now() - GeminiClient.authFailedAt < GeminiClient.AUTH_COOLDOWN_MS) {
+      throw new GeminiError(
+        'Sessao expirada. Faca login novamente.',
+        'UNAUTHORIZED',
+        401
+      )
+    }
+
     // Check billing limit before every AI call (fail-open: errors allow the call through)
     try {
       const limit = await checkInteractionLimit()
@@ -220,7 +240,7 @@ export class GeminiClient {
 
   /**
    * Faz request HTTP ao backend
-   * Retries once on 401 with a fresh token (defense-in-depth for expired JWTs, #681, #723)
+   * On 401, uses serialized refresh to prevent TOKEN_REFRESHED cascade (#723)
    */
   private async makeRequest(
     endpoint: string,
@@ -229,27 +249,22 @@ export class GeminiClient {
     const token = await this.getAuthToken()
     const response = await this.doFetch(endpoint, request, token)
 
-    // If 401, try refreshing the token once and retry
+    // If 401, try serialized refresh once and retry
     if (response.status === 401) {
-      log.debug('Received 401, attempting token refresh and retry...')
-      invalidateAuthCache()
-      try {
-        const { data, error } = await supabase.auth.refreshSession()
-        if (!error && data.session?.access_token && data.session.access_token !== token) {
-          const retryResponse = await this.doFetch(endpoint, request, data.session.access_token)
-          if (!retryResponse.ok) {
-            throw await this.handleError(retryResponse)
-          }
-          return retryResponse.json()
+      log.debug('Received 401, attempting serialized token refresh...')
+      const newToken = await this.refreshTokenOnce()
+      if (newToken && newToken !== token) {
+        // Clear circuit breaker on successful refresh
+        GeminiClient.authFailedAt = 0
+        const retryResponse = await this.doFetch(endpoint, request, newToken)
+        if (!retryResponse.ok) {
+          throw await this.handleError(retryResponse)
         }
-        // Refresh returned same token or error — session may be invalid (#723)
-        if (error) {
-          log.error('Token refresh failed after 401:', error.message)
-        }
-      } catch (retryErr) {
-        if (retryErr instanceof GeminiError) throw retryErr
-        log.error('Token refresh threw after 401:', retryErr)
+        return retryResponse.json()
       }
+      // Refresh failed or returned same token — activate circuit breaker
+      GeminiClient.authFailedAt = Date.now()
+      log.error('Auth failed — circuit breaker activated for', GeminiClient.AUTH_COOLDOWN_MS, 'ms')
       throw await this.handleError(response)
     }
 
@@ -289,7 +304,7 @@ export class GeminiClient {
   /**
    * Obtém token de autenticação do Supabase
    * Uses getCachedSession() to avoid auth lock contention (#660, #665)
-   * Proactively refreshes expired/expiring tokens to prevent 401 from Edge Functions (#681, #723)
+   * Uses serialized refresh to prevent TOKEN_REFRESHED cascade (#723)
    */
   private async getAuthToken(): Promise<string> {
     const { session, error } = await getCachedSession()
@@ -303,42 +318,66 @@ export class GeminiClient {
     }
 
     // Check if token is expired or expiring within 60s — refresh proactively
-    // This prevents 401 from Edge Functions with verify_jwt = true
-    const tokenExpired = this.isTokenExpired(session.access_token)
     if (this.isTokenExpiringSoon(session.access_token)) {
+      const tokenExpired = this.isTokenExpired(session.access_token)
       log.debug('Access token expired or expiring soon, refreshing...')
-      invalidateAuthCache()
-      try {
-        const { data, error: refreshError } = await supabase.auth.refreshSession()
-        if (!refreshError && data.session?.access_token) {
-          return data.session.access_token
-        }
-        // Refresh returned error — if token is already expired, throw immediately (#723)
-        if (tokenExpired) {
-          log.error('Token expired and refresh failed:', refreshError?.message)
-          throw new GeminiError(
-            'Sessao expirada. Faca login novamente.',
-            'UNAUTHORIZED',
-            401
-          )
-        }
-      } catch (err) {
-        // Re-throw GeminiError (from above or from handleError)
-        if (err instanceof GeminiError) throw err
-        // Refresh threw — if token is already expired, don't try with a dead token (#723)
-        if (tokenExpired) {
-          log.error('Token expired and refresh threw:', err)
-          throw new GeminiError(
-            'Sessao expirada. Faca login novamente.',
-            'UNAUTHORIZED',
-            401
-          )
-        }
-        // Token is expiring but not yet expired — fall through with current token
+
+      const newToken = await this.refreshTokenOnce()
+      if (newToken) {
+        GeminiClient.authFailedAt = 0 // Clear circuit breaker on success
+        return newToken
       }
+
+      // Refresh failed — if token is already expired, throw immediately
+      if (tokenExpired) {
+        GeminiClient.authFailedAt = Date.now()
+        throw new GeminiError(
+          'Sessao expirada. Faca login novamente.',
+          'UNAUTHORIZED',
+          401
+        )
+      }
+      // Token is expiring but not yet expired — fall through with current token
     }
 
     return session.access_token
+  }
+
+  /**
+   * Serialized token refresh — only one refreshSession() runs at a time.
+   * Concurrent callers share the same promise to prevent TOKEN_REFRESHED cascade (#723).
+   */
+  private async refreshTokenOnce(): Promise<string | null> {
+    // If a refresh is already in flight, wait for it
+    if (GeminiClient.refreshPromise) {
+      return GeminiClient.refreshPromise
+    }
+
+    GeminiClient.refreshPromise = (async () => {
+      invalidateAuthCache()
+      try {
+        const { data, error } = await supabase.auth.refreshSession()
+        if (!error && data.session?.access_token) {
+          return data.session.access_token
+        }
+        if (error) {
+          log.error('Token refresh failed:', error.message)
+        }
+        return null
+      } catch (err) {
+        log.error('Token refresh threw:', err)
+        return null
+      }
+    })()
+
+    // Keep result available for 2s so concurrent callers can use it
+    GeminiClient.refreshPromise.finally(() => {
+      setTimeout(() => {
+        GeminiClient.refreshPromise = null
+      }, 2000)
+    })
+
+    return GeminiClient.refreshPromise
   }
 
   /**


### PR DESCRIPTION
## Summary
- **Serialized refresh**: Only one `refreshSession()` runs at a time via shared promise — concurrent callers wait for the result instead of each independently calling refresh (which caused TOKEN_REFRESHED cascade)
- **Circuit breaker**: After auth failure, all GeminiClient calls fail fast for 10s cooldown instead of flooding Supabase with doomed 401 requests
- **Auto-recovery**: Circuit breaker clears on successful token refresh

## Root cause
Multiple concurrent GeminiClient calls (dailyQuestionService carousel, transcription, etc.) all get 401 simultaneously. Each one independently called `supabase.auth.refreshSession()`, creating a race where each refresh invalidated the previous token — causing an infinite 401 loop.

## Test plan
- [ ] `npm run build` passes
- [ ] `npm run typecheck` passes
- [ ] Open app → no 401 flood in console
- [ ] After session expiry → single "Sessao expirada" error instead of cascade
- [ ] After re-login → AI calls work again (circuit breaker clears)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>