### PR TITLE
feat(architecture): add DDD rules + wire LifeScoreWidget to VidaPage

### DIFF
--- a/.claude/rules/domain-driven-design.md
+++ b/.claude/rules/domain-driven-design.md
@@ -1,0 +1,113 @@
+# Domain-Driven Design — AICA Life OS
+
+## Bounded Contexts = 8 Modules
+
+Each module in `src/modules/` is a **Bounded Context** with its own types, services, hooks, and components. Cross-module communication goes through shared services or the Life Score system.
+
+| Bounded Context | Module Path | Aggregate Root |
+|----------------|-------------|----------------|
+| Atlas | `src/modules/atlas/` | `WorkItem` |
+| Journey | `src/modules/journey/` | `Moment` |
+| Studio | `src/modules/studio/` | `PodcastEpisode` |
+| Grants | `src/modules/grants/` | `GrantProject` |
+| Finance | `src/modules/finance/` | `FinanceTransaction` |
+| Connections | `src/modules/connections/` | `ConnectionSpace` |
+| Flux | `src/modules/flux/` | `WorkoutBlock` |
+| Agenda | `src/modules/agenda/` | `CalendarEvent` |
+
+## Aggregate Roots
+
+### `LifeScore` (Cross-Module Aggregate)
+- Composite of 7 domain scores, owns spiral alerts + goodhart alerts
+- Persistence: `life_score_history`, `life_score_weights`, `life_score_domain_correlations`
+- Service: `src/services/scoring/lifeScoreService.ts`
+
+### Module Aggregates
+- **`WorkItem`** (Atlas) — owns subtasks, recurrence, priority matrix position
+- **`Moment`** (Journey) — owns emotion, CP award, media attachments
+- **`PodcastEpisode`** (Studio) — owns segments, guests, scoring
+- **`GrantProject`** (Grants) — owns opportunities, deadlines, documents
+- **`WorkoutBlock`** (Flux) — owns exercises, athlete assignments, alerts
+
+## Value Objects
+
+Immutable data carriers — no identity, compared by value:
+
+| Value Object | Location | Description |
+|-------------|----------|-------------|
+| `DomainScore` | `src/services/scoring/types.ts` | score + trend + metadata for a single domain |
+| `ScientificScore` | `src/services/scoring/types.ts` | methodology, confidence, effect size |
+| `SpiralAlert` | `src/services/scoring/types.ts` | correlated domain decline detection result |
+| `GoodhartAlert` | `src/services/scoring/types.ts` | metric gaming detection result |
+| `CorrelationResult` | `src/services/scoring/types.ts` | domain pair + Pearson coefficient + significance |
+| `SufficiencyLevel` | `src/services/scoring/types.ts` | thriving / adequate / struggling / critical |
+
+## Domain Services
+
+Services that encapsulate domain logic not belonging to a single entity:
+
+| Service | File | Pattern |
+|---------|------|---------|
+| `scoringEngine` | `src/services/scoring/scoringEngine.ts` | **Provider Registration** — modules register scoring functions via `registerDomainProvider(domain, provider)` |
+| `lifeScoreService` | `src/services/scoring/lifeScoreService.ts` | Persistence layer (RPCs, history, weights) |
+| `spiralDetectionService` | `src/services/scoring/spiralDetectionService.ts` | Detects correlated domain declines |
+| `goodhartDetectionService` | `src/services/scoring/goodhartDetectionService.ts` | Detects metric gaming patterns |
+| `correlationAnalysisService` | `src/services/scoring/correlationAnalysisService.ts` | Pearson correlations across domains |
+| `sabbaticalService` | `src/services/scoring/sabbaticalService.ts` | Intentional domain pause management |
+
+## Application Services (React Hooks)
+
+Hooks orchestrate domain services for UI consumption:
+
+| Hook | File | Orchestrates |
+|------|------|-------------|
+| `useLifeScore` | `src/hooks/useLifeScore.ts` | scoringEngine + lifeScoreService + alerts |
+| `useHealthScore` | `src/hooks/useHealthScore.ts` | Contact relationship health scoring |
+| `useScientificScore` | `src/hooks/useScientificScore.ts` | Generic scientific methodology tracking |
+
+## Anti-Corruption Layer
+
+When modules need data from other modules, they go through:
+1. **Life Score system** — normalized 0-100 scores per domain
+2. **Shared services** in `src/services/` — not module-internal services
+3. **Supabase RPCs** — server-side joins when needed
+
+**NEVER** import directly from another module's internal services or hooks.
+
+## When to Apply DDD
+
+### YES — Use DDD Patterns
+- Cross-module features (Life Score, gamification, daily council)
+- Complex domain logic with invariants (scoring engine, spiral detection)
+- Aggregate boundaries that protect consistency (workout blocks, grant projects)
+- New domain services that span multiple entities
+
+### NO — Keep It Simple
+- Simple CRUD operations within a single module
+- Pure UI components with no domain logic
+- Utility functions and configuration
+- Modules with <3 entities — use lightweight patterns
+
+## Provider Registration Pattern
+
+The scoring engine uses a registry pattern for extensibility:
+
+```typescript
+// In module initialization
+import { registerDomainProvider } from '@/services/scoring/scoringEngine';
+
+registerDomainProvider('atlas', async (userId) => {
+  // Compute Atlas domain score
+  return { score: 75, trend: 'improving', metadata: {...} };
+});
+```
+
+Each module registers its own scoring provider. The scoring engine calls all registered providers to compute the composite Life Score.
+
+## Naming Conventions
+
+- **Aggregate Root types**: PascalCase, singular (`WorkItem`, `Moment`, `PodcastEpisode`)
+- **Value Objects**: PascalCase, descriptive (`DomainScore`, `SpiralAlert`)
+- **Domain Services**: camelCase + `Service` suffix (`scoringEngine`, `lifeScoreService`)
+- **Application Services**: `use` + PascalCase (`useLifeScore`, `useHealthScore`)
+- **Events/Commands**: past tense for events (`ScoreComputed`), imperative for commands (`ComputeScore`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,7 @@ Detailed instructions are in `.claude/rules/` (loaded automatically):
 | `design-system.md` | When editing `src/components/` | Ceramic tokens, foundation components |
 | `database.md` | When editing `supabase/migrations/` | Migration checklist, RLS, table warnings |
 | `whatsapp.md` | When editing connections or webhooks | Pipeline, privacy, troubleshooting |
+| `domain-driven-design.md` | When editing `src/services/scoring/` or cross-module features | DDD: Aggregates, Value Objects, Bounded Contexts |
 
 ## Quality Targets
 

--- a/src/pages/VidaPage.tsx
+++ b/src/pages/VidaPage.tsx
@@ -11,7 +11,7 @@ import { Wallet, Heart, Building2, BookOpen, Scale, Mic, Briefcase, Compass, typ
 import { HeaderGlobal, ProfileDrawer, ModuleCard, ExploreMoreSection } from '../components';
 import { VidaUniversalInput } from '@/components/features/VidaUniversalInput';
 import { MementoMoriBar } from '@/components/features/MementoMoriBar';
-// #440: LifeCouncilCard, PatternsSummary, LifeScoreWidget removed from /vida (moved to Journey)
+import { LifeScoreWidget } from '@/components/features/LifeScoreWidget';
 import { FinanceCard } from '../modules/finance/components/FinanceCard';
 import { GrantsCard } from '../modules/grants/components/GrantsCard';
 import { JourneyHeroCard } from '../modules/journey';
@@ -19,7 +19,6 @@ import { useWeatherInsight } from '@/hooks/useWeatherInsight';
 import { FluxCard } from '../modules/flux';
 import { useConsciousnessPoints } from '../modules/journey/hooks/useConsciousnessPoints';
 import { LEVEL_COLORS } from '../modules/journey/types/consciousnessPoints';
-// #440: useLifeCouncil and useUserPatterns removed from /vida
 import { useGrantsHomeQuery } from '@/hooks/queries';
 import { ViewState } from '../../types';
 import { supabase } from '@/services/supabaseClient';
@@ -125,8 +124,6 @@ export default function VidaPage({
 
    // Identity data from Journey CP system
    const { stats: cpStats, progress: cpProgress } = useConsciousnessPoints();
-
-   // #440: Life Council and Patterns hooks removed — re-enable when data is sufficient
 
    // User metadata for avatar and profile
    const avatarUrl = useMemo(() => user?.user_metadata?.avatar_url, [user]);
@@ -252,6 +249,18 @@ export default function VidaPage({
                      onOpenJourney={() => onNavigateToView('journey')}
                      stats={cpStats}
                   />
+               </motion.div>
+            )}
+
+            {/* Life Score — full width (cascade step 3) */}
+            {cascadeStep >= 3 && (
+               <motion.div
+                  variants={cardVariants}
+                  initial="hidden"
+                  animate="visible"
+                  custom={0.5}
+               >
+                  <LifeScoreWidget />
                </motion.div>
             )}
 


### PR DESCRIPTION
## Summary
- Create `.claude/rules/domain-driven-design.md` with AICA-specific DDD guidance (bounded contexts = 8 modules, aggregate roots, value objects, domain/application services, anti-corruption layer, provider registration pattern)
- Update `CLAUDE.md` rules index to reference the new DDD rule file
- Re-add `LifeScoreWidget` to VidaPage — was commented out in Issue #440, now restored between JourneyHeroCard and module cards grid

## Context
Batch 3 (Life Score) was 95% complete from parallel sessions. The only remaining gap was wiring `LifeScoreWidget` back into VidaPage. All infrastructure exists: `useLifeScore` hook, `LifeScoreWidget` component (267 lines), `LifeScoreAnalyticsPage`, `/life-score` route, settings menu entry, DB tables, 7 Edge Functions, 6 scoring services.

## Test plan
- [x] `npm run build` passes
- [x] `npm run typecheck` — no new errors (pre-existing ones in database.types.ts and momentValidation.ts)
- [ ] LifeScoreWidget visible on VidaPage (manual check)
- [ ] `/life-score` route loads analytics page
- [ ] Settings menu has Life Score entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>