### PR TITLE
refactor(architecture): move transcribeAudio to shared audioService

### DIFF
--- a/src/components/features/MultiModalInput.tsx
+++ b/src/components/features/MultiModalInput.tsx
@@ -15,7 +15,7 @@ import {
   XMarkIcon,
   PaperAirplaneIcon,
 } from '@heroicons/react/24/solid'
-import { transcribeAudio } from '@/modules/journey/services/momentPersistenceService'
+import { transcribeAudio } from '@/services/audioService'
 
 // ─── Types ────────────────────────────────────────────────────────────
 

--- a/src/hooks/useVoiceRecorder.ts
+++ b/src/hooks/useVoiceRecorder.ts
@@ -9,7 +9,7 @@
  */
 
 import { useState, useRef, useCallback, useEffect } from 'react'
-import { transcribeAudio } from '@/modules/journey/services/momentPersistenceService'
+import { transcribeAudio } from '@/services/audioService'
 
 interface UseVoiceRecorderOptions {
   onResult: (transcript: string) => void

--- a/src/modules/journey/components/insights/DailyQuestionCard.tsx
+++ b/src/modules/journey/components/insights/DailyQuestionCard.tsx
@@ -7,7 +7,7 @@ import React, { useState, useCallback } from 'react'
 import { createNamespacedLogger } from '@/lib/logger'
 import { QuestionWithResponse } from '../../types/dailyQuestion'
 import { AudioRecorder } from '../capture/AudioRecorder'
-import { transcribeAudio } from '../../services/momentPersistenceService'
+import { transcribeAudio } from '@/services/audioService'
 
 const log = createNamespacedLogger('DailyQuestionCard')
 import {

--- a/src/modules/journey/components/insights/DailyQuestionCarousel.tsx
+++ b/src/modules/journey/components/insights/DailyQuestionCarousel.tsx
@@ -13,7 +13,7 @@ import {
   QUESTION_CATEGORY_ICONS,
 } from '../../types/dailyQuestion'
 import { AudioRecorder } from '../capture/AudioRecorder'
-import { transcribeAudio } from '../../services/momentPersistenceService'
+import { transcribeAudio } from '@/services/audioService'
 import {
   SparklesIcon,
   CheckCircleIcon,

--- a/src/modules/journey/components/insights/WeeklySummaryCard.tsx
+++ b/src/modules/journey/components/insights/WeeklySummaryCard.tsx
@@ -9,7 +9,7 @@ import React, { useState, useCallback, useMemo } from 'react'
 import { createNamespacedLogger } from '@/lib/logger'
 import { WeeklySummary } from '../../types/weeklySummary'
 import { AudioRecorder } from '../capture/AudioRecorder'
-import { transcribeAudio } from '../../services/momentPersistenceService'
+import { transcribeAudio } from '@/services/audioService'
 import { useStreakTrend } from '@/hooks/useStreakTrend'
 
 const log = createNamespacedLogger('WeeklySummaryCard')

--- a/src/modules/journey/services/momentPersistenceService.ts
+++ b/src/modules/journey/services/momentPersistenceService.ts
@@ -342,69 +342,6 @@ function blobToBase64(blob: Blob): Promise<string> {
   })
 }
 
-// =====================================================
-// AUDIO TRANSCRIPTION (Universal Input Funnel - Phase 0)
-// =====================================================
-
-/**
- * Transcribe audio blob to text using Gemini via gemini-chat Edge Function
- *
- * @param audioBlob - Audio Blob from MediaRecorder or file input
- * @returns Transcribed text string
- */
-export async function transcribeAudio(audioBlob: Blob): Promise<string> {
-  const startTime = Date.now()
-
-  try {
-    const audioBase64 = await blobToBase64(audioBlob)
-    const mimeType = audioBlob.type || 'audio/webm'
-
-    log.debug('[momentPersistenceService] Transcribing audio', {
-      mimeType,
-      sizeBytes: audioBlob.size,
-    })
-
-    const response = await geminiClient.call({
-      action: 'transcribe_audio',
-      payload: {
-        audioBase64,
-        mimeType,
-      },
-    })
-
-    const raw = response.result?.transcription || response.result?.text || ''
-    // Strip Gemini thinking tokens that may leak with 2.5 Flash
-    const transcription = raw.replace(/<THINK>[\s\S]*?<\/THINK>\s*/gi, '').trim()
-
-    // Track AI usage (non-blocking)
-    trackAIUsage({
-      operation_type: 'audio_transcription',
-      ai_model: 'gemini-2.5-flash',
-      input_tokens: response.usageMetadata?.promptTokenCount || 0,
-      output_tokens: response.usageMetadata?.candidatesTokenCount || 0,
-      module_type: 'journey',
-      duration_seconds: (Date.now() - startTime) / 1000,
-      request_metadata: {
-        function_name: 'transcribeAudio',
-        operation: 'audio_transcription',
-        audio_size_bytes: audioBlob.size,
-        audio_mime_type: mimeType,
-      },
-    }).catch(error => {
-      log.warn('[Journey AI Tracking] Non-blocking error:', error.message)
-    })
-
-    log.debug('[momentPersistenceService] Audio transcribed', {
-      transcriptionLength: transcription.length,
-      durationMs: Date.now() - startTime,
-    })
-
-    return transcription
-  } catch (error) {
-    log.error('[momentPersistenceService] Error transcribing audio:', error)
-    throw new Error('Falha na transcricao do audio. Tente novamente.')
-  }
-}
 
 /**
  * Describe an image using Gemini vision (OCR + description)

--- a/src/modules/journey/services/momentService.ts
+++ b/src/modules/journey/services/momentService.ts
@@ -15,7 +15,7 @@ import {
 } from '../types/moment'
 import { SentimentAnalysis } from '../types/sentiment'
 import { mapAIMoodToValue } from '../types/emotionHelper'
-import { transcribeAudio } from './momentPersistenceService'
+import { transcribeAudio } from '@/services/audioService'
 import { evaluateAndCalculateCP, updateAvgQualityScore } from './qualityEvaluationService'
 
 const geminiClient = GeminiClient.getInstance()

--- a/src/services/audioService.ts
+++ b/src/services/audioService.ts
@@ -1,0 +1,84 @@
+/**
+ * Audio Service
+ * Shared audio transcription service — module-agnostic.
+ * Extracted from Journey's momentPersistenceService to respect DDD bounded contexts.
+ */
+
+import { GeminiClient } from '@/lib/gemini'
+import { createNamespacedLogger } from '@/lib/logger'
+import { trackAIUsage } from '@/services/aiUsageTrackingService'
+
+const log = createNamespacedLogger('audioService')
+const geminiClient = GeminiClient.getInstance()
+
+function blobToBase64(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => {
+      const dataUrl = reader.result as string
+      resolve(dataUrl.split(',')[1])
+    }
+    reader.onerror = reject
+    reader.readAsDataURL(blob)
+  })
+}
+
+/**
+ * Transcribe audio blob to text using Gemini via gemini-chat Edge Function
+ *
+ * @param audioBlob - Audio Blob from MediaRecorder or file input
+ * @returns Transcribed text string
+ */
+export async function transcribeAudio(audioBlob: Blob): Promise<string> {
+  const startTime = Date.now()
+
+  try {
+    const audioBase64 = await blobToBase64(audioBlob)
+    const mimeType = audioBlob.type || 'audio/webm'
+
+    log.debug('[audioService] Transcribing audio', {
+      mimeType,
+      sizeBytes: audioBlob.size,
+    })
+
+    const response = await geminiClient.call({
+      action: 'transcribe_audio',
+      payload: {
+        audioBase64,
+        mimeType,
+      },
+    })
+
+    const raw = response.result?.transcription || response.result?.text || ''
+    // Strip Gemini thinking tokens that may leak with 2.5 Flash
+    const transcription = raw.replace(/<THINK>[\s\S]*?<\/THINK>\s*/gi, '').trim()
+
+    // Track AI usage (non-blocking)
+    trackAIUsage({
+      operation_type: 'audio_transcription',
+      ai_model: 'gemini-2.5-flash',
+      input_tokens: response.usageMetadata?.promptTokenCount || 0,
+      output_tokens: response.usageMetadata?.candidatesTokenCount || 0,
+      module_type: 'shared',
+      duration_seconds: (Date.now() - startTime) / 1000,
+      request_metadata: {
+        function_name: 'transcribeAudio',
+        operation: 'audio_transcription',
+        audio_size_bytes: audioBlob.size,
+        audio_mime_type: mimeType,
+      },
+    }).catch(error => {
+      log.warn('[Audio AI Tracking] Non-blocking error:', error.message)
+    })
+
+    log.debug('[audioService] Audio transcribed', {
+      transcriptionLength: transcription.length,
+      durationMs: Date.now() - startTime,
+    })
+
+    return transcription
+  } catch (error) {
+    log.error('[audioService] Error transcribing audio:', error)
+    throw new Error('Falha na transcricao do audio. Tente novamente.')
+  }
+}

--- a/src/services/taskExtractionService.ts
+++ b/src/services/taskExtractionService.ts
@@ -6,7 +6,7 @@
  */
 
 import { GeminiClient } from '@/lib/gemini'
-import { transcribeAudio } from '@/modules/journey/services/momentPersistenceService'
+import { transcribeAudio } from '@/services/audioService'
 import { createNamespacedLogger } from '@/lib/logger'
 
 const geminiClient = GeminiClient.getInstance()


### PR DESCRIPTION
## Summary
- Closes #730
- Extracts `transcribeAudio` from `src/modules/journey/services/momentPersistenceService.ts` to `src/services/audioService.ts`
- Updates 7 consumer imports across 4 modules (hooks, components, services, journey)
- Fixes DDD bounded context violation: cross-module code was importing from Journey's internal service

## Context
Issue: #730 — Mover transcribeAudio para src/services/audioService.ts

The `transcribeAudio` function was defined inside Journey's `momentPersistenceService` but consumed by:
- `src/hooks/useVoiceRecorder.ts` (shared hook)
- `src/components/features/MultiModalInput.tsx` (shared component)
- `src/services/taskExtractionService.ts` (shared service)
- `src/modules/journey/services/momentService.ts` (journey internal)
- `src/modules/journey/components/insights/DailyQuestionCard.tsx`
- `src/modules/journey/components/insights/DailyQuestionCarousel.tsx`
- `src/modules/journey/components/insights/WeeklySummaryCard.tsx`

## Test plan
- [x] `npm run build` passes
- [x] `npm run typecheck` — pre-existing errors only (unrelated to this change)
- [ ] Manual testing: voice recording transcription works on VidaPage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal audio transcription services to improve code maintainability and module structure without affecting user-facing functionality or audio transcription capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->