### PR TITLE
fix(flux): move useMemo hooks above early returns in AthletePortalView

### DIFF
--- a/src/modules/flux/views/AthletePortalView.tsx
+++ b/src/modules/flux/views/AthletePortalView.tsx
@@ -176,6 +176,33 @@ export default function AthletePortalView() {
     finally { setUpdating(null); }
   }, [refetch]);
 
+  // ── Hooks that MUST be above early returns (React Rules of Hooks) ──
+
+  const pastWorkoutDays = useMemo(() => {
+    const micro = profile?.active_microcycle;
+    if (!micro?.slots?.length || !micro.start_date) return 0;
+    const today = new Date();
+    today.setHours(23, 59, 59, 999);
+    const startDate = new Date(micro.start_date);
+    let count = 0;
+    for (const slot of micro.slots) {
+      const weekOffset = (slot.week_number - 1) * 7;
+      const dayOffset = slot.day_of_week - 1;
+      const slotDate = new Date(startDate);
+      slotDate.setDate(startDate.getDate() + weekOffset + dayOffset);
+      if (slotDate <= today) count++;
+    }
+    return count;
+  }, [profile?.active_microcycle]);
+
+  const prescribedModalities = useMemo((): Array<keyof typeof MODALITY_CONFIG> => {
+    const mod = profile?.modality as keyof typeof MODALITY_CONFIG;
+    if (mod === 'triathlon') {
+      return ['triathlon', 'swimming', 'running', 'cycling'];
+    }
+    return mod && MODALITY_CONFIG[mod] ? [mod] : ['strength'];
+  }, [profile?.modality]);
+
   // ── Early returns ──
 
   if (isLoading) {
@@ -257,35 +284,7 @@ export default function AthletePortalView() {
 
   const micro = profile.active_microcycle;
   const modalityConfig = MODALITY_CONFIG[profile.modality];
-
-  // Count past workout days (days that have already passed) instead of manual completions
-  const pastWorkoutDays = useMemo(() => {
-    if (!micro?.slots?.length || !micro.start_date) return 0;
-    const today = new Date();
-    today.setHours(23, 59, 59, 999);
-    const startDate = new Date(micro.start_date);
-    let count = 0;
-    for (const slot of micro.slots) {
-      const weekOffset = (slot.week_number - 1) * 7;
-      const dayOffset = slot.day_of_week - 1;
-      const slotDate = new Date(startDate);
-      slotDate.setDate(startDate.getDate() + weekOffset + dayOffset);
-      if (slotDate <= today) count++;
-    }
-    return count;
-  }, [micro?.slots, micro?.start_date]);
   const completionPct = micro ? Math.round((pastWorkoutDays / Math.max(micro.total_slots, 1)) * 100) : 0;
-
-  // Derive athlete modalities from profile.modality
-  // Template categories (warmup, main, cooldown) don't map to training modalities,
-  // so we use the athlete's declared modality and expand triathlon to its components.
-  const prescribedModalities = useMemo((): Array<keyof typeof MODALITY_CONFIG> => {
-    const mod = profile.modality as keyof typeof MODALITY_CONFIG;
-    if (mod === 'triathlon') {
-      return ['triathlon', 'swimming', 'running', 'cycling'];
-    }
-    return MODALITY_CONFIG[mod] ? [mod] : ['strength'];
-  }, [profile.modality]);
 
   const weeks = micro
     ? [1, 2, 3, 4].map((wk) => {


### PR DESCRIPTION
## Summary
- Fixes React error #310 on `/meu-treino` page (issue #746)
- Moved `pastWorkoutDays` and `prescribedModalities` `useMemo` hooks above early return statements
- Added null-safe optional chaining (`profile?.active_microcycle`, `profile?.modality`) for when profile is null during loading/error states

## Root Cause
Two `useMemo` hooks were placed after early return statements (loading, error, parq wizard, welcome). When network instability caused auth token refresh failures, the component hit an early return with N hooks. When connectivity resumed and data loaded, the component tried to render the full UI with N+2 hooks, violating React's Rules of Hooks.

## Test plan
- [x] `npm run build` passes
- [x] No TypeScript errors in AthletePortalView
- [ ] Manual test: navigate to `/meu-treino` with intermittent network → no crash
- [ ] Manual test: normal flow still works (loading → profile → workouts)

Closes #746

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed modality initialization in the athlete portal to ensure prescribed modalities load correctly.

* **Improvements**
  * Triathlon modality now expands into individual components; undefined modalities default to strength for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->