### PR TITLE
fix(flux): Meu-Treino sprint — 9 issues (#757-#764, #768)

### DIFF
--- a/src/modules/flux/components/athlete/AthleteFeedbackView.tsx
+++ b/src/modules/flux/components/athlete/AthleteFeedbackView.tsx
@@ -54,91 +54,6 @@ export function AthleteFeedbackView({ profile, onRefetch: _onRefetch, selectedWe
         <h3 className="text-sm font-bold text-ceramic-text-primary">Meu Feedback</h3>
       </div>
 
-      {/* Aggregated Radar Chart + Stress/Fatigue Gauges (#607) */}
-      {aggregatedQuestionnaire ? (
-        <div className="bg-white rounded-xl p-4 shadow-sm border border-ceramic-border/30 space-y-4">
-          <FeedbackRadarChart
-            questionnaire={aggregatedQuestionnaire}
-            size={260}
-            title="Visao Geral"
-            subtitle="Media de todos os feedbacks respondidos"
-          />
-          <StressFatigueGauges
-            stress={aggregatedQuestionnaire.stress}
-            fatigue={aggregatedQuestionnaire.fatigue}
-          />
-        </div>
-      ) : !isLoading && weekSummaries.length > 0 ? (
-        <div className="bg-ceramic-cool/50 rounded-xl p-4 text-center">
-          <BarChart3 className="w-6 h-6 text-ceramic-text-secondary mx-auto mb-2" />
-          <p className="text-xs text-ceramic-text-secondary">
-            Responda os questionarios para ver seu radar de performance
-          </p>
-          <p className="text-[10px] text-ceramic-text-secondary/60 mt-1">
-            Volume · Intensidade · Alimentacao · Sono · Stress · Cansaco
-          </p>
-        </div>
-      ) : null}
-
-      {/* AI Fatigue Assessment */}
-      {isFatigueLoading ? (
-        <div className="flex items-center gap-2 px-4 py-3 rounded-xl bg-ceramic-cool/50">
-          <Loader2 className="w-4 h-4 animate-spin text-ceramic-text-secondary" />
-          <span className="text-xs text-ceramic-text-secondary">Avaliando fadiga...</span>
-        </div>
-      ) : fatigueAssessment ? (
-        <div className="bg-white rounded-xl p-4 shadow-sm border border-ceramic-border/30 space-y-3">
-          <div className="flex items-center gap-2">
-            <Activity className="w-4 h-4 text-emerald-500" />
-            <span className="text-xs font-bold text-ceramic-text-primary">Avaliacao de Fadiga (AI)</span>
-            <span className={`ml-auto text-[10px] font-medium px-2 py-0.5 rounded-full ${
-              fatigueAssessment.fatigueRisk === 'low' ? 'bg-emerald-100 text-emerald-700' :
-              fatigueAssessment.fatigueRisk === 'moderate' ? 'bg-amber-100 text-amber-700' :
-              fatigueAssessment.fatigueRisk === 'high' ? 'bg-orange-100 text-orange-700' :
-              'bg-red-100 text-red-700'
-            }`}>
-              {fatigueAssessment.fatigueRisk === 'low' ? 'Risco Baixo' :
-               fatigueAssessment.fatigueRisk === 'moderate' ? 'Risco Moderado' :
-               fatigueAssessment.fatigueRisk === 'high' ? 'Risco Alto' :
-               'Overtraining'}
-            </span>
-          </div>
-          <div className="grid grid-cols-4 gap-2 text-center">
-            <div>
-              <p className="text-[10px] text-ceramic-text-secondary">Prontidao</p>
-              <p className="text-sm font-bold text-ceramic-text-primary">{fatigueAssessment.readinessScore}</p>
-            </div>
-            <div>
-              <p className="text-[10px] text-ceramic-text-secondary">CTL</p>
-              <p className="text-sm font-bold text-ceramic-text-primary">{fatigueAssessment.ctl.toFixed(0)}</p>
-            </div>
-            <div>
-              <p className="text-[10px] text-ceramic-text-secondary">ATL</p>
-              <p className="text-sm font-bold text-ceramic-text-primary">{fatigueAssessment.atl.toFixed(0)}</p>
-            </div>
-            <div>
-              <p className="text-[10px] text-ceramic-text-secondary">TSB</p>
-              <p className="text-sm font-bold text-ceramic-text-primary">{fatigueAssessment.tsb.toFixed(0)}</p>
-            </div>
-          </div>
-          {fatigueAssessment.recommendation && (
-            <p className="text-xs text-ceramic-text-secondary italic">
-              {fatigueAssessment.recommendation}
-            </p>
-          )}
-          <div className="flex items-center gap-1.5">
-            <span className="text-[10px] text-ceramic-text-secondary">Intensidade sugerida:</span>
-            <span className="text-[10px] font-medium text-ceramic-text-primary capitalize">
-              {fatigueAssessment.suggestedIntensity}
-            </span>
-          </div>
-        </div>
-      ) : fatigueError ? (
-        <div className="px-4 py-3 rounded-xl bg-amber-50 border border-amber-100">
-          <p className="text-xs text-amber-600">Avaliacao de fadiga indisponivel</p>
-        </div>
-      ) : null}
-
       {/* Error */}
       {error && (
         <div className="px-4 py-3 rounded-xl bg-red-50 border border-red-100">
@@ -146,19 +61,112 @@ export function AthleteFeedbackView({ profile, onRefetch: _onRefetch, selectedWe
         </div>
       )}
 
-      {/* Loading */}
-      {isLoading ? (
-        <div className="flex items-center justify-center py-12">
-          <Loader2 className="w-5 h-5 animate-spin text-ceramic-text-secondary" />
+      {/* Side-by-side: Visao Geral (left) + Visao Semanal (right) */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 items-start">
+        {/* Left column: Visao Geral (radar chart + gauges + fatigue) */}
+        <div className="space-y-4">
+          {/* Aggregated Radar Chart + Stress/Fatigue Gauges (#607) */}
+          {aggregatedQuestionnaire ? (
+            <div className="bg-white rounded-xl p-4 shadow-sm border border-ceramic-border/30 space-y-4">
+              <FeedbackRadarChart
+                questionnaire={aggregatedQuestionnaire}
+                size={260}
+                title="Visao Geral"
+                subtitle="Media de todos os feedbacks respondidos"
+              />
+              <StressFatigueGauges
+                stress={aggregatedQuestionnaire.stress}
+                fatigue={aggregatedQuestionnaire.fatigue}
+              />
+            </div>
+          ) : !isLoading && weekSummaries.length > 0 ? (
+            <div className="bg-ceramic-cool/50 rounded-xl p-4 text-center">
+              <BarChart3 className="w-6 h-6 text-ceramic-text-secondary mx-auto mb-2" />
+              <p className="text-xs text-ceramic-text-secondary">
+                Responda os questionarios para ver seu radar de performance
+              </p>
+              <p className="text-[10px] text-ceramic-text-secondary/60 mt-1">
+                Volume · Intensidade · Alimentacao · Sono · Stress · Cansaco
+              </p>
+            </div>
+          ) : null}
+
+          {/* AI Fatigue Assessment */}
+          {isFatigueLoading ? (
+            <div className="flex items-center gap-2 px-4 py-3 rounded-xl bg-ceramic-cool/50">
+              <Loader2 className="w-4 h-4 animate-spin text-ceramic-text-secondary" />
+              <span className="text-xs text-ceramic-text-secondary">Avaliando fadiga...</span>
+            </div>
+          ) : fatigueAssessment ? (
+            <div className="bg-white rounded-xl p-4 shadow-sm border border-ceramic-border/30 space-y-3">
+              <div className="flex items-center gap-2">
+                <Activity className="w-4 h-4 text-emerald-500" />
+                <span className="text-xs font-bold text-ceramic-text-primary">Avaliacao de Fadiga (AI)</span>
+                <span className={`ml-auto text-[10px] font-medium px-2 py-0.5 rounded-full ${
+                  fatigueAssessment.fatigueRisk === 'low' ? 'bg-emerald-100 text-emerald-700' :
+                  fatigueAssessment.fatigueRisk === 'moderate' ? 'bg-amber-100 text-amber-700' :
+                  fatigueAssessment.fatigueRisk === 'high' ? 'bg-orange-100 text-orange-700' :
+                  'bg-red-100 text-red-700'
+                }`}>
+                  {fatigueAssessment.fatigueRisk === 'low' ? 'Risco Baixo' :
+                   fatigueAssessment.fatigueRisk === 'moderate' ? 'Risco Moderado' :
+                   fatigueAssessment.fatigueRisk === 'high' ? 'Risco Alto' :
+                   'Overtraining'}
+                </span>
+              </div>
+              <div className="grid grid-cols-4 gap-2 text-center">
+                <div>
+                  <p className="text-[10px] text-ceramic-text-secondary">Prontidao</p>
+                  <p className="text-sm font-bold text-ceramic-text-primary">{fatigueAssessment.readinessScore}</p>
+                </div>
+                <div>
+                  <p className="text-[10px] text-ceramic-text-secondary">CTL</p>
+                  <p className="text-sm font-bold text-ceramic-text-primary">{fatigueAssessment.ctl.toFixed(0)}</p>
+                </div>
+                <div>
+                  <p className="text-[10px] text-ceramic-text-secondary">ATL</p>
+                  <p className="text-sm font-bold text-ceramic-text-primary">{fatigueAssessment.atl.toFixed(0)}</p>
+                </div>
+                <div>
+                  <p className="text-[10px] text-ceramic-text-secondary">TSB</p>
+                  <p className="text-sm font-bold text-ceramic-text-primary">{fatigueAssessment.tsb.toFixed(0)}</p>
+                </div>
+              </div>
+              {fatigueAssessment.recommendation && (
+                <p className="text-xs text-ceramic-text-secondary italic">
+                  {fatigueAssessment.recommendation}
+                </p>
+              )}
+              <div className="flex items-center gap-1.5">
+                <span className="text-[10px] text-ceramic-text-secondary">Intensidade sugerida:</span>
+                <span className="text-[10px] font-medium text-ceramic-text-primary capitalize">
+                  {fatigueAssessment.suggestedIntensity}
+                </span>
+              </div>
+            </div>
+          ) : fatigueError ? (
+            <div className="px-4 py-3 rounded-xl bg-amber-50 border border-amber-100">
+              <p className="text-xs text-amber-600">Avaliacao de fadiga indisponivel</p>
+            </div>
+          ) : null}
         </div>
-      ) : (
-        <FeedbackTimeline
-          weekSummaries={filteredSummaries}
-          currentWeek={currentWeek}
-          isSubmitting={isSubmitting}
-          modality={profile.modality}
-        />
-      )}
+
+        {/* Right column: Visao Semanal (weekly feedback timeline) */}
+        <div>
+          {isLoading ? (
+            <div className="flex items-center justify-center py-12">
+              <Loader2 className="w-5 h-5 animate-spin text-ceramic-text-secondary" />
+            </div>
+          ) : (
+            <FeedbackTimeline
+              weekSummaries={filteredSummaries}
+              currentWeek={currentWeek}
+              isSubmitting={isSubmitting}
+              modality={profile.modality}
+            />
+          )}
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/modules/flux/components/athlete/FeedbackForm.tsx
+++ b/src/modules/flux/components/athlete/FeedbackForm.tsx
@@ -7,7 +7,7 @@
 
 import { useState, useCallback } from 'react';
 import { motion } from 'framer-motion';
-import { CheckCircle, Circle, X, Send, Loader2 } from 'lucide-react';
+import { X, Send, Loader2 } from 'lucide-react';
 import type { FeedbackSlotSummary } from '../../hooks/useAthleteFeedback';
 
 function getRpeBgClass(rpe: number): string {
@@ -132,7 +132,7 @@ export function FeedbackForm({
                       return (
                         <div key={slot.slotId} className="flex items-center gap-3 p-3 rounded-xl bg-ceramic-cool/40">
                           <button type="button" onClick={() => updateSlot(slot.slotId, { completed: !state?.completed })} className="flex-shrink-0">
-                            {state?.completed ? <CheckCircle className="w-5 h-5 text-green-500" /> : <Circle className="w-5 h-5 text-ceramic-border" />}
+                            <span className={`w-2.5 h-2.5 rounded-full inline-block ${state?.completed ? 'bg-green-500' : 'bg-ceramic-border'}`} />
                           </button>
                           <div className="flex-1 min-w-0">
                             <p className="text-xs font-medium text-ceramic-text-primary truncate">{slot.templateName}</p>

--- a/src/modules/flux/components/athlete/FeedbackStatusRow.tsx
+++ b/src/modules/flux/components/athlete/FeedbackStatusRow.tsx
@@ -6,7 +6,7 @@
  * Day grouping is handled by the parent — this component no longer shows day labels.
  */
 
-import { Check, ChevronRight, Lock } from 'lucide-react';
+import { ChevronRight, Lock } from 'lucide-react';
 
 export interface FeedbackStatusRowProps {
   type: 'exercise' | 'weekly';
@@ -49,18 +49,16 @@ export function FeedbackStatusRow({
         ${type === 'weekly' ? 'bg-ceramic-cool/30' : ''}
       `}
     >
-      {/* Status icon */}
+      {/* Status indicator */}
       <div className="flex-shrink-0">
         {locked ? (
-          <div className="w-5 h-5 rounded bg-ceramic-cool flex items-center justify-center">
+          <div className="w-5 h-5 rounded-full bg-ceramic-cool flex items-center justify-center">
             <Lock className="w-3 h-3 text-ceramic-text-secondary/50" />
           </div>
         ) : isSubmitted ? (
-          <div className="w-5 h-5 rounded bg-green-500 flex items-center justify-center">
-            <Check className="w-3 h-3 text-white" />
-          </div>
+          <span className="w-2.5 h-2.5 rounded-full bg-green-500 inline-block" />
         ) : (
-          <div className="w-5 h-5 rounded border-2 border-ceramic-border" />
+          <span className="w-2.5 h-2.5 rounded-full bg-amber-400 inline-block" />
         )}
       </div>
 

--- a/src/modules/flux/components/athlete/WeeklyFeedbackCard.tsx
+++ b/src/modules/flux/components/athlete/WeeklyFeedbackCard.tsx
@@ -13,7 +13,6 @@ import {
   MessageSquare,
   Send,
   Loader2,
-  Check,
   ChevronDown,
   ChevronUp,
   ChevronLeft,
@@ -144,7 +143,7 @@ function DayFeedbackCard({
     return (
       <div className="bg-white rounded-xl shadow-sm px-4 py-3">
         <div className="flex items-center gap-2">
-          <Check className="w-3.5 h-3.5 text-green-500 flex-shrink-0" />
+          <span className="w-2.5 h-2.5 rounded-full bg-green-500 inline-block flex-shrink-0" />
           <span className="text-xs font-bold text-ceramic-text-primary">{dayLabel}</span>
           {dateStr && <span className="text-[10px] text-ceramic-text-secondary">{dateStr}</span>}
           <span className="ml-auto text-[10px] text-ceramic-text-secondary">
@@ -299,7 +298,7 @@ function DayFeedbackCard({
                     {/* Summary */}
                     {answeredCount > 0 && (
                       <div className="flex items-center gap-2 px-3 py-2 rounded-xl bg-amber-50 border border-amber-200/50">
-                        <Check className="w-3.5 h-3.5 text-amber-600 flex-shrink-0" />
+                        <span className="w-2.5 h-2.5 rounded-full bg-amber-500 inline-block flex-shrink-0" />
                         <span className="text-[10px] text-amber-700">
                           {answeredCount} de {QUESTIONS.length} perguntas respondidas
                         </span>

--- a/src/modules/flux/views/AthletePortalView.tsx
+++ b/src/modules/flux/views/AthletePortalView.tsx
@@ -6,13 +6,12 @@
  * workout cards, feedback tab (Momentos-style), and coach availability.
  */
 
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { motion, type Variants } from 'framer-motion';
 import { useMyAthleteProfile } from '../hooks/useMyAthleteProfile';
 import { useParQ } from '../hooks/useParQ';
 import { useAthleteDocuments } from '../hooks/useAthleteDocuments';
-import { useCanvasCalendar } from '../hooks/useCanvasCalendar';
 import { WorkoutSlotService } from '../services/workoutSlotService';
 import { AthleteWelcome } from '../components/AthleteWelcome';
 import { ParQWizard } from '../components/parq/ParQWizard';
@@ -35,6 +34,8 @@ import {
   MessageSquare,
   CheckCircle,
   FileText,
+  DollarSign,
+  Heart,
 } from 'lucide-react';
 
 const log = createNamespacedLogger('AthletePortalView');
@@ -89,6 +90,9 @@ export default function AthletePortalView() {
     catch { return 'list'; }
   });
 
+  const [highlightedSlotId, setHighlightedSlotId] = useState<string | null>(null);
+  const slotRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+
   const welcomeParam = searchParams.get('welcome') === 'true';
   const [showWelcome, setShowWelcome] = useState(() => welcomeParam || !AthleteWelcome.hasBeenShown());
 
@@ -139,12 +143,24 @@ export default function AthletePortalView() {
     try { localStorage.setItem('flux_athlete_view_mode', mode); } catch { /* noop */ }
   }, []);
 
+  const handleGridWorkoutClick = useCallback((slotId: string) => {
+    handleViewModeChange('list');
+    setHighlightedSlotId(slotId);
+    setTimeout(() => {
+      const el = slotRefs.current.get(slotId);
+      if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }, 100);
+    setTimeout(() => setHighlightedSlotId(null), 2100);
+  }, [handleViewModeChange]);
+
   // ── Canvas hooks ──
 
   const canvasWeekStart = useMemo(() => {
     const micro = profile?.active_microcycle;
     if (!micro?.start_date) return weekStart;
-    const start = new Date(micro.start_date);
+    // Append T12:00:00 to avoid UTC midnight → previous day in BR timezone (UTC-3)
+    const dateStr = micro.start_date.includes('T') ? micro.start_date : `${micro.start_date}T12:00:00`;
+    const start = new Date(dateStr);
     const weekOffset = (selectedWeek - 1) * 7;
     const canvasStart = new Date(start);
     canvasStart.setDate(start.getDate() + weekOffset);
@@ -164,8 +180,6 @@ export default function AthletePortalView() {
     }));
   }, [profile?.active_microcycle, profile?.modality, selectedWeek]);
 
-  const calendar = useCanvasCalendar({ weekStartDate: canvasWeekStart, athleteId: viewMode === 'canvas' ? profile?.athlete_id : undefined });
-
   const handleCanvasReorder = useCallback(async (workoutId: string, _fromDay: number, toDay: number, toTime: string) => {
     setUpdating(workoutId);
     try {
@@ -178,22 +192,25 @@ export default function AthletePortalView() {
 
   // ── Hooks that MUST be above early returns (React Rules of Hooks) ──
 
-  const pastWorkoutDays = useMemo(() => {
+  // Count feedbacks responded for this microcycle
+  const [feedbackCount, setFeedbackCount] = useState(0);
+  const totalFeedbackDays = useMemo(() => {
     const micro = profile?.active_microcycle;
-    if (!micro?.slots?.length || !micro.start_date) return 0;
-    const today = new Date();
-    today.setHours(23, 59, 59, 999);
-    const startDate = new Date(micro.start_date);
-    let count = 0;
-    for (const slot of micro.slots) {
-      const weekOffset = (slot.week_number - 1) * 7;
-      const dayOffset = slot.day_of_week - 1;
-      const slotDate = new Date(startDate);
-      slotDate.setDate(startDate.getDate() + weekOffset + dayOffset);
-      if (slotDate <= today) count++;
-    }
-    return count;
+    if (!micro?.slots?.length) return 0;
+    // Count unique day_of_week+week_number combos that have slots (i.e., training days needing feedback)
+    const days = new Set(micro.slots.map((s) => `${s.week_number}-${s.day_of_week}`));
+    return days.size;
   }, [profile?.active_microcycle]);
+
+  useEffect(() => {
+    const micro = profile?.active_microcycle;
+    if (!micro?.id) { setFeedbackCount(0); return; }
+    supabase
+      .from('athlete_feedback_entries')
+      .select('id', { count: 'exact', head: true })
+      .eq('microcycle_id', micro.id)
+      .then(({ count }) => setFeedbackCount(count || 0));
+  }, [profile?.active_microcycle?.id]);
 
   const prescribedModalities = useMemo((): Array<keyof typeof MODALITY_CONFIG> => {
     const mod = profile?.modality as keyof typeof MODALITY_CONFIG;
@@ -284,13 +301,15 @@ export default function AthletePortalView() {
 
   const micro = profile.active_microcycle;
   const modalityConfig = MODALITY_CONFIG[profile.modality];
-  const completionPct = micro ? Math.round((pastWorkoutDays / Math.max(micro.total_slots, 1)) * 100) : 0;
+  const completionPct = micro ? Math.round((feedbackCount / Math.max(totalFeedbackDays, 1)) * 100) : 0;
 
   const weeks = micro
     ? [1, 2, 3, 4].map((wk) => {
         let dateRange = '';
         if (micro.start_date) {
-          const start = new Date(micro.start_date);
+          // Append T12:00:00 to avoid UTC midnight → previous day in BR timezone (UTC-3)
+          const dateStr = micro.start_date.includes('T') ? micro.start_date : `${micro.start_date}T12:00:00`;
+          const start = new Date(dateStr);
           const ws = new Date(start); ws.setDate(start.getDate() + (wk - 1) * 7);
           const we = new Date(ws); we.setDate(ws.getDate() + 6);
           dateRange = `${ws.getDate().toString().padStart(2, '0')}/${(ws.getMonth() + 1).toString().padStart(2, '0')} - ${we.getDate().toString().padStart(2, '0')}/${(we.getMonth() + 1).toString().padStart(2, '0')}`;
@@ -315,7 +334,9 @@ export default function AthletePortalView() {
 
   const getDateForDay = (dayOfWeek: number): Date | null => {
     if (!micro?.start_date) return null;
-    const start = new Date(micro.start_date);
+    // Append T12:00:00 to avoid UTC midnight → previous day in BR timezone (UTC-3)
+    const dateStr = micro.start_date.includes('T') ? micro.start_date : `${micro.start_date}T12:00:00`;
+    const start = new Date(dateStr);
     const weekOffset = (selectedWeek - 1) * 7;
     const dayOffset = dayOfWeek - 1;
     const date = new Date(start);
@@ -375,6 +396,19 @@ export default function AthletePortalView() {
                     </span>
                   ))}
                 </div>
+                {/* Alert badges for health/financial pending */}
+                <div className="flex items-center gap-1 flex-shrink-0">
+                  {profile.parq_clearance_status && ['pending', 'blocked', 'expired'].includes(profile.parq_clearance_status) && (
+                    <span className="w-5 h-5 rounded-full bg-ceramic-error/10 flex items-center justify-center" title="Pendencia de saude">
+                      <Heart className="w-3 h-3 text-ceramic-error" />
+                    </span>
+                  )}
+                  {(profile as unknown as Record<string, unknown>).hasPendingPayment && (
+                    <span className="w-5 h-5 rounded-full bg-amber-500/10 flex items-center justify-center" title="Pendencia financeira">
+                      <DollarSign className="w-3 h-3 text-amber-600" />
+                    </span>
+                  )}
+                </div>
               </div>
               <div className="flex items-center gap-2 mt-0.5">
                 <p className="text-xs text-ceramic-text-secondary">Prescrito por {profile.coach_name}</p>
@@ -386,13 +420,13 @@ export default function AthletePortalView() {
             </div>
           </div>
 
-          {/* Treinos Cumpridos — overall progress */}
+          {/* Feedbacks Concluidos — overall progress */}
           {micro && (
             <div className="space-y-2 pt-3 border-t border-ceramic-border/30">
               <div className="flex items-center gap-1.5">
-                <span className="w-2 h-2 rounded-full bg-ceramic-text-secondary inline-block" />
-                <span className="text-sm font-bold text-ceramic-text-primary">{pastWorkoutDays}/{micro.total_slots}</span>
-                <span className="text-[10px] font-bold text-ceramic-text-secondary uppercase tracking-wider">Treinos Cumpridos</span>
+                <MessageSquare className="w-3.5 h-3.5 text-amber-500" />
+                <span className="text-sm font-bold text-ceramic-text-primary">{feedbackCount}/{totalFeedbackDays}</span>
+                <span className="text-[10px] font-bold text-ceramic-text-secondary uppercase tracking-wider">Feedbacks Concluidos</span>
               </div>
               <div className="flex items-center justify-between">
                 <span className="text-xs text-ceramic-text-secondary">Semana {micro.current_week}/4</span>
@@ -501,13 +535,11 @@ export default function AthletePortalView() {
             viewMode === 'canvas' ? (
               <motion.section className="px-5 flex-1" custom={4} initial="hidden" animate="visible" variants={sectionVariants}>
                 <div className="bg-white rounded-2xl shadow-sm overflow-hidden" style={{ height: 'calc(100vh - 400px)', minHeight: '500px' }}>
-                  <WeeklyGrid weekNumber={selectedWeek} workouts={canvasWorkouts} calendarEvents={calendar.busySlots}
-                    onReorderWorkout={handleCanvasReorder} onWorkoutClick={(id) => handleViewFeedback(id)}
-                    startDate={canvasWeekStart} isLoading={calendar.isLoading} />
+                  <WeeklyGrid weekNumber={selectedWeek} workouts={canvasWorkouts} calendarEvents={[]}
+                    onReorderWorkout={handleCanvasReorder} onWorkoutClick={(id) => handleGridWorkoutClick(id)}
+                    startDate={canvasWeekStart} isLoading={false} />
                 </div>
                 <div className="flex items-center gap-4 mt-3 px-1">
-                  <div className="flex items-center gap-1.5"><span className="w-2.5 h-2.5 rounded-sm bg-[#7B8FA2]/20" /><span className="text-[10px] text-ceramic-text-secondary">Coach ocupado</span></div>
-                  <div className="flex items-center gap-1.5"><span className="w-2.5 h-2.5 rounded-sm bg-[#C4883A]/20" /><span className="text-[10px] text-ceramic-text-secondary">Sua agenda</span></div>
                   <span className="text-[10px] text-ceramic-text-tertiary ml-auto">Arraste treinos para reorganizar</span>
                 </div>
               </motion.section>
@@ -525,21 +557,32 @@ export default function AthletePortalView() {
                       {daySlots.length > 0 ? (
                         <div className="space-y-2">
                           {daySlots.map((slot) => (
-                            <WorkoutCard key={slot.id} slot={slot}
-                              isUpdating={updating === slot.id} modality={profile.modality} />
+                            <div
+                              key={slot.id}
+                              ref={(el) => { if (el) slotRefs.current.set(slot.id, el); }}
+                              className={`transition-all duration-500 rounded-xl ${highlightedSlotId === slot.id ? 'ring-2 ring-amber-400 bg-amber-50/50' : ''}`}
+                            >
+                              <WorkoutCard slot={slot}
+                                isUpdating={updating === slot.id} modality={profile.modality} />
+                            </div>
                           ))}
                           {/* Day feedback — 8-question questionnaire right after this day's workouts */}
                           {user && micro && (
-                            <WeeklyFeedbackCard
-                              athleteId={profile.athlete_id}
-                              microcycleId={micro.id}
-                              weekNumber={selectedWeek}
-                              userId={user.id}
-                              currentWeek={micro.current_week || 1}
-                              microcycleStartDate={micro.start_date}
-                              workoutDays={[day]}
-                              onFeedbackSubmitted={() => refetch()}
-                            />
+                            <>
+                              <div className="flex items-center justify-center py-2">
+                                <span className="text-[10px] font-bold text-ceramic-text-secondary uppercase tracking-wider">Feedback</span>
+                              </div>
+                              <WeeklyFeedbackCard
+                                athleteId={profile.athlete_id}
+                                microcycleId={micro.id}
+                                weekNumber={selectedWeek}
+                                userId={user.id}
+                                currentWeek={micro.current_week || 1}
+                                microcycleStartDate={micro.start_date}
+                                workoutDays={[day]}
+                                onFeedbackSubmitted={() => refetch()}
+                              />
+                            </>
                           )}
                         </div>
                       ) : (


### PR DESCRIPTION
## Summary
Sprint de 9 issues do módulo Flux — página Meu-Treino do atleta.

- **#757**: Ícones de alerta (saúde/financeiro) ao lado do nome do atleta
- **#758**: Troca "Treinos Cumpridos" por contagem de feedbacks respondidos
- **#759**: Layout Feedback lado a lado (Visão Geral + Visão Semanal) no desktop
- **#760**: Label "Feedback" centralizado ao final da lista de exercícios
- **#761**: Correção de datas com 1 dia de defasagem (timezone UTC→BR)
- **#762**: Clique no card da grade navega para lista com highlight temporário
- **#763**: Removida agenda do coach da visão do atleta
- **#764**: Checkboxes substituídos por dots coloridos nos componentes de feedback
- **#768**: Layout do header investigado — ordem atual corresponde ao design

Closes #757, #758, #759, #760, #761, #762, #763, #764, #768

## Test plan
- [ ] `npm run build` passes
- [ ] `npm run typecheck` passes
- [ ] Verificar visualmente página Meu-Treino em staging
- [ ] Testar clique no card da grade → navega para lista com highlight
- [ ] Verificar datas nos cards de semana (sem defasagem)
- [ ] Verificar layout Feedback lado a lado no desktop
- [ ] Verificar ícones de alerta no Profile Card

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive workout grid with click-to-view functionality and slot highlighting.
  * Introduced feedback completion tracking and progress indicators on athlete portal.
  * Added health and financial status badges.
  * Enabled week-specific feedback filtering.

* **UI/Design**
  * Reorganized feedback view into side-by-side layout (overview and weekly timeline).
  * Simplified status indicators using colored dots instead of icons.
  * Improved error state visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->