### PR TITLE
fix(ui): quick bug fixes #671, #703, #672

### DIFF
--- a/src/modules/connections/components/AddMemberSheet.tsx
+++ b/src/modules/connections/components/AddMemberSheet.tsx
@@ -99,7 +99,7 @@ export function AddMemberSheet({ isOpen, onClose, spaceId, onMemberAdded }: AddM
 
           {/* Sheet */}
           <motion.div
-            className="fixed bottom-0 left-0 right-0 z-50 ceramic-card rounded-t-2xl p-6 max-h-[80vh] overflow-y-auto"
+            className="fixed bottom-0 left-0 right-0 z-50 ceramic-card rounded-t-2xl p-6 pb-24 sm:pb-6 max-h-[80vh] overflow-y-auto"
             initial={{ y: '100%' }}
             animate={{ y: 0 }}
             exit={{ y: '100%' }}

--- a/src/modules/connections/components/CreateSpaceDrawer.tsx
+++ b/src/modules/connections/components/CreateSpaceDrawer.tsx
@@ -218,7 +218,7 @@ export function CreateSpaceDrawer({
             </form>
 
             {/* Footer (fixed) */}
-            <div className="flex items-center justify-end gap-3 p-6 border-t border-ceramic-border bg-ceramic-cool/20">
+            <div className="flex items-center justify-end gap-3 p-6 pb-24 sm:pb-6 border-t border-ceramic-border bg-ceramic-cool/20">
               <button
                 type="button"
                 onClick={handleClose}

--- a/src/modules/journey/components/capture/QuickCapture.tsx
+++ b/src/modules/journey/components/capture/QuickCapture.tsx
@@ -164,9 +164,9 @@ export function QuickCapture({
         showPhoto
       />
 
-      {/* AI Suggestion (appears after 3s of no typing) */}
+      {/* AI Suggestion (appears after 3s of no typing) — question type removed (#703) */}
       <AnimatePresence>
-        {aiSuggestion && (
+        {aiSuggestion && aiSuggestion.type !== 'question' && (
           <motion.div
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: 'auto' }}

--- a/src/modules/journey/hooks/useDailyQuestionAI.ts
+++ b/src/modules/journey/hooks/useDailyQuestionAI.ts
@@ -20,6 +20,7 @@ import {
   getDailyQuestionsForCarousel,
   saveDailyResponse,
   logDailyQuestionUsage,
+  markQuestionTextAnswered,
 } from '../services/dailyQuestionService'
 import { answerQuestion as saveQuestionResponse } from '../services/questionService'
 
@@ -122,6 +123,7 @@ export function useDailyQuestionAI() {
         } else {
           // AI/template/pool question with synthetic ID — use heuristic CP scoring
           await saveDailyResponse(user.id, state.question.id, responseText, state.source as 'ai' | 'journey' | 'pool')
+          markQuestionTextAnswered(state.question.question_text)
 
           // Use the same heuristic-quality approach as qualityEvaluationService
           // for consistency between DB-question and AI/pool-question scoring paths
@@ -286,6 +288,7 @@ export function useDailyQuestionCarousel(count: number = 5) {
           })
         } else {
           await saveDailyResponse(user.id, question.id, responseText, source)
+          markQuestionTextAnswered(question.question_text)
 
           // Quality-aware heuristic CP scoring
           const words = responseText.trim().split(/\s+/).filter(w => w.length > 0)

--- a/src/modules/journey/services/dailyQuestionService.ts
+++ b/src/modules/journey/services/dailyQuestionService.ts
@@ -757,6 +757,32 @@ function addRecentlyShownId(id: string): void {
   } catch { /* ignore */ }
 }
 
+/**
+ * Track answered question texts in sessionStorage to prevent showing
+ * the same question again after the user answers it.
+ * This is needed because pool/AI questions use synthetic IDs that
+ * aren't stored in the DB, so we can't check question_responses.
+ */
+function getAnsweredQuestionTexts(): Set<string> {
+  if (typeof window === 'undefined') return new Set()
+  try {
+    const stored = sessionStorage.getItem('daily_question_answered_texts')
+    if (stored) return new Set(JSON.parse(stored))
+  } catch { /* ignore */ }
+  return new Set()
+}
+
+export function markQuestionTextAnswered(text: string): void {
+  if (typeof window === 'undefined') return
+  try {
+    const answered = getAnsweredQuestionTexts()
+    answered.add(text.toLowerCase().trim())
+    const arr = Array.from(answered)
+    if (arr.length > 30) arr.splice(0, arr.length - 30)
+    sessionStorage.setItem('daily_question_answered_texts', JSON.stringify(arr))
+  } catch { /* ignore */ }
+}
+
 function getPoolQuestion(userId: string): DailyQuestion {
   const hour = new Date().getHours()
   const timeOfDay = hour >= 5 && hour < 12 ? 'morning' : hour >= 12 && hour < 18 ? 'afternoon' : 'evening'
@@ -1002,7 +1028,8 @@ export async function getDailyQuestionsForCarousel(
 ): Promise<DailyQuestionResult[]> {
   const generatedAt = new Date().toISOString()
   const results: DailyQuestionResult[] = []
-  const usedTexts = new Set<string>()
+  const answeredTexts = getAnsweredQuestionTexts()
+  const usedTexts = new Set<string>(answeredTexts)
 
   // Fetch user context ONCE
   let userContext: UserContext


### PR DESCRIPTION
## Summary
- **#671** — Add `pb-24 sm:pb-6` mobile padding to CreateSpaceDrawer and AddMemberSheet footer to prevent buttons from being hidden behind BottomNav
- **#703** — Filter out `question` type AI suggestions in QuickCapture (keep only reflection and pattern types)
- **#672** — Track answered question texts in sessionStorage to prevent daily questions from appearing twice (pool/AI questions use non-UUID IDs that skip DB insert, so there was no dedup)

## Test plan
- [x] `npm run build` passes
- [ ] `npm run typecheck` passes
- [ ] Manual: Open CreateSpaceDrawer on mobile — save button visible above BottomNav
- [ ] Manual: Open AddMemberSheet on mobile — submit button visible above BottomNav
- [ ] Manual: QuickCapture no longer shows "Pergunta para aprofundar" AI suggestions
- [ ] Manual: Answer a daily pool question, navigate away and back — same question doesn't reappear

Closes #671, #703, #672

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized responsive spacing and padding on mobile screens, providing better visual presentation and usability for member addition and space creation interfaces.
  * Enhanced AI suggestion system to prevent repeating previously answered questions and intelligently filter out question-type suggestions from the quick capture interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->