### PR TITLE
fix(multi): edge function timeouts + studio profile UX

### DIFF
--- a/src/modules/studio/components/workspace/SetupStage.tsx
+++ b/src/modules/studio/components/workspace/SetupStage.tsx
@@ -514,7 +514,9 @@ Exemplo: ["Tema 1", "Tema 2", "Tema 3"]`,
                     <div className="flex items-start space-x-3 mb-3">
                       <CheckCircle className="w-5 h-5 text-ceramic-success flex-shrink-0 mt-0.5" aria-hidden="true" />
                       <div className="flex-1">
-                        <h3 className="font-semibold text-ceramic-text-primary mb-1">Perfil encontrado!</h3>
+                        <h3 className="font-semibold text-ceramic-text-primary mb-1">
+                          Perfil encontrado — é essa pessoa?
+                        </h3>
                         {profileData.full_name && (
                           <p className="text-sm text-ceramic-text-primary">
                             <strong>Nome completo:</strong> {profileData.full_name}
@@ -531,17 +533,22 @@ Exemplo: ["Tema 1", "Tema 2", "Tema 3"]`,
                           </p>
                         )}
                         {profileData.bio_summary && (
-                          <p className="text-sm text-ceramic-secondary mt-2">{profileData.bio_summary}</p>
+                          <p className="text-sm text-ceramic-text-secondary mt-2 italic">
+                            &ldquo;{profileData.bio_summary}&rdquo;
+                          </p>
                         )}
                       </div>
                     </div>
+                    <p className="text-xs text-ceramic-text-secondary mb-3">
+                      Confirme se este é o convidado que você procura, ou busque novamente com outro nome/referência.
+                    </p>
                     <div className="flex space-x-3">
                       <button
                         type="button"
                         onClick={handleConfirmProfile}
                         className="px-4 py-2 bg-ceramic-success text-white rounded-lg hover:bg-ceramic-success/90 transition-colors text-sm focus:outline-none focus:ring-4 focus:ring-ceramic-success/20"
                       >
-                        Confirmar Perfil
+                        Sim, é essa pessoa
                       </button>
                       <button
                         type="button"
@@ -551,7 +558,7 @@ Exemplo: ["Tema 1", "Tema 2", "Tema 3"]`,
                         }}
                         className="px-4 py-2 bg-ceramic-surface-hover text-ceramic-text-primary rounded-lg hover:bg-ceramic-disabled transition-colors text-sm focus:outline-none focus:ring-4 focus:ring-ceramic-accent/20"
                       >
-                        Buscar Novamente
+                        Não, buscar novamente
                       </button>
                     </div>
                   </div>

--- a/supabase/functions/external-weather/index.ts
+++ b/supabase/functions/external-weather/index.ts
@@ -280,14 +280,19 @@ Vento maximo: ${maxWind.toFixed(0)} km/h
 
 Responda SOMENTE com a frase, sem aspas nem explicacao.`;
 
-  const result = await model.generateContent({
+  // Race Gemini call against timeout to prevent 504 gateway timeouts
+  const geminiPromise = model.generateContent({
     contents: [{ role: 'user', parts: [{ text: prompt }] }],
     generationConfig: {
       maxOutputTokens: 256,
       temperature: 0.7,
     },
   });
+  const timeoutPromise = new Promise<never>((_, reject) =>
+    setTimeout(() => reject(new Error('Gemini insight timeout (8s)')), 8000)
+  );
 
+  const result = await Promise.race([geminiPromise, timeoutPromise]);
   const text = result.response.text().trim();
   // Ensure insight is not too long
   return text.length > 150 ? text.substring(0, 147) + '...' : text;

--- a/supabase/functions/finance-monthly-digest/index.ts
+++ b/supabase/functions/finance-monthly-digest/index.ts
@@ -240,13 +240,23 @@ serve(async (req: Request) => {
       )
     }
 
-    // Fetch previous month for comparison
-    const { data: prevTransactions } = await supabase
-      .from('finance_transactions')
-      .select('id, description, amount, type, category, transaction_date, merchant_name, is_recurring')
-      .eq('user_id', user.id)
-      .gte('transaction_date', prevStartDate)
-      .lte('transaction_date', prevEndDate)
+    // Fetch previous month for comparison (non-critical — continue if fails)
+    let prevTransactions: typeof transactions = null
+    try {
+      const { data, error: prevError } = await supabase
+        .from('finance_transactions')
+        .select('id, description, amount, type, category, transaction_date, merchant_name, is_recurring')
+        .eq('user_id', user.id)
+        .gte('transaction_date', prevStartDate)
+        .lte('transaction_date', prevEndDate)
+      if (prevError) {
+        console.warn('[finance-monthly-digest] Previous month query failed:', prevError.message)
+      } else {
+        prevTransactions = data
+      }
+    } catch (prevErr) {
+      console.warn('[finance-monthly-digest] Previous month query error:', prevErr)
+    }
 
     // Calculate stats
     const { current, previous, percentChange } = calculateStats(
@@ -310,20 +320,29 @@ Regras:
     // Call Gemini 2.5 Flash via REST API
     const geminiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${geminiApiKey}`
 
-    const geminiResponse = await fetch(geminiUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        contents: [{ role: 'user', parts: [{ text: prompt }] }],
-        generationConfig: {
-          maxOutputTokens: 4096,
-          temperature: 0.3,
-        },
-        thinkingConfig: {
-          thinkingBudget: 0,
-        },
-      }),
-    })
+    const abortController = new AbortController()
+    const geminiTimeout = setTimeout(() => abortController.abort(), 25000)
+
+    let geminiResponse: Response
+    try {
+      geminiResponse = await fetch(geminiUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        signal: abortController.signal,
+        body: JSON.stringify({
+          contents: [{ role: 'user', parts: [{ text: prompt }] }],
+          generationConfig: {
+            maxOutputTokens: 4096,
+            temperature: 0.3,
+          },
+          thinkingConfig: {
+            thinkingBudget: 0,
+          },
+        }),
+      })
+    } finally {
+      clearTimeout(geminiTimeout)
+    }
 
     if (!geminiResponse.ok) {
       const errText = await geminiResponse.text()


### PR DESCRIPTION
## Summary
- **#773** — Add 8s `Promise.race` timeout to Gemini insight call in `external-weather` Edge Function (prevents 504 gateway timeout when Gemini API hangs)
- **#771** — Add error handling for previous month query + 25s `AbortController` timeout on Gemini fetch in `finance-monthly-digest` Edge Function
- **#674** — Improve "Perfil encontrado" UX in Studio SetupStage: show bio_summary as italicized quote, add "é essa pessoa?" confirmation question, clearer button labels ("Sim, é essa pessoa" / "Não, buscar novamente")

## Test plan
- [x] `npm run build` passes
- [ ] Manual: Weather widget loads without 504 (even when Gemini is slow, weather data still returns)
- [ ] Manual: Finance monthly digest shows result or clear error (no hanging)
- [ ] Manual: Studio guest search shows profile context with confirmation question

## Edge Function Deploy Required
After merge, deploy modified Edge Functions:
```bash
npx supabase functions deploy external-weather --no-verify-jwt
npx supabase functions deploy finance-monthly-digest --no-verify-jwt
```

Closes #773, #771, #674

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>