### PR TITLE
fix(flux): Meu Treino UI quick fixes #779 #780 #792 #793 #794

### DIFF
--- a/src/modules/flux/components/canvas/WeeklyGrid.tsx
+++ b/src/modules/flux/components/canvas/WeeklyGrid.tsx
@@ -80,18 +80,6 @@ const MODALITY_COLORS: Record<string, { bg: string; border: string; text: string
   triathlon: { bg: 'rgba(251,113,133,0.12)', border: 'rgb(251,113,133)', text: '#881337' },
 };
 
-const INTENSITY_DOTS: Record<string, string> = {
-  low: 'bg-[#6B7B5C]',
-  medium: 'bg-amber-500',
-  high: 'bg-[#9B4D3A]',
-};
-
-const INTENSITY_LABELS: Record<string, string> = {
-  low: 'Leve',
-  medium: 'Moderado',
-  high: 'Intenso',
-};
-
 const MODALITY_ICONS: Record<string, string> = {
   swimming: '\u{1F3CA}',
   running: '\u{1F3C3}',
@@ -240,18 +228,11 @@ const PositionedWorkoutCard = React.forwardRef<HTMLDivElement, PositionedWorkout
             />
           </div>
         </div>
-        <div className="flex items-center gap-1.5">
-          {workout.start_time && (
-            <span className="text-[9px] font-medium text-ceramic-text-secondary">
-              {workout.start_time}–{endTime}
-            </span>
-          )}
-          <span className="text-[9px] text-ceramic-text-tertiary">{workout.duration}min</span>
-          <span className={`w-1.5 h-1.5 rounded-full ${INTENSITY_DOTS[workout.intensity] || ''}`} />
-          <span className="text-[8px] font-medium text-ceramic-text-secondary">
-            {INTENSITY_LABELS[workout.intensity] || ''}
+        {workout.start_time && (
+          <span className="text-[9px] font-medium text-ceramic-text-secondary">
+            {workout.start_time}–{endTime}
           </span>
-        </div>
+        )}
       </div>
     </motion.div>
   );

--- a/src/modules/flux/views/AthletePortalView.tsx
+++ b/src/modules/flux/views/AthletePortalView.tsx
@@ -180,7 +180,7 @@ export default function AthletePortalView() {
       id: slot.id, day_of_week: slot.day_of_week, start_time: slot.time_of_day || undefined,
       name: slot.template?.name || 'Treino', duration: slot.custom_duration || slot.template?.duration || 60,
       intensity: (['low', 'medium', 'high'].includes(slot.template?.intensity || '') ? slot.template.intensity : 'medium') as 'low' | 'medium' | 'high',
-      modality: (['swimming', 'running', 'cycling', 'strength'].includes(profile?.modality || '') ? profile?.modality : 'strength') as WeekWorkout['modality'],
+      modality: (['swimming', 'running', 'cycling', 'strength', 'walking', 'triathlon'].includes(profile?.modality || '') ? profile?.modality : 'strength') as WeekWorkout['modality'],
     }));
   }, [profile?.active_microcycle, profile?.modality, selectedWeek]);
 
@@ -412,12 +412,12 @@ export default function AthletePortalView() {
             <span className="text-xs font-bold uppercase tracking-wider">Meu Treino</span>
           </button>
           {activeTab === 'treinos' && (
-            <div className="flex items-center gap-1 p-1 rounded-xl bg-ceramic-cool/60">
-              <button onClick={() => handleViewModeChange('list')} className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-bold transition-all ${viewMode === 'list' ? 'bg-white text-ceramic-text-primary shadow-sm' : 'text-ceramic-text-secondary hover:text-ceramic-text-primary'}`}>
-                <List className="w-3.5 h-3.5" />Lista
+            <div className="flex items-center gap-1 p-1 rounded-xl bg-ceramic-cool shadow-sm border border-ceramic-border/40">
+              <button onClick={() => handleViewModeChange('list')} className={`flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-bold transition-all ${viewMode === 'list' ? 'bg-white text-ceramic-text-primary shadow-md' : 'text-ceramic-text-secondary hover:text-ceramic-text-primary hover:bg-white/50'}`}>
+                <List className="w-4 h-4" />Lista
               </button>
-              <button onClick={() => handleViewModeChange('canvas')} className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-bold transition-all ${viewMode === 'canvas' ? 'bg-white text-ceramic-text-primary shadow-sm' : 'text-ceramic-text-secondary hover:text-ceramic-text-primary'}`}>
-                <LayoutGrid className="w-3.5 h-3.5" />Grade
+              <button onClick={() => handleViewModeChange('canvas')} className={`flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-bold transition-all ${viewMode === 'canvas' ? 'bg-white text-ceramic-text-primary shadow-md' : 'text-ceramic-text-secondary hover:text-ceramic-text-primary hover:bg-white/50'}`}>
+                <LayoutGrid className="w-4 h-4" />Grade
               </button>
             </div>
           )}
@@ -476,23 +476,6 @@ export default function AthletePortalView() {
             </div>
           </div>
 
-          {/* Feedbacks Concluidos — overall progress */}
-          {micro && (
-            <div className="space-y-2 pt-3 border-t border-ceramic-border/30">
-              <div className="flex items-center gap-1.5">
-                <MessageSquare className="w-3.5 h-3.5 text-amber-500" />
-                <span className="text-sm font-bold text-ceramic-text-primary">{feedbackCount}/{totalFeedbackDays}</span>
-                <span className="text-[10px] font-bold text-ceramic-text-secondary uppercase tracking-wider">Feedbacks Concluidos</span>
-              </div>
-              <div className="flex items-center justify-between">
-                <span className="text-xs text-ceramic-text-secondary">Semana {micro.current_week}/4</span>
-                <span className="text-xs font-bold text-ceramic-text-primary">{completionPct}%</span>
-              </div>
-              <div className="h-1.5 bg-ceramic-cool rounded-full overflow-hidden">
-                <motion.div className="h-full bg-amber-400 rounded-full" initial={{ width: 0 }} animate={{ width: `${completionPct}%` }} transition={{ duration: 0.6, delay: 0.2 }} />
-              </div>
-            </div>
-          )}
         </div>
       </motion.section>
 
@@ -604,11 +587,13 @@ export default function AthletePortalView() {
                 {[1, 2, 3, 4, 5, 6, 7].map((day) => {
                   const daySlots = slotsByDay.get(day) || [];
                   const date = getDateForDay(day);
+                  const isToday = date != null && date.getFullYear() === todayMidnight.getFullYear() && date.getMonth() === todayMidnight.getMonth() && date.getDate() === todayMidnight.getDate();
                   return (
                     <div key={day}>
                       <div className="flex items-center gap-2 py-3">
                         <span className="text-xs font-black text-ceramic-text-primary uppercase">{DAY_NAMES[day]}</span>
                         {date && <span className="text-xs text-ceramic-text-secondary">{date.getDate()} {MONTH_NAMES[date.getMonth()]}</span>}
+                        {isToday && <span className="text-[10px] font-bold text-amber-600 bg-amber-100 px-2 py-0.5 rounded-full">Hoje</span>}
                       </div>
                       {daySlots.length > 0 ? (
                         <div className="space-y-2">
@@ -616,7 +601,8 @@ export default function AthletePortalView() {
                             <div
                               key={slot.id}
                               ref={(el) => { if (el) slotRefs.current.set(slot.id, el); }}
-                              className={`transition-all duration-500 rounded-xl ${highlightedSlotId === slot.id ? 'ring-2 ring-amber-400 bg-amber-50/50' : ''}`}
+                              className={`transition-all duration-500 rounded-2xl ${highlightedSlotId === slot.id ? 'ring-2 ring-amber-400 bg-amber-50/50' : ''} ${isToday && highlightedSlotId !== slot.id ? 'ring-2 ring-amber-400/60' : ''}`}
+                              style={isToday && highlightedSlotId !== slot.id ? { background: 'linear-gradient(135deg, rgba(251,191,36,0.15) 0%, rgba(251,191,36,0.04) 40%, transparent 70%)' } : undefined}
                             >
                               <WorkoutCard slot={slot}
                                 isUpdating={updating === slot.id} modality={profile.modality} />


### PR DESCRIPTION
## Summary
- Remove "Feedbacks Concluidos" week progression section from Meu Treino (#779)
- Make Lista/Grade toggle more prominent with larger sizing and visual weight (#793)
- Add "Hoje" badge pill and amber gradient highlight on today's workout cards (#780)
- Remove redundant time/duration/intensity metadata row from Grade view cards (#792)
- Add `walking` and `triathlon` to modality color whitelist in AthletePortalView (#794)

## Files changed
- `src/modules/flux/views/AthletePortalView.tsx` — layout cleanup, today highlight, toggle styling, modality whitelist
- `src/modules/flux/components/canvas/WeeklyGrid.tsx` — remove card metadata row + unused constants

## Test plan
- [x] `npm run build` passes
- [ ] Manual: Open Meu Treino → verify "Feedbacks Concluidos" section is gone
- [ ] Manual: Verify Lista/Grade toggle is visually prominent
- [ ] Manual: Verify today's card has amber gradient + "Hoje" badge
- [ ] Manual: Open Grade view → verify cards show only title/modality (no time/intensity row)
- [ ] Manual: Create workout with walking/triathlon modality → verify color renders

Closes #779, #780, #792, #793, #794

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual indicator for the current day in the week view with a "Hoje" badge.

* **Bug Fixes**
  * Removed intensity indicators from workout cards for a cleaner display.
  * Removed overall progress section from the profile header.

* **Style**
  * Redesigned header controls with improved styling and larger touch targets.
  * Enhanced day-slot styling with updated visual treatments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->