### PR TITLE
fix(flux): Canvas coach UI cleanup #782 #785 #786 #790

### DIFF
--- a/src/modules/flux/components/canvas/CanvasFilterToolbar.tsx
+++ b/src/modules/flux/components/canvas/CanvasFilterToolbar.tsx
@@ -1,7 +1,7 @@
 /**
  * CanvasFilterToolbar
  *
- * Horizontal filter bar above the grid: Modality + Zone + Volume pills.
+ * Horizontal filter bar above the grid: Modality + Zone pills.
  * Extracted from CanvasLibrarySidebar for better layout (#698).
  */
 
@@ -17,7 +17,6 @@ export const MODALITY_ICONS: Record<string, string> = {
   cycling: '\u{1F6B4}',
   strength: '\u{1F4AA}',
   walking: '\u{1F6B6}',
-  triathlon: '\u{1F3C5}',
 };
 
 export const MODALITY_PT_LABELS: Record<string, string> = {
@@ -26,23 +25,14 @@ export const MODALITY_PT_LABELS: Record<string, string> = {
   cycling: 'Ciclismo',
   strength: 'Musculacao',
   walking: 'Caminhada',
-  triathlon: 'Triatleta',
 };
 
 export const ZONE_OPTIONS = [
-  { key: 'all', label: 'Todas' },
   { key: 'Z1', label: 'Z1' },
   { key: 'Z2', label: 'Z2' },
   { key: 'Z3', label: 'Z3' },
   { key: 'Z4', label: 'Z4' },
   { key: 'Z5', label: 'Z5' },
-];
-
-export const VOLUME_OPTIONS = [
-  { key: 'all', label: 'Todos', min: 0, max: Infinity },
-  { key: 'short', label: '< 30min', min: 0, max: 30 },
-  { key: 'medium', label: '30-60min', min: 30, max: 60 },
-  { key: 'long', label: '> 60min', min: 60, max: Infinity },
 ];
 
 // ============================================
@@ -53,10 +43,8 @@ interface CanvasFilterToolbarProps {
   athleteModality?: string;
   libraryModality: string | null;
   onModalityChange: (mod: string | null) => void;
-  zoneFilter: string;
-  onZoneChange: (zone: string) => void;
-  volumeFilter: string;
-  onVolumeChange: (vol: string) => void;
+  zoneFilter: string[];
+  onZoneToggle: (zone: string) => void;
 }
 
 export const CanvasFilterToolbar: React.FC<CanvasFilterToolbarProps> = ({
@@ -64,9 +52,7 @@ export const CanvasFilterToolbar: React.FC<CanvasFilterToolbarProps> = ({
   libraryModality,
   onModalityChange,
   zoneFilter,
-  onZoneChange,
-  volumeFilter,
-  onVolumeChange,
+  onZoneToggle,
 }) => {
   const activeModality = libraryModality || athleteModality;
 
@@ -114,39 +100,19 @@ export const CanvasFilterToolbar: React.FC<CanvasFilterToolbarProps> = ({
       {/* Divider */}
       <div className="w-px h-5 bg-ceramic-border/30" />
 
-      {/* Zone pills */}
+      {/* Zone pills (multi-select toggle: empty = show all) */}
       <div className="flex items-center gap-1">
         {ZONE_OPTIONS.map((zone) => (
           <button
             key={zone.key}
-            onClick={() => onZoneChange(zone.key)}
+            onClick={() => onZoneToggle(zone.key)}
             className={`px-2.5 py-1 rounded-lg text-[10px] font-bold uppercase tracking-wider transition-all ${
-              zoneFilter === zone.key
+              zoneFilter.includes(zone.key)
                 ? 'bg-ceramic-base text-ceramic-text-primary shadow-sm'
                 : 'text-ceramic-text-tertiary hover:text-ceramic-text-secondary'
             }`}
           >
             {zone.label}
-          </button>
-        ))}
-      </div>
-
-      {/* Divider */}
-      <div className="w-px h-5 bg-ceramic-border/30" />
-
-      {/* Volume pills */}
-      <div className="flex items-center gap-1">
-        {VOLUME_OPTIONS.map((vol) => (
-          <button
-            key={vol.key}
-            onClick={() => onVolumeChange(vol.key)}
-            className={`px-2.5 py-1 rounded-lg text-[10px] font-bold uppercase tracking-wider transition-all ${
-              volumeFilter === vol.key
-                ? 'bg-ceramic-base text-ceramic-text-primary shadow-sm'
-                : 'text-ceramic-text-tertiary hover:text-ceramic-text-secondary'
-            }`}
-          >
-            {vol.label}
           </button>
         ))}
       </div>

--- a/src/modules/flux/components/canvas/CanvasLibrarySidebar.tsx
+++ b/src/modules/flux/components/canvas/CanvasLibrarySidebar.tsx
@@ -4,13 +4,12 @@
  * Left sidebar for the Canvas editor: search bar + template library.
  * Templates are draggable into the grid.
  *
- * Filters (modality, zone, volume) have been moved to CanvasFilterToolbar (#698).
+ * Filters (modality, zone) have been moved to CanvasFilterToolbar (#698).
  */
 
 import React, { useState, useMemo } from 'react';
 import { Search } from 'lucide-react';
 import { useWorkoutTemplates } from '../../hooks/useWorkoutTemplates';
-import { MODALITY_ICONS, MODALITY_PT_LABELS, VOLUME_OPTIONS } from './CanvasFilterToolbar';
 import type { WorkoutTemplate } from '../../types/flow';
 import type { Athlete } from '../../types/flux';
 
@@ -33,8 +32,7 @@ interface CanvasLibrarySidebarProps {
   onTemplateSelect: (template: WorkoutTemplate) => void;
   // Filter state lifted to parent
   libraryModality: string | null;
-  zoneFilter: string;
-  volumeFilter: string;
+  zoneFilter: string[];
 }
 
 export const CanvasLibrarySidebar: React.FC<CanvasLibrarySidebarProps> = ({
@@ -42,7 +40,6 @@ export const CanvasLibrarySidebar: React.FC<CanvasLibrarySidebarProps> = ({
   onTemplateSelect,
   libraryModality,
   zoneFilter,
-  volumeFilter,
 }) => {
   const [searchQuery, setSearchQuery] = useState('');
 
@@ -55,8 +52,8 @@ export const CanvasLibrarySidebar: React.FC<CanvasLibrarySidebarProps> = ({
   const filtered = useMemo(() => {
     let result = templates;
 
-    // Zone filter: match against intensity mapping (Z1-Z2 = low, Z3 = medium, Z4-Z5 = high)
-    if (zoneFilter !== 'all') {
+    // Zone filter: multi-select toggle (empty = show all)
+    if (zoneFilter.length > 0) {
       const zoneIntensityMap: Record<string, string[]> = {
         Z1: ['low'],
         Z2: ['low'],
@@ -64,16 +61,8 @@ export const CanvasLibrarySidebar: React.FC<CanvasLibrarySidebarProps> = ({
         Z4: ['high'],
         Z5: ['high'],
       };
-      const intensities = zoneIntensityMap[zoneFilter] || [];
-      result = result.filter((t) => intensities.includes(t.intensity));
-    }
-
-    // Volume filter
-    if (volumeFilter !== 'all') {
-      const vol = VOLUME_OPTIONS.find((v) => v.key === volumeFilter);
-      if (vol) {
-        result = result.filter((t) => t.duration >= vol.min && t.duration < vol.max);
-      }
+      const allowedIntensities = new Set(zoneFilter.flatMap((z) => zoneIntensityMap[z] || []));
+      result = result.filter((t) => allowedIntensities.has(t.intensity));
     }
 
     // Search filter
@@ -87,32 +76,12 @@ export const CanvasLibrarySidebar: React.FC<CanvasLibrarySidebarProps> = ({
     }
 
     return result;
-  }, [templates, zoneFilter, volumeFilter, searchQuery]);
+  }, [templates, zoneFilter, searchQuery]);
 
   return (
     <div className="flex flex-col w-80 h-full border-r border-ceramic-text-secondary/10">
-      {/* Header + Search */}
-      <div className="p-4 border-b border-ceramic-text-secondary/10 space-y-3 bg-ceramic-base flex-shrink-0">
-        <div className="flex items-center gap-3">
-          <div
-            className="p-2 rounded-[12px]"
-            style={{
-              boxShadow:
-                'inset 2px 2px 5px rgba(163,158,145,0.2), inset -2px -2px 5px rgba(255,255,255,0.9)',
-            }}
-          >
-            <span className="text-xl">{MODALITY_ICONS[modality] || '\u{1F3C3}'}</span>
-          </div>
-          <div>
-            <p className="text-[10px] text-ceramic-text-secondary font-medium uppercase tracking-wider">
-              Biblioteca
-            </p>
-            <h3 className="text-lg font-bold text-ceramic-text-primary capitalize">
-              {MODALITY_PT_LABELS[modality] || modality}
-            </h3>
-          </div>
-        </div>
-
+      {/* Search */}
+      <div className="p-4 border-b border-ceramic-text-secondary/10 bg-ceramic-base flex-shrink-0">
         {/* Search Input */}
         <div className="relative">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-ceramic-text-secondary" />

--- a/src/modules/flux/components/canvas/WeeklyGrid.tsx
+++ b/src/modules/flux/components/canvas/WeeklyGrid.tsx
@@ -9,7 +9,7 @@
 
 import React, { useState, useCallback, useMemo, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Calendar, GripVertical, Plus, Trash2 } from 'lucide-react';
+import { GripVertical, Trash2 } from 'lucide-react';
 import { springHover } from '@/lib/animations/ceramic-motion';
 
 // ============================================
@@ -502,33 +502,6 @@ export const WeeklyGrid: React.FC<WeeklyGridProps> = ({
 
   return (
     <div className="flex-1 flex flex-col h-full bg-ceramic-base">
-      {/* Week Header */}
-      <div
-        className="px-5 py-3 border-b border-ceramic-text-secondary/10 flex-shrink-0"
-        style={{ background: '#F0EFE9' }}
-      >
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <div
-              className="p-2 rounded-[12px]"
-              style={{
-                boxShadow: 'inset 2px 2px 5px rgba(163,158,145,0.2), inset -2px -2px 5px rgba(255,255,255,0.9)',
-              }}
-            >
-              <Calendar className="w-4 h-4 text-[#7B8FA2]" />
-            </div>
-            <div>
-              <h2 className="text-base font-bold text-ceramic-text-primary">
-                Semana {weekNumber}
-              </h2>
-            </div>
-          </div>
-          <div className="flex items-center gap-4 text-xs text-ceramic-text-secondary">
-            <span>{workouts.length} treino(s)</span>
-          </div>
-        </div>
-      </div>
-
       {/* Time Grid */}
       <div className="flex-1 overflow-auto">
         <div className="flex min-w-[800px]">

--- a/src/modules/flux/views/CanvasEditorView.tsx
+++ b/src/modules/flux/views/CanvasEditorView.tsx
@@ -206,8 +206,7 @@ export default function CanvasEditorView() {
 
   // Filter state (lifted from sidebar for shared toolbar)
   const [libraryModality, setLibraryModality] = useState<string | null>(null);
-  const [zoneFilter, setZoneFilter] = useState('all');
-  const [volumeFilter, setVolumeFilter] = useState('all');
+  const [zoneFilter, setZoneFilter] = useState<string[]>([]);
 
   // All hooks MUST be called before any conditional return
   const { athletes, isLoading: athletesLoading } = useAthletes();
@@ -551,9 +550,11 @@ export default function CanvasEditorView() {
           libraryModality={libraryModality}
           onModalityChange={setLibraryModality}
           zoneFilter={zoneFilter}
-          onZoneChange={setZoneFilter}
-          volumeFilter={volumeFilter}
-          onVolumeChange={setVolumeFilter}
+          onZoneToggle={(zone) =>
+            setZoneFilter((prev) =>
+              prev.includes(zone) ? prev.filter((z) => z !== zone) : [...prev, zone]
+            )
+          }
         />
       )}
 
@@ -566,7 +567,6 @@ export default function CanvasEditorView() {
             onTemplateSelect={handleTemplateSelect}
             libraryModality={libraryModality}
             zoneFilter={zoneFilter}
-            volumeFilter={volumeFilter}
           />
         )}
 


### PR DESCRIPTION
## Summary
- Remove triathlon from modality filter pills — it's a badge, not a trainable modality (#785)
- Remove volume/duration filter from toolbar (#782)
- Change zone filter to multi-select toggle — no selection shows all, selecting zones filters (#786)
- Remove sidebar modality icon/Biblioteca header (#790)
- Remove "Semana X" header with calendar icon from WeeklyGrid (#790)

## Files changed
- `src/modules/flux/components/canvas/CanvasFilterToolbar.tsx` — removed triathlon, volume, zone "Todas"
- `src/modules/flux/components/canvas/CanvasLibrarySidebar.tsx` — removed header, updated zone filter to array
- `src/modules/flux/components/canvas/WeeklyGrid.tsx` — removed week header
- `src/modules/flux/views/CanvasEditorView.tsx` — updated state/props for zone array, removed volume

## Test plan
- [x] `npm run build` passes
- [ ] Manual: Open Canvas → verify triathlon pill is gone from modality bar
- [ ] Manual: Verify no duration/volume filter section
- [ ] Manual: Click zone pills → toggles on/off, multiple zones selectable
- [ ] Manual: No zones selected → all exercises shown
- [ ] Manual: Sidebar has search only, no header with icon
- [ ] Manual: Grid has no "Semana X" header above columns

Closes #782, #785, #786, #790

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>