### PR TITLE
fix(flux): voice transcript duplication + athlete profile feedback #778 #781

### DIFF
--- a/src/modules/flux/components/athlete/ExerciseQuestionnaireSheet.tsx
+++ b/src/modules/flux/components/athlete/ExerciseQuestionnaireSheet.tsx
@@ -87,6 +87,23 @@ const QUESTIONS: QuestionDef[] = [
 
 const TOTAL_STEPS = QUESTIONS.length + 1; // 8 questions + 1 notes step
 
+/**
+ * Detects and removes duplicated transcript text from Gemini responses.
+ * e.g. "Os exercícios foram bons.Os exercícios foram bons." → "Os exercícios foram bons."
+ */
+function deduplicateTranscript(text: string): string {
+  if (!text || text.length < 10) return text;
+  const len = text.length;
+  // Check if the text is roughly the same phrase repeated (within half ±5 chars)
+  for (let mid = Math.floor(len / 2) - 5; mid <= Math.ceil(len / 2) + 5; mid++) {
+    if (mid <= 0 || mid >= len) continue;
+    const first = text.slice(0, mid).trim();
+    const second = text.slice(mid).trim();
+    if (first.length > 10 && first === second) return first;
+  }
+  return text;
+}
+
 // ─── Props ─────────────────────────────────────────
 
 export interface ExerciseQuestionnaireSheetProps {
@@ -148,11 +165,15 @@ export function ExerciseQuestionnaireSheet({
       }
 
       const raw = data?.result?.transcription || data?.result?.text || '';
-      const text = raw.replace(/<THINK>[\s\S]*?<\/THINK>\s*/gi, '').trim();
+      const cleaned = raw.replace(/<THINK>[\s\S]*?<\/THINK>\s*/gi, '').trim();
+
+      // Deduplicate if Gemini returned repeated text (e.g. "abc.abc." → "abc.")
+      const text = deduplicateTranscript(cleaned);
 
       if (text) {
         setVoiceTranscript(text);
-        setNotes((prev) => prev ? `${prev}\n${text}` : text);
+        // Replace notes with transcript (not append) to prevent duplication on re-record
+        setNotes(text);
       }
     } catch (err: any) {
       log.error('Transcription error:', err);

--- a/src/modules/flux/views/AthleteDetailView.tsx
+++ b/src/modules/flux/views/AthleteDetailView.tsx
@@ -40,8 +40,11 @@ import {
   DollarSign,
 } from 'lucide-react';
 import { PaymentRuler } from '../components/athlete/PaymentRuler';
+import { FeedbackRadarChart } from '../components/athlete/FeedbackRadarChart';
+import { StressFatigueGauges } from '../components/athlete/StressFatigueGauges';
 import { getPaymentData } from '../services/athleteService';
 import type { AthletePaymentData } from '../services/athleteService';
+import type { QuestionnaireData, FeedbackEntryRow } from '../hooks/useAthleteFeedback';
 
 const AVATAR_COLORS = [
   'bg-rose-500', 'bg-sky-500', 'bg-emerald-500', 'bg-amber-500',
@@ -82,6 +85,8 @@ export default function AthleteDetailView() {
   const [latestParQ, setLatestParQ] = useState<ParQResponse | null>(null);
   const [parqLoading, setParqLoading] = useState(false);
   const [feedbacks, setFeedbacks] = useState<SlotFeedback[]>([]);
+  const [feedbackEntries, setFeedbackEntries] = useState<FeedbackEntryRow[]>([]);
+  const [aggregatedQuestionnaire, setAggregatedQuestionnaire] = useState<QuestionnaireData | null>(null);
   const [activeMicrocycle, setActiveMicrocycle] = useState<{ id: string; status: string; name?: string } | null>(null);
   const [activatingMicrocycle, setActivatingMicrocycle] = useState(false);
   const alerts: Alert[] = [];
@@ -188,7 +193,7 @@ export default function AthleteDetailView() {
     return () => { cancelled = true; };
   }, [athleteId, athlete?.allow_parq_onboarding]);
 
-  // Load recent feedbacks from workout_slots
+  // Load recent feedbacks from workout_slots (legacy)
   useEffect(() => {
     if (!athleteId) return;
     let cancelled = false;
@@ -209,6 +214,59 @@ export default function AthleteDetailView() {
     loadFeedbacks();
     return () => { cancelled = true; };
   }, [athleteId]);
+
+  // Load structured feedback entries + compute aggregated radar (#781)
+  useEffect(() => {
+    if (!activeMicrocycle?.id) return;
+    let cancelled = false;
+
+    const loadFeedbackEntries = async () => {
+      const { data, error } = await supabase
+        .from('athlete_feedback_entries')
+        .select('*')
+        .eq('microcycle_id', activeMicrocycle.id)
+        .order('created_at', { ascending: false });
+
+      if (cancelled || error || !data) return;
+      const rows = data as FeedbackEntryRow[];
+      setFeedbackEntries(rows);
+
+      // Compute aggregated questionnaire averages
+      const KEYS: (keyof QuestionnaireData)[] = [
+        'volume_adequate', 'volume_completed', 'intensity_adequate', 'intensity_completed',
+        'fatigue', 'stress', 'nutrition', 'sleep',
+      ];
+      const withQ = rows.filter((r) => {
+        if (!r.questionnaire) return false;
+        return KEYS.filter((k) => (r.questionnaire as QuestionnaireData)?.[k] != null).length >= 3;
+      });
+      if (withQ.length === 0) { setAggregatedQuestionnaire(null); return; }
+
+      const sums: Record<string, { total: number; count: number }> = {};
+      for (const row of withQ) {
+        for (const key of KEYS) {
+          const val = (row.questionnaire as QuestionnaireData)?.[key];
+          if (val != null) {
+            if (!sums[key]) sums[key] = { total: 0, count: 0 };
+            sums[key].total += val;
+            sums[key].count += 1;
+          }
+        }
+      }
+      const result: QuestionnaireData = {};
+      let populated = 0;
+      for (const key of KEYS) {
+        if (sums[key] && sums[key].count > 0) {
+          (result as Record<string, number>)[key] = Math.round((sums[key].total / sums[key].count) * 10) / 10;
+          populated++;
+        }
+      }
+      setAggregatedQuestionnaire(populated >= 3 ? result : null);
+    };
+
+    loadFeedbackEntries();
+    return () => { cancelled = true; };
+  }, [activeMicrocycle?.id]);
 
   // Load active/draft microcycle for "Liberar Treino" button (#381)
   useEffect(() => {
@@ -1366,11 +1424,95 @@ export default function AthleteDetailView() {
           </h2>
         </div>
 
-        {feedbacks.length > 0 ? (
+        {/* Aggregated Radar Chart + Gauges (#781) */}
+        {aggregatedQuestionnaire && (
+          <div className="ceramic-card p-4 mb-4 space-y-4">
+            <FeedbackRadarChart
+              questionnaire={aggregatedQuestionnaire}
+              size={220}
+              title="Visao Geral"
+              subtitle="Media dos feedbacks do atleta"
+            />
+            <StressFatigueGauges
+              stress={aggregatedQuestionnaire.stress}
+              fatigue={aggregatedQuestionnaire.fatigue}
+            />
+          </div>
+        )}
+
+        {/* Structured feedback entries from athlete_feedback_entries */}
+        {feedbackEntries.length > 0 && (
+          <div className="space-y-3 mb-4">
+            {feedbackEntries.slice(0, 10).map((entry) => (
+              <div key={entry.id} className="ceramic-card p-4 space-y-3">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <Activity className="w-4 h-4 text-ceramic-text-secondary" />
+                    <p className="text-sm font-bold text-ceramic-text-primary">
+                      {entry.feedback_type === 'weekly' ? `Feedback Semanal (Sem ${entry.week_number})` : `Feedback de Exercicio`}
+                    </p>
+                  </div>
+                  <p className="text-xs text-ceramic-text-secondary">
+                    {new Date(entry.created_at).toLocaleDateString('pt-BR', { day: 'numeric', month: 'long' })}
+                  </p>
+                </div>
+
+                {/* Questionnaire summary badges */}
+                {entry.questionnaire && (
+                  <div className="flex flex-wrap gap-2">
+                    {entry.questionnaire.fatigue != null && (
+                      <span className={`text-[10px] font-bold px-2 py-0.5 rounded-lg ${
+                        entry.questionnaire.fatigue >= 4 ? 'bg-red-100 text-red-700' :
+                        entry.questionnaire.fatigue >= 2 ? 'bg-amber-100 text-amber-700' :
+                        'bg-green-100 text-green-700'
+                      }`}>
+                        Cansaco: {entry.questionnaire.fatigue}/5
+                      </span>
+                    )}
+                    {entry.questionnaire.stress != null && (
+                      <span className={`text-[10px] font-bold px-2 py-0.5 rounded-lg ${
+                        entry.questionnaire.stress >= 4 ? 'bg-red-100 text-red-700' :
+                        entry.questionnaire.stress >= 2 ? 'bg-amber-100 text-amber-700' :
+                        'bg-green-100 text-green-700'
+                      }`}>
+                        Stress: {entry.questionnaire.stress}/5
+                      </span>
+                    )}
+                    {entry.questionnaire.sleep != null && (
+                      <span className={`text-[10px] font-bold px-2 py-0.5 rounded-lg ${
+                        entry.questionnaire.sleep >= 3 ? 'bg-green-100 text-green-700' :
+                        'bg-amber-100 text-amber-700'
+                      }`}>
+                        Sono: {entry.questionnaire.sleep}/5
+                      </span>
+                    )}
+                    {entry.questionnaire.nutrition != null && (
+                      <span className={`text-[10px] font-bold px-2 py-0.5 rounded-lg ${
+                        entry.questionnaire.nutrition >= 3 ? 'bg-green-100 text-green-700' :
+                        'bg-amber-100 text-amber-700'
+                      }`}>
+                        Nutricao: {entry.questionnaire.nutrition}/5
+                      </span>
+                    )}
+                  </div>
+                )}
+
+                {/* Notes / Voice transcript */}
+                {(entry.notes || entry.voice_transcript) && (
+                  <p className="text-sm text-ceramic-text-primary font-light italic">
+                    &ldquo;{entry.notes || entry.voice_transcript}&rdquo;
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Legacy feedback from workout_slots (backward compat) */}
+        {feedbackEntries.length === 0 && feedbacks.length > 0 && (
           <div className="space-y-3">
             {feedbacks.map((fb) => (
               <div key={fb.id} className="ceramic-card p-4 space-y-3">
-                {/* Header: slot name + date */}
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-2">
                     <Activity className="w-4 h-4 text-ceramic-text-secondary" />
@@ -1387,13 +1529,9 @@ export default function AthleteDetailView() {
                     </p>
                   )}
                 </div>
-
-                {/* Athlete feedback text */}
                 <p className="text-sm text-ceramic-text-primary font-light">
                   {fb.athlete_feedback}
                 </p>
-
-                {/* RPE if available */}
                 {fb.rpe != null && (
                   <div className="flex items-center gap-2 text-xs pt-2 border-t border-ceramic-text-secondary/10">
                     <span className="text-ceramic-text-secondary">RPE:</span>
@@ -1409,7 +1547,9 @@ export default function AthleteDetailView() {
               </div>
             ))}
           </div>
-        ) : (
+        )}
+
+        {feedbackEntries.length === 0 && feedbacks.length === 0 && (
           <div className="ceramic-inset p-8 text-center">
             <p className="text-sm text-ceramic-text-secondary font-light">
               Nenhum feedback registrado ainda


### PR DESCRIPTION
## Summary
- **#778** Fix voice transcription duplication: replace notes on re-record instead of appending, add `deduplicateTranscript()` to catch Gemini-doubled text
- **#781** Connect athlete feedback backend to coach profile view: query `athlete_feedback_entries`, display `FeedbackRadarChart` + `StressFatigueGauges` + structured feedback cards with questionnaire badges

## Changes
- `ExerciseQuestionnaireSheet.tsx`: `setNotes(text)` replaces append; added dedup helper
- `AthleteDetailView.tsx`: New imports for radar/gauges, new `useEffect` for `athlete_feedback_entries` query, aggregated questionnaire computation, rich feedback section with fallback to legacy `workout_slots`

## Test plan
- [ ] `npm run build` passes
- [ ] `npm run typecheck` passes (no new errors)
- [ ] Voice record in Meu Treino → transcript appears once (not doubled)
- [ ] Re-record → replaces previous transcript (not appends)
- [ ] Coach athlete profile → radar chart + gauges visible when feedback exists
- [ ] Coach athlete profile → feedback cards show fatigue/stress/sleep/nutrition badges

Closes #778, Closes #781

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured feedback dashboard with aggregated metrics visualization, including radar charts and stress/fatigue gauges for athlete performance tracking.
  * Feedback entries now display detailed questionnaire responses (fatigue, stress, sleep, nutrition) with dates and optional notes.

* **Bug Fixes**
  * Fixed issue where voice transcripts would contain duplicate phrases during re-recordings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->