### PR TITLE
feat(flux): default to month summary view + duplicate workout action (#789, #791)

### DIFF
--- a/src/modules/flux/components/canvas/CanvasGridContainer.tsx
+++ b/src/modules/flux/components/canvas/CanvasGridContainer.tsx
@@ -30,6 +30,7 @@ interface CanvasGridContainerProps {
   isLoading: boolean;
   onWorkoutClick: (workoutId: string) => void;
   onWorkoutDelete: (workoutId: string) => void;
+  onWorkoutDuplicate?: (workoutId: string) => void;
   onEmptySlotClick: (dayOfWeek: number, startTime: string) => void;
   onDropWorkout: (dayOfWeek: number, startTime: string, templateData: string) => void;
   onReorderWorkout: (workoutId: string, fromDay: number, toDay: number, toTime: string) => void;
@@ -48,6 +49,7 @@ export const CanvasGridContainer: React.FC<CanvasGridContainerProps> = ({
   isLoading,
   onWorkoutClick,
   onWorkoutDelete,
+  onWorkoutDuplicate,
   onEmptySlotClick,
   onDropWorkout,
   onReorderWorkout,
@@ -100,6 +102,7 @@ export const CanvasGridContainer: React.FC<CanvasGridContainerProps> = ({
                 calendarEvents={busySlots}
                 currentWeek={currentWeek}
                 onWorkoutClick={onWorkoutClick}
+                onWorkoutDuplicate={onWorkoutDuplicate}
                 onDropWorkout={onMicrocycleDropWorkout}
                 onWeekClick={onWeekClick}
                 isLoading={isLoading}

--- a/src/modules/flux/components/canvas/MicrocycleGrid.tsx
+++ b/src/modules/flux/components/canvas/MicrocycleGrid.tsx
@@ -9,7 +9,7 @@
 
 import React, { useMemo } from 'react';
 import { motion } from 'framer-motion';
-import { Eye } from 'lucide-react';
+import { Eye, Copy } from 'lucide-react';
 import {
   springHover,
   staggerContainer,
@@ -51,6 +51,7 @@ interface MicrocycleGridProps {
   calendarEvents?: BusySlot[];
   currentWeek: number; // Which week is "active" (1-4)
   onWorkoutClick?: (workoutId: string) => void;
+  onWorkoutDuplicate?: (workoutId: string) => void;
   onDropWorkout?: (weekNumber: number, dayOfWeek: number, templateData: string) => void;
   onWeekClick?: (weekNumber: number) => void;
   isLoading?: boolean;
@@ -138,25 +139,37 @@ const MiniBusySlot: React.FC<MiniBusySlotProps> = ({ slot }) => {
 interface WorkoutPillProps {
   workout: WeekWorkout;
   onClick?: () => void;
+  onDuplicate?: () => void;
 }
 
-const WorkoutPill: React.FC<WorkoutPillProps> = ({ workout, onClick }) => {
+const WorkoutPill: React.FC<WorkoutPillProps> = ({ workout, onClick, onDuplicate }) => {
   const style = MODALITY_PILL_STYLES[workout.modality];
   const icon = MODALITY_ICONS[workout.modality] || '\u{1F3CB}\u{FE0F}';
 
   return (
-    <motion.button
-      onClick={onClick}
-      className="w-full text-left px-1.5 py-1 rounded-lg text-[9px] font-semibold truncate"
-      whileHover={{ scale: 1.03, transition: springHover }}
-      title={`${workout.name} - ${workout.duration}min`}
-      style={{
-        background: style.bg,
-        color: style.text,
-      }}
-    >
-      {icon} {workout.name} <span className="opacity-70">{workout.duration}&prime;</span>
-    </motion.button>
+    <div className="group/pill relative w-full">
+      <motion.button
+        onClick={onClick}
+        className="w-full text-left px-1.5 py-1 rounded-lg text-[9px] font-semibold truncate"
+        whileHover={{ scale: 1.03, transition: springHover }}
+        title={`${workout.name} - ${workout.duration}min`}
+        style={{
+          background: style.bg,
+          color: style.text,
+        }}
+      >
+        {icon} {workout.name} <span className="opacity-70">{workout.duration}&prime;</span>
+      </motion.button>
+      {onDuplicate && (
+        <button
+          onClick={(e) => { e.stopPropagation(); onDuplicate(); }}
+          className="absolute -top-1 -right-1 w-4 h-4 rounded-full bg-amber-500 text-white flex items-center justify-center opacity-0 group-hover/pill:opacity-100 transition-opacity shadow-sm"
+          title="Duplicar e Editar"
+        >
+          <Copy size={8} />
+        </button>
+      )}
+    </div>
   );
 };
 
@@ -170,6 +183,7 @@ interface MiniDayCellProps {
   busySlots: BusySlot[];
   weekNumber: number;
   onWorkoutClick?: (workoutId: string) => void;
+  onWorkoutDuplicate?: (workoutId: string) => void;
   onDrop?: (templateData: string) => void;
 }
 
@@ -177,6 +191,7 @@ const MiniDayCell: React.FC<MiniDayCellProps> = ({
   workouts,
   busySlots,
   onWorkoutClick,
+  onWorkoutDuplicate,
   onDrop,
 }) => {
   const handleDragOver = (e: React.DragEvent) => {
@@ -220,6 +235,7 @@ const MiniDayCell: React.FC<MiniDayCellProps> = ({
           key={workout.id}
           workout={workout}
           onClick={() => onWorkoutClick?.(workout.id)}
+          onDuplicate={onWorkoutDuplicate ? () => onWorkoutDuplicate(workout.id) : undefined}
         />
       ))}
     </div>
@@ -236,6 +252,7 @@ interface WeekStripProps {
   calendarEvents: BusySlot[];
   isCurrent: boolean;
   onWorkoutClick?: (workoutId: string) => void;
+  onWorkoutDuplicate?: (workoutId: string) => void;
   onDropWorkout?: (dayOfWeek: number, templateData: string) => void;
   onWeekClick?: () => void;
 }
@@ -246,6 +263,7 @@ const WeekStrip: React.FC<WeekStripProps> = ({
   calendarEvents,
   isCurrent,
   onWorkoutClick,
+  onWorkoutDuplicate,
   onDropWorkout,
   onWeekClick,
 }) => {
@@ -336,6 +354,7 @@ const WeekStrip: React.FC<WeekStripProps> = ({
             workouts={workoutsByDay[dayNum]}
             busySlots={eventsByDay[dayNum]}
             onWorkoutClick={onWorkoutClick}
+            onWorkoutDuplicate={onWorkoutDuplicate}
             onDrop={(data) => onDropWorkout?.(dayNum, data)}
           />
         ))}
@@ -354,6 +373,7 @@ export const MicrocycleGrid: React.FC<MicrocycleGridProps> = ({
   calendarEvents = [],
   currentWeek,
   onWorkoutClick,
+  onWorkoutDuplicate,
   onDropWorkout,
   onWeekClick,
   isLoading = false,
@@ -396,6 +416,7 @@ export const MicrocycleGrid: React.FC<MicrocycleGridProps> = ({
             calendarEvents={calendarEvents}
             isCurrent={weekNum === currentWeek}
             onWorkoutClick={onWorkoutClick}
+            onWorkoutDuplicate={onWorkoutDuplicate}
             onDropWorkout={(dayOfWeek, templateData) =>
               onDropWorkout?.(weekNum, dayOfWeek, templateData)
             }

--- a/src/modules/flux/views/CanvasEditorView.tsx
+++ b/src/modules/flux/views/CanvasEditorView.tsx
@@ -191,7 +191,7 @@ export default function CanvasEditorView() {
   const { actions } = useFlux();
 
   // State
-  const [viewMode, setViewMode] = useState<ViewMode>('weekly');
+  const [viewMode, setViewMode] = useState<ViewMode>('microcycle');
   const [currentWeek, setCurrentWeek] = useState(1);
   const [isEditorOpen, setIsEditorOpen] = useState(false);
   const [editingSlotId, setEditingSlotId] = useState<string | null>(null);
@@ -356,6 +356,56 @@ export default function CanvasEditorView() {
       await updateSlot({ id: workoutId, day_of_week: toDay, start_time: toTime });
     },
     [updateSlot]
+  );
+
+  // Duplicate workout + open for editing (#791)
+  const handleDuplicateWorkout = useCallback(
+    async (workoutId: string) => {
+      const slot = slots.find((s) => s.id === workoutId);
+      if (!slot) return;
+      // Create a duplicate slot on the same day/week
+      const newSlot = await createSlot({
+        week_number: slot.week_number,
+        day_of_week: slot.day_of_week,
+        start_time: slot.start_time || '08:00',
+        name: `${slot.name} (copia)`,
+        duration: slot.duration,
+        intensity: slot.intensity,
+        modality: slot.modality,
+        exercise_structure: slot.exercise_structure,
+        coach_notes: slot.coach_notes,
+        ftp_percentage: slot.ftp_percentage,
+        pace_zone: slot.pace_zone,
+        css_percentage: slot.css_percentage,
+        rpe: slot.rpe,
+      });
+      // Open the new slot for editing
+      if (newSlot?.id) {
+        const templateData: WorkoutTemplate = {
+          id: newSlot.template_id || newSlot.id,
+          user_id: newSlot.user_id,
+          name: newSlot.name,
+          description: '',
+          category: 'main',
+          modality: newSlot.modality,
+          duration: newSlot.duration,
+          intensity: newSlot.intensity,
+          exercise_structure: newSlot.exercise_structure,
+          ftp_percentage: newSlot.ftp_percentage,
+          pace_zone: newSlot.pace_zone,
+          css_percentage: newSlot.css_percentage,
+          rpe: newSlot.rpe,
+          coach_notes: newSlot.coach_notes,
+          created_at: '',
+          updated_at: '',
+          usage_count: 0,
+        };
+        setEditingSlotId(newSlot.id);
+        setEditingTemplateData(templateData);
+        setIsEditorOpen(true);
+      }
+    },
+    [slots, createSlot]
   );
 
   const handleWorkoutClick = useCallback(
@@ -586,6 +636,7 @@ export default function CanvasEditorView() {
           isLoading={workoutsLoading}
           onWorkoutClick={handleWorkoutClick}
           onWorkoutDelete={handleDeleteWorkout}
+          onWorkoutDuplicate={handleDuplicateWorkout}
           onEmptySlotClick={handleEmptySlotClick}
           onDropWorkout={handleDropWorkout}
           onReorderWorkout={handleReorderWorkout}


### PR DESCRIPTION
## Summary
- **#789**: Default Canvas view changed from weekly to microcycle (month summary) — coaches see the full training overview first
- **#791**: Added "Duplicate & Edit" action on workout pills in MicrocycleGrid — hover reveals amber copy button, creates a copy and opens editor

## Files Changed
- `CanvasEditorView.tsx` — default viewMode + handleDuplicateWorkout handler
- `MicrocycleGrid.tsx` — WorkoutPill duplicate button + prop threading through WeekStrip/MiniDayCell
- `CanvasGridContainer.tsx` — onWorkoutDuplicate prop passthrough

## Test plan
- [x] `npx vite build` passes
- [ ] Manual: Canvas opens in microcycle (month) view by default
- [ ] Manual: Hovering workout pill shows amber copy icon
- [ ] Manual: Clicking copy creates duplicate and opens editor

Closes #789, #791

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>