### PR TITLE
feat(flux): athlete week scheduling + Google Calendar sync (#796)

### DIFF
--- a/src/modules/flux/components/canvas/CanvasEditorDrawer.tsx
+++ b/src/modules/flux/components/canvas/CanvasEditorDrawer.tsx
@@ -76,9 +76,10 @@ type ViewMode = 'weekly' | 'microcycle';
 interface ViewToggleProps {
   mode: ViewMode;
   onChange: (mode: ViewMode) => void;
+  weeklyDisabled?: boolean;
 }
 
-const ViewToggle: React.FC<ViewToggleProps> = ({ mode, onChange }) => (
+const ViewToggle: React.FC<ViewToggleProps> = ({ mode, onChange, weeklyDisabled }) => (
   <div
     className="flex rounded-[12px] p-1"
     style={{
@@ -87,20 +88,24 @@ const ViewToggle: React.FC<ViewToggleProps> = ({ mode, onChange }) => (
     }}
   >
     <button
-      onClick={() => onChange('weekly')}
+      onClick={() => !weeklyDisabled && onChange('weekly')}
+      disabled={weeklyDisabled}
       className={`flex items-center gap-1.5 px-3 py-1.5 rounded-[10px] text-[10px] font-bold uppercase tracking-wider transition-all ${
-        mode === 'weekly'
+        weeklyDisabled
+          ? 'text-ceramic-text-tertiary/40 cursor-not-allowed'
+          : mode === 'weekly'
           ? 'bg-ceramic-base text-ceramic-text-primary'
           : 'text-ceramic-text-tertiary hover:text-ceramic-text-secondary'
       }`}
       style={
-        mode === 'weekly'
+        mode === 'weekly' && !weeklyDisabled
           ? {
               boxShadow:
                 '2px 2px 6px rgba(163,158,145,0.15), -2px -2px 6px rgba(255,255,255,0.9)',
             }
           : {}
       }
+      title={weeklyDisabled ? 'Atleta ainda nao organizou os horarios na semana' : undefined}
     >
       <List size={11} />
       Semana
@@ -153,6 +158,7 @@ export interface CanvasEditorDrawerProps {
   microcycleStatus?: string;
   onReleaseMicrocycle?: () => void;
   isReleasing?: boolean;
+  athleteHasScheduled?: boolean;
   // Actions
   onBack: () => void;
   onOpenCalculator: () => void;
@@ -171,6 +177,7 @@ export const CanvasEditorDrawer: React.FC<CanvasEditorDrawerProps> = ({
   microcycleStatus,
   onReleaseMicrocycle,
   isReleasing,
+  athleteHasScheduled,
   onBack,
 }) => {
   const hasFinancialPending =
@@ -257,7 +264,7 @@ export const CanvasEditorDrawer: React.FC<CanvasEditorDrawerProps> = ({
 
           {/* Action Buttons */}
           <div className="flex items-center gap-3">
-            <ViewToggle mode={viewMode} onChange={setViewMode} />
+            <ViewToggle mode={viewMode} onChange={setViewMode} weeklyDisabled={athleteHasScheduled === false} />
 
             {/* Liberar Treino / Status Badge */}
             {microcycleStatus === 'draft' && onReleaseMicrocycle && (

--- a/src/modules/flux/views/AthletePortalView.tsx
+++ b/src/modules/flux/views/AthletePortalView.tsx
@@ -19,8 +19,10 @@ import { ProgressTimeline, WorkoutCard, AthleteFeedbackView, ExerciseQuestionnai
 import { WeeklyGrid, type WeekWorkout } from '../components/canvas/WeeklyGrid';
 import type { FeedbackData } from '../components/athlete';
 import { useAuth } from '@/hooks/useAuth';
+import { useGoogleCalendarEvents } from '@/hooks/useGoogleCalendarEvents';
 import { supabase } from '@/services/supabaseClient';
 import { MODALITY_CONFIG } from '../types';
+import type { BusySlot } from '../hooks/useCanvasCalendar';
 import { createNamespacedLogger } from '@/lib/logger';
 import {
   Loader2,
@@ -34,9 +36,11 @@ import {
   MessageSquare,
   CheckCircle,
   FileText,
+  CalendarDays,
   DollarSign,
   Heart,
   Lock,
+  MoveHorizontal,
 } from 'lucide-react';
 
 const log = createNamespacedLogger('AthletePortalView');
@@ -171,6 +175,57 @@ export default function AthletePortalView() {
     canvasStart.setHours(0, 0, 0, 0);
     return canvasStart;
   }, [profile?.active_microcycle?.start_date, selectedWeek, weekStart]);
+
+  const canvasWeekEnd = useMemo(() => {
+    const end = new Date(canvasWeekStart);
+    end.setDate(end.getDate() + 7);
+    return end;
+  }, [canvasWeekStart]);
+
+  // Google Calendar integration (#796)
+  const {
+    events: calendarEvents,
+    isConnected: calendarConnected,
+  } = useGoogleCalendarEvents({
+    autoSync: true,
+    syncInterval: 300,
+    startDate: canvasWeekStart,
+    endDate: canvasWeekEnd,
+  });
+
+  const calendarBusySlots = useMemo<BusySlot[]>(() => {
+    if (!calendarConnected || !calendarEvents.length) return [];
+    return calendarEvents
+      .filter((e) => !e.aicaModule) // exclude AICA events to avoid duplication
+      .filter((e) => {
+        const start = new Date(e.startTime);
+        return start >= canvasWeekStart && start < canvasWeekEnd;
+      })
+      .map((e) => {
+        const jsDay = new Date(e.startTime).getDay();
+        const dayOfWeek = jsDay === 0 ? 7 : jsDay;
+        const fmtTime = (iso: string) => {
+          const d = new Date(iso);
+          return `${d.getHours().toString().padStart(2, '0')}:${d.getMinutes().toString().padStart(2, '0')}`;
+        };
+        return {
+          dayOfWeek,
+          startTime: e.isAllDay ? '00:00' : fmtTime(e.startTime),
+          endTime: e.isAllDay ? '23:59' : fmtTime(e.endTime),
+          title: e.title,
+          source: 'athlete' as const,
+          isAllDay: e.isAllDay,
+        };
+      });
+  }, [calendarEvents, calendarConnected, canvasWeekStart, canvasWeekEnd]);
+
+  // Check if athlete has unscheduled workouts (no time set) (#796)
+  const hasUnscheduledWorkouts = useMemo(() => {
+    const micro = profile?.active_microcycle;
+    if (!micro?.slots?.length) return false;
+    const weekSlots = micro.slots.filter((s) => s.week_number === selectedWeek);
+    return weekSlots.some((s) => !s.time_of_day);
+  }, [profile?.active_microcycle, selectedWeek]);
 
   const canvasWorkouts = useMemo<WeekWorkout[]>(() => {
     const micro = profile?.active_microcycle;
@@ -573,12 +628,36 @@ export default function AthletePortalView() {
           {micro ? (
             viewMode === 'canvas' ? (
               <motion.section className="px-5 flex-1" custom={4} initial="hidden" animate="visible" variants={sectionVariants}>
+                {/* Scheduling prompt (#796) */}
+                {hasUnscheduledWorkouts && (
+                  <div className="flex items-center gap-3 px-4 py-3 mb-3 bg-ceramic-info/10 border border-ceramic-info/20 rounded-xl">
+                    <MoveHorizontal className="w-4 h-4 text-ceramic-info flex-shrink-0" />
+                    <p className="text-xs text-blue-800 leading-relaxed">
+                      <span className="font-bold">Organize seus horarios!</span> Arraste os treinos para os horarios que funcionam melhor para voce.
+                      {!calendarConnected && ' Conecte o Google Calendar para ver seus compromissos.'}
+                    </p>
+                    {!calendarConnected && (
+                      <a
+                        href="/agenda?connect=google"
+                        className="flex-shrink-0 flex items-center gap-1 px-3 py-1.5 bg-ceramic-info text-white rounded-lg text-[10px] font-bold uppercase tracking-wider hover:bg-blue-600 transition-colors"
+                      >
+                        <CalendarDays className="w-3 h-3" />
+                        Conectar
+                      </a>
+                    )}
+                  </div>
+                )}
                 <div className="bg-white rounded-2xl shadow-sm overflow-hidden" style={{ height: 'calc(100vh - 400px)', minHeight: '500px' }}>
-                  <WeeklyGrid weekNumber={selectedWeek} workouts={canvasWorkouts} calendarEvents={[]}
+                  <WeeklyGrid weekNumber={selectedWeek} workouts={canvasWorkouts} calendarEvents={calendarBusySlots}
                     onReorderWorkout={handleCanvasReorder} onWorkoutClick={(id) => handleGridWorkoutClick(id)}
                     startDate={canvasWeekStart} isLoading={false} />
                 </div>
                 <div className="flex items-center gap-4 mt-3 px-1">
+                  {calendarConnected && (
+                    <span className="text-[10px] text-ceramic-text-tertiary flex items-center gap-1">
+                      <CalendarDays className="w-3 h-3" /> Google Calendar sincronizado
+                    </span>
+                  )}
                   <span className="text-[10px] text-ceramic-text-tertiary ml-auto">Arraste treinos para reorganizar</span>
                 </div>
               </motion.section>

--- a/src/modules/flux/views/CanvasEditorView.tsx
+++ b/src/modules/flux/views/CanvasEditorView.tsx
@@ -285,6 +285,12 @@ export default function CanvasEditorView() {
     return map;
   }, [slots]);
 
+  // Check if athlete has scheduled any workout times (#796)
+  const athleteHasScheduled = useMemo(() => {
+    if (slots.length === 0) return false;
+    return slots.some((s) => s.start_time != null && s.start_time !== '');
+  }, [slots]);
+
   // Handlers
   const handleBack = useCallback(() => {
     if (athlete) {
@@ -589,6 +595,7 @@ export default function CanvasEditorView() {
         microcycleStatus={microcycleStatus}
         onReleaseMicrocycle={handleReleaseMicrocycle}
         isReleasing={isReleasing}
+        athleteHasScheduled={athleteHasScheduled}
         onBack={handleBack}
         onOpenCalculator={() => setIsCalculatorOpen(true)}
       />


### PR DESCRIPTION
## Summary
- **Coach side**: Weekly view toggle disabled with tooltip when athlete hasn't set workout times — guides coach to use microcycle view until athlete organizes schedule
- **Athlete side**: Google Calendar events now display as busy slot overlays in canvas/Grade view, helping athletes see conflicts when scheduling workouts
- **Athlete side**: Scheduling prompt banner appears when workouts exist but lack time assignments, with "Connect Google Calendar" CTA if not connected

## Files Changed
- `CanvasEditorDrawer.tsx` — ViewToggle `weeklyDisabled` prop + `athleteHasScheduled` on drawer
- `CanvasEditorView.tsx` — Compute `athleteHasScheduled` from slots, pass to drawer
- `AthletePortalView.tsx` — `useGoogleCalendarEvents` integration, busy slots transform, scheduling prompt banner

## Test plan
- [x] `npx vite build` passes
- [ ] Manual: Coach Canvas weekly toggle disabled when no slots have start_time
- [ ] Manual: Coach Canvas weekly toggle enabled when slots have times
- [ ] Manual: Athlete canvas view shows Google Calendar events as overlays
- [ ] Manual: Athlete sees scheduling prompt when workouts lack times

Closes #796

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Google Calendar sync to display busy time slots in the scheduling interface
  * Added calendar connection status indicator with option to connect
  * Scheduling prompt bar displays unscheduled workouts
  * Weekly view tab availability now responds to athlete scheduling state

<!-- end of auto-generated comment: release notes by coderabbit.ai -->