### PR TITLE
feat(flux): upgrade radar chart to 6 scientific axes + add ACWR gauge (#769)

### DIFF
--- a/src/modules/flux/components/athlete/FeedbackRadarChart.tsx
+++ b/src/modules/flux/components/athlete/FeedbackRadarChart.tsx
@@ -1,15 +1,16 @@
 /**
  * FeedbackRadarChart -- Pure SVG radar/spider chart for feedback questionnaire data.
  *
- * Shows exactly 6 indicators from the athlete questionnaire:
- *   1. Volume adequado
- *   2. Intensidade adequada
- *   3. Cuidado com alimentacao
- *   4. Cumpriu com volume
- *   5. Cumpriu com intensidade
- *   6. Qualidade do sono
+ * Shows exactly 6 scientific training indicators:
+ *   1. Volume      (volume_adequate — coach prescription vs perception)
+ *   2. Intensidade (intensity_adequate — coach prescription vs perception)
+ *   3. Aderencia   (average of volume_completed + intensity_completed)
+ *   4. Carga sRPE  (session RPE derived from stress, scaled 0-5)
+ *   5. Recuperacao  (Hooper-inspired: avg of sleep + inverted fatigue)
+ *   6. Alimentacao (nutrition)
  *
- * Stress and fatigue are displayed as separate gauges (StressFatigueGauges).
+ * Stress and fatigue feed into derived axes (sRPE and Recovery).
+ * Raw stress/fatigue + ACWR are displayed as separate gauges (StressFatigueGauges).
  *
  * Reference implementation: EntityStatRadar.tsx (Life RPG module)
  */
@@ -71,36 +72,58 @@ interface RadarDimension {
 const MAX_VALUE = 5;
 
 /**
- * Derive exactly 6 radar dimensions from the raw questionnaire fields.
- * Returns null if fewer than 3 fields are populated (not enough data to render).
+ * Derive exactly 6 scientific radar dimensions from the raw questionnaire fields.
+ * Returns null if fewer than 3 source fields are populated (not enough data to render).
  *
- * The 6 indicators are:
- *   1. Volume adequado   (volume_adequate)
- *   2. Intensidade adequada (intensity_adequate)
- *   3. Cuidado com alimentacao (nutrition)
- *   4. Cumpriu com volume (volume_completed)
- *   5. Cumpriu com intensidade (intensity_completed)
- *   6. Qualidade do sono  (sleep)
+ * The 6 scientific axes (#769):
+ *   1. Volume        — volume_adequate (prescription perception)
+ *   2. Intensidade   — intensity_adequate (prescription perception)
+ *   3. Aderencia     — avg(volume_completed, intensity_completed) (compliance)
+ *   4. Carga (sRPE)  — stress field as session RPE proxy, scaled 0-5
+ *   5. Recuperacao   — Hooper-inspired: avg(sleep, 5-fatigue)
+ *   6. Alimentacao   — nutrition
  */
 function extractDimensions(q: QuestionnaireData): RadarDimension[] | null {
-  const dims: { label: string; raw: number | undefined }[] = [
-    { label: 'Volume adequado', raw: q.volume_adequate },
-    { label: 'Intensidade adequada', raw: q.intensity_adequate },
-    { label: 'Alimentacao', raw: q.nutrition },
-    { label: 'Cumpriu volume', raw: q.volume_completed },
-    { label: 'Cumpriu intensidade', raw: q.intensity_completed },
-    { label: 'Qualidade do sono', raw: q.sleep },
+  // Count raw source fields that have data
+  const sources = [
+    q.volume_adequate,
+    q.intensity_adequate,
+    q.volume_completed,
+    q.intensity_completed,
+    q.stress,
+    q.sleep,
+    q.fatigue,
+    q.nutrition,
   ];
+  const populated = sources.filter((v) => v != null).length;
+  if (populated < 3) return null;
 
-  // Need at least 3 populated dimensions
-  const populated = dims.filter((d) => d.raw != null);
-  if (populated.length < 3) return null;
+  // Derived: Aderencia = average of compliance metrics
+  const adherence =
+    q.volume_completed != null && q.intensity_completed != null
+      ? (q.volume_completed + q.intensity_completed) / 2
+      : q.volume_completed ?? q.intensity_completed ?? 0;
 
-  // Fill missing with 0 so the polygon still closes
-  return dims.map((d) => ({
-    label: d.label,
-    value: d.raw ?? 0,
-  }));
+  // Derived: Carga (sRPE proxy) — stress 0-5 mapped directly
+  const load = q.stress ?? 0;
+
+  // Derived: Recuperacao (Hooper-inspired) — avg(sleep, inverted fatigue)
+  // Higher = better recovery. Fatigue inverted: 5 - fatigue.
+  const sleepVal = q.sleep ?? 0;
+  const invertedFatigue = q.fatigue != null ? MAX_VALUE - q.fatigue : 0;
+  const recovery =
+    q.sleep != null || q.fatigue != null
+      ? (sleepVal + invertedFatigue) / (q.sleep != null && q.fatigue != null ? 2 : 1)
+      : 0;
+
+  return [
+    { label: 'Volume', value: q.volume_adequate ?? 0 },
+    { label: 'Intensidade', value: q.intensity_adequate ?? 0 },
+    { label: 'Aderencia', value: adherence },
+    { label: 'Carga (sRPE)', value: load },
+    { label: 'Recuperacao', value: recovery },
+    { label: 'Alimentacao', value: q.nutrition ?? 0 },
+  ];
 }
 
 // ---- Component ----

--- a/src/modules/flux/components/athlete/StressFatigueGauges.tsx
+++ b/src/modules/flux/components/athlete/StressFatigueGauges.tsx
@@ -1,16 +1,21 @@
 /**
- * StressFatigueGauges -- Horizontal bar gauges for stress and fatigue levels.
+ * StressFatigueGauges -- Horizontal bar gauges for stress, fatigue, and ACWR.
  *
- * Displays two separate indicators alongside the radar chart:
- *   1. Nivel de stress
- *   2. Nivel de cansaco (fatigue)
+ * Displays indicators alongside the radar chart:
+ *   1. Nivel de stress   (0-5 scale)
+ *   2. Nivel de cansaco  (0-5 scale, fatigue)
+ *   3. ACWR              (Acute:Chronic Workload Ratio, 0-2 scale, optional)
  *
- * Color gradient:
+ * Stress/Fatigue color gradient:
  *   Low (0-33%):    green  (ceramic-success / green-400)
  *   Medium (34-66%): yellow (ceramic-warning / amber-400)
  *   High (67-100%):  red   (ceramic-error / red-400)
  *
- * Values are on a 0-5 scale (matching the questionnaire).
+ * ACWR zones (#769):
+ *   < 0.8:        Undertrained (amber)
+ *   0.8 - 1.3:    Sweet spot   (green)
+ *   1.3 - 1.5:    Caution      (amber)
+ *   > 1.5:        Danger       (red)
  */
 
 import React from 'react';
@@ -72,21 +77,108 @@ function Gauge({ label, value, maxValue = MAX }: GaugeProps) {
   );
 }
 
+// ---- ACWR Gauge (injury risk zones) ----
+
+interface ACWRGaugeProps {
+  value: number | undefined;
+}
+
+function getACWRColor(value: number): string {
+  if (value < 0.8) return 'bg-amber-400';
+  if (value <= 1.3) return 'bg-green-400';
+  if (value <= 1.5) return 'bg-amber-400';
+  return 'bg-red-400';
+}
+
+function getACWRLabel(value: number): string {
+  if (value < 0.8) return 'Subtreino';
+  if (value <= 1.3) return 'Ideal';
+  if (value <= 1.5) return 'Atencao';
+  return 'Risco';
+}
+
+function getACWRTextColor(value: number): string {
+  if (value < 0.8) return 'text-amber-600';
+  if (value <= 1.3) return 'text-green-600';
+  if (value <= 1.5) return 'text-amber-600';
+  return 'text-red-600';
+}
+
+function ACWRGauge({ value }: ACWRGaugeProps) {
+  if (value == null) return null;
+
+  const maxACWR = 2;
+  const pct = Math.min(Math.max((value / maxACWR) * 100, 0), 100);
+  const barColor = getACWRColor(value);
+  const label = getACWRLabel(value);
+  const textColor = getACWRTextColor(value);
+
+  // Zone markers as percentages of bar width (maxACWR = 2)
+  const zone08 = (0.8 / maxACWR) * 100;
+  const zone13 = (1.3 / maxACWR) * 100;
+  const zone15 = (1.5 / maxACWR) * 100;
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between">
+        <span className="text-[11px] font-bold text-ceramic-text-primary">ACWR</span>
+        <span className={`text-[10px] font-bold ${textColor}`}>
+          {value.toFixed(2)} — {label}
+        </span>
+      </div>
+      <div className="relative h-2 bg-ceramic-cool rounded-full overflow-hidden">
+        <div
+          className={`h-full rounded-full transition-all duration-500 ${barColor}`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      {/* Zone markers */}
+      <div className="relative h-1">
+        <div
+          className="absolute top-0 w-px h-2 bg-ceramic-text-secondary/40"
+          style={{ left: `${zone08}%` }}
+        />
+        <div
+          className="absolute top-0 w-px h-2 bg-ceramic-text-secondary/40"
+          style={{ left: `${zone13}%` }}
+        />
+        <div
+          className="absolute top-0 w-px h-2 bg-ceramic-text-secondary/40"
+          style={{ left: `${zone15}%` }}
+        />
+      </div>
+      <div className="flex justify-between">
+        <span className="text-[9px] text-ceramic-text-secondary">0</span>
+        <span className="text-[9px] text-amber-500">0.8</span>
+        <span className="text-[9px] text-green-500">1.3</span>
+        <span className="text-[9px] text-amber-500">1.5</span>
+        <span className="text-[9px] text-ceramic-text-secondary">2.0</span>
+      </div>
+    </div>
+  );
+}
+
+// ---- Main Component ----
+
 export interface StressFatigueGaugesProps {
   stress: number | undefined;
   fatigue: number | undefined;
+  /** Acute:Chronic Workload Ratio from fatigueModeling. Optional. */
+  acwr?: number;
 }
 
 export const StressFatigueGauges: React.FC<StressFatigueGaugesProps> = ({
   stress,
   fatigue,
+  acwr,
 }) => {
-  if (stress == null && fatigue == null) return null;
+  if (stress == null && fatigue == null && acwr == null) return null;
 
   return (
     <div className="space-y-3">
       <Gauge label="Nivel de stress" value={stress} />
       <Gauge label="Nivel de cansaco" value={fatigue} />
+      <ACWRGauge value={acwr} />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- **FeedbackRadarChart**: Updated `extractDimensions()` to map to 6 scientific training axes: Volume, Intensidade, Aderencia (compliance avg), Carga sRPE (stress proxy), Recuperacao (Hooper-inspired: sleep + inverted fatigue), Alimentacao
- **StressFatigueGauges**: Added optional `acwr` prop with ACWR gauge showing injury risk zones — green (0.8-1.3 sweet spot), amber (<0.8 undertrained / 1.3-1.5 caution), red (>1.5 danger)

Closes #769

## Test plan
- [x] `npm run build` passes
- [x] No new type errors in modified files
- [ ] Manual testing on dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ACWR gauge visualization alongside stress and fatigue metrics.
  * Updated training performance radar with six scientific training axes: Volume, Intensity, Adherence, Load (sRPE), Recovery, and Nutrition.

* **Improvements**
  * Relaxed data validation requirements for metrics display (now requires minimum 3 data sources).
  * Enhanced recovery calculations with integrated sleep and fatigue data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->