### PR TITLE
fix(flux): reorganize athlete portal layout + remove coach grid

### DIFF
--- a/src/modules/flux/components/coach/AdminDashboardSection.tsx
+++ b/src/modules/flux/components/coach/AdminDashboardSection.tsx
@@ -8,8 +8,7 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Users, AlertTriangle, DollarSign, MessageSquare, BookOpen, Dumbbell } from 'lucide-react';
-import type { Athlete, TrainingModality, AthleteLevel } from '../../types/flux';
-import { MODALITY_CONFIG, LEVEL_LABELS } from '../../types/flux';
+import type { Athlete } from '../../types/flux';
 
 interface AdminDashboardSectionProps {
   athletes: Athlete[];
@@ -64,22 +63,6 @@ export function AdminDashboardSection({ athletes, templateCount }: AdminDashboar
       filterKey: 'no_block',
     },
   ];
-
-  // --- Modality groups ---
-  const modalityCounts = activeAthletes.reduce<Record<TrainingModality, number>>((acc, a) => {
-    const mod = a.modality || 'strength';
-    acc[mod] = (acc[mod] || 0) + 1;
-    return acc;
-  }, {} as Record<TrainingModality, number>);
-
-  const totalActive = activeAthletes.length || 1; // avoid divide by zero
-
-  // --- Level groups ---
-  const levelCounts = activeAthletes.reduce<Record<AthleteLevel, number>>((acc, a) => {
-    const lvl = a.level || 'iniciante';
-    acc[lvl] = (acc[lvl] || 0) + 1;
-    return acc;
-  }, {} as Record<AthleteLevel, number>);
 
   if (athletes.length === 0) {
     return null;
@@ -154,86 +137,6 @@ export function AdminDashboardSection({ athletes, templateCount }: AdminDashboar
         </div>
       </div>
 
-      {/* Modality + Level side by side */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        {/* By modality */}
-        <div className="bg-ceramic-50 rounded-xl p-6 shadow-ceramic-emboss">
-          <h3 className="text-sm font-bold text-ceramic-text-secondary uppercase tracking-wider mb-4">
-            Por Modalidade
-          </h3>
-          <div className="space-y-3">
-            {(Object.keys(MODALITY_CONFIG) as TrainingModality[]).map((mod) => {
-              const count = modalityCounts[mod] || 0;
-              if (count === 0) return null;
-              const pct = Math.round((count / totalActive) * 100);
-              const config = MODALITY_CONFIG[mod];
-              return (
-                <button
-                  key={mod}
-                  onClick={() => navigate(`/flux/crm?modality=${mod}`)}
-                  className="flex items-center gap-3 w-full text-left hover:bg-white/50 rounded-lg p-1 -m-1 transition-colors cursor-pointer"
-                >
-                  <span className="text-lg">{config.icon}</span>
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center justify-between mb-1">
-                      <span className="text-sm font-medium text-ceramic-text-primary">{config.label}</span>
-                      <span className="text-xs text-ceramic-text-secondary">{count} ({pct}%)</span>
-                    </div>
-                    <div className="w-full h-2 bg-ceramic-border/30 rounded-full overflow-hidden">
-                      <div
-                        className="h-full bg-ceramic-info rounded-full transition-all"
-                        style={{ width: `${pct}%` }}
-                      />
-                    </div>
-                  </div>
-                </button>
-              );
-            })}
-            {Object.values(modalityCounts).every((c) => c === 0) && (
-              <p className="text-sm text-ceramic-text-secondary">Nenhum atleta ativo</p>
-            )}
-          </div>
-        </div>
-
-        {/* By level */}
-        <div className="bg-ceramic-50 rounded-xl p-6 shadow-ceramic-emboss">
-          <h3 className="text-sm font-bold text-ceramic-text-secondary uppercase tracking-wider mb-4">
-            Por Nivel
-          </h3>
-          <div className="space-y-3">
-            {(Object.keys(LEVEL_LABELS) as AthleteLevel[]).map((lvl) => {
-              const count = levelCounts[lvl] || 0;
-              const pct = Math.round((count / totalActive) * 100);
-              const colorMap: Record<AthleteLevel, string> = {
-                iniciante: 'bg-ceramic-success',
-                intermediario: 'bg-ceramic-warning',
-                avancado: 'bg-ceramic-error',
-              };
-              return (
-                <button
-                  key={lvl}
-                  onClick={() => navigate(`/flux/crm?level=${lvl}`)}
-                  className="flex items-center gap-3 w-full text-left hover:bg-white/50 rounded-lg p-1 -m-1 transition-colors cursor-pointer"
-                >
-                  <div className={`w-3 h-3 rounded-full ${colorMap[lvl]}`} />
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center justify-between mb-1">
-                      <span className="text-sm font-medium text-ceramic-text-primary">{LEVEL_LABELS[lvl]}</span>
-                      <span className="text-xs text-ceramic-text-secondary">{count} ({pct}%)</span>
-                    </div>
-                    <div className="w-full h-2 bg-ceramic-border/30 rounded-full overflow-hidden">
-                      <div
-                        className={`h-full ${colorMap[lvl]} rounded-full transition-all`}
-                        style={{ width: `${pct}%` }}
-                      />
-                    </div>
-                  </div>
-                </button>
-              );
-            })}
-          </div>
-        </div>
-      </div>
     </div>
   );
 }

--- a/src/modules/flux/views/AthletePortalView.tsx
+++ b/src/modules/flux/views/AthletePortalView.tsx
@@ -466,16 +466,6 @@ export default function AthletePortalView() {
             <ArrowLeft className="w-4 h-4" />
             <span className="text-xs font-bold uppercase tracking-wider">Meu Treino</span>
           </button>
-          {activeTab === 'treinos' && (
-            <div className="flex items-center gap-1 p-1 rounded-xl bg-ceramic-cool shadow-sm border border-ceramic-border/40">
-              <button onClick={() => handleViewModeChange('list')} className={`flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-bold transition-all ${viewMode === 'list' ? 'bg-white text-ceramic-text-primary shadow-md' : 'text-ceramic-text-secondary hover:text-ceramic-text-primary hover:bg-white/50'}`}>
-                <List className="w-4 h-4" />Lista
-              </button>
-              <button onClick={() => handleViewModeChange('canvas')} className={`flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-bold transition-all ${viewMode === 'canvas' ? 'bg-white text-ceramic-text-primary shadow-md' : 'text-ceramic-text-secondary hover:text-ceramic-text-primary hover:bg-white/50'}`}>
-                <LayoutGrid className="w-4 h-4" />Grade
-              </button>
-            </div>
-          )}
         </div>
       </header>
 
@@ -531,6 +521,21 @@ export default function AthletePortalView() {
             </div>
           </div>
 
+          {/* Microcycle Status Badge — inside profile card */}
+          {micro && micro.status === 'draft' && (
+            <div className="flex items-center gap-2 px-3 py-2 bg-amber-500/10 border border-amber-500/20 rounded-xl">
+              <Clock className="w-4 h-4 text-amber-600 flex-shrink-0" />
+              <span className="text-sm font-bold text-amber-700">Treino Pendente</span>
+              <span className="text-xs text-amber-600">Aguardando liberacao do coach</span>
+            </div>
+          )}
+          {micro && micro.status === 'active' && (
+            <div className="flex items-center gap-2 px-3 py-2 bg-ceramic-success/10 border border-ceramic-success/20 rounded-xl">
+              <CheckCircle className="w-4 h-4 text-ceramic-success flex-shrink-0" />
+              <span className="text-sm font-bold text-ceramic-success">Treino Liberado</span>
+            </div>
+          )}
+
         </div>
       </motion.section>
 
@@ -539,25 +544,6 @@ export default function AthletePortalView() {
         <motion.section className="px-5 mb-4" custom={1} initial="hidden" animate="visible" variants={sectionVariants}>
           <ProgressTimeline weeks={weeks} currentWeek={micro.current_week || 1} microcycleName={micro.name} status={micro.status} selectedWeek={selectedWeek} onWeekSelect={setSelectedWeek} />
         </motion.section>
-      )}
-
-      {/* Microcycle Status Badge — #381: PENDENTE / LIBERADO */}
-      {micro && micro.status === 'draft' && (
-        <motion.div className="px-5 mb-3" custom={1.5} initial="hidden" animate="visible" variants={sectionVariants}>
-          <div className="flex items-center gap-2 px-3 py-2 bg-amber-500/10 border border-amber-500/20 rounded-xl">
-            <Clock className="w-4 h-4 text-amber-600 flex-shrink-0" />
-            <span className="text-sm font-bold text-amber-700">Treino Pendente</span>
-            <span className="text-xs text-amber-600">Aguardando liberacao do coach</span>
-          </div>
-        </motion.div>
-      )}
-      {micro && micro.status === 'active' && (
-        <motion.div className="px-5 mb-3" custom={1.5} initial="hidden" animate="visible" variants={sectionVariants}>
-          <div className="flex items-center gap-2 px-3 py-2 bg-ceramic-success/10 border border-ceramic-success/20 rounded-xl">
-            <CheckCircle className="w-4 h-4 text-ceramic-success flex-shrink-0" />
-            <span className="text-sm font-bold text-ceramic-success">Treino Liberado</span>
-          </div>
-        </motion.div>
       )}
 
       {/* Document Pending Banner — #381 */}
@@ -616,6 +602,18 @@ export default function AthletePortalView() {
 
       {activeTab === 'treinos' ? (
         <>
+          {/* Lista / Grade sub-toggle inside Treinos tab */}
+          <div className="px-5 mb-3">
+            <div className="flex items-center gap-1 p-1 rounded-xl bg-ceramic-cool/40 w-fit">
+              <button onClick={() => handleViewModeChange('list')} className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-bold transition-all ${viewMode === 'list' ? 'bg-white text-ceramic-text-primary shadow-sm' : 'text-ceramic-text-secondary hover:text-ceramic-text-primary hover:bg-white/50'}`}>
+                <List className="w-3.5 h-3.5" />Lista
+              </button>
+              <button onClick={() => handleViewModeChange('canvas')} className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-bold transition-all ${viewMode === 'canvas' ? 'bg-white text-ceramic-text-primary shadow-sm' : 'text-ceramic-text-secondary hover:text-ceramic-text-primary hover:bg-white/50'}`}>
+                <LayoutGrid className="w-3.5 h-3.5" />Grade
+              </button>
+            </div>
+          </div>
+
           {micro?.status === 'draft' && (
             <motion.div className="px-5 mb-4" custom={3} initial="hidden" animate="visible" variants={sectionVariants}>
               <div className="bg-amber-500/10 border border-amber-500/20 rounded-xl p-3 flex items-start gap-3">


### PR DESCRIPTION
## Summary
- Move "Treino Liberado/Pendente" badge inside the profile card (was standalone section)
- Move Lista/Grade view toggle from header into Treinos tab as inline sub-toggle
- Remove "Por Modalidade + Por Nivel" grid from coach admin dashboard

## Test plan
- [x] `npm run build` passes
- [ ] Manual testing on dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>