### PR TITLE
fix(flux): WCAG a11y, trend computation, cleanup from PR #823 audit

### DIFF
--- a/src/modules/flux/components/FatigueRiskBadge.tsx
+++ b/src/modules/flux/components/FatigueRiskBadge.tsx
@@ -32,8 +32,8 @@ const BADGE_CONFIG: Record<FatigueRisk, { bg: string; text: string; label: strin
     label: 'Alto',
   },
   overtraining: {
-    bg: 'bg-ceramic-error-bg',
-    text: 'text-ceramic-error',
+    bg: 'bg-red-900/15',
+    text: 'text-red-900',
     label: 'Overtraining',
   },
 };
@@ -58,7 +58,7 @@ export const FatigueRiskBadge: React.FC<FatigueRiskBadgeProps> = ({
           fatigueRisk === 'low' ? 'bg-ceramic-success' :
           fatigueRisk === 'moderate' ? 'bg-ceramic-warning' :
           fatigueRisk === 'high' ? 'bg-ceramic-error' :
-          'bg-ceramic-error'
+          'bg-red-900'
         }`}
       />
       {config.label}

--- a/src/modules/flux/components/MicrocycleProgressBar.tsx
+++ b/src/modules/flux/components/MicrocycleProgressBar.tsx
@@ -65,7 +65,14 @@ export function MicrocycleProgressBar({
         </div>
 
         {/* Progress Bar */}
-        <div className="relative h-3 bg-ceramic-cool/30 rounded-full overflow-hidden">
+        <div
+          className="relative h-3 bg-ceramic-cool/30 rounded-full overflow-hidden"
+          role="progressbar"
+          aria-valuenow={safeCompletionPercentage}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={`Progresso geral do microciclo: ${safeCompletionPercentage}%`}
+        >
           <div
             className={`absolute inset-y-0 left-0 ${getProgressColor(
               safeCompletionPercentage

--- a/src/modules/flux/components/ProgressionBar.tsx
+++ b/src/modules/flux/components/ProgressionBar.tsx
@@ -64,7 +64,14 @@ export function ProgressionBar({
 
       {/* Progress Bar */}
       <div className="space-y-2">
-        <div className="relative h-3 bg-ceramic-text-secondary/10 rounded-full overflow-hidden">
+        <div
+          className="relative h-3 bg-ceramic-text-secondary/10 rounded-full overflow-hidden"
+          role="progressbar"
+          aria-valuenow={progressPercentage}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={`Progresso do ciclo: semana ${currentWeek} de ${totalWeeks} (${progressPercentage}%)`}
+        >
           {/* Background gradient */}
           <div
             className="absolute inset-y-0 left-0 bg-gradient-to-r from-ceramic-info to-ceramic-accent rounded-full transition-all duration-500"

--- a/src/modules/flux/components/ReadinessGauge.tsx
+++ b/src/modules/flux/components/ReadinessGauge.tsx
@@ -19,7 +19,7 @@ const RISK_COLORS: Record<FatigueRisk, { stroke: string; text: string; bg: strin
   low: { stroke: '#6B7B5C', text: 'text-ceramic-success', bg: 'bg-ceramic-success-bg' },
   moderate: { stroke: '#C4883A', text: 'text-ceramic-warning', bg: 'bg-ceramic-warning-bg' },
   high: { stroke: '#9B4D3A', text: 'text-ceramic-error', bg: 'bg-ceramic-error-bg' },
-  overtraining: { stroke: '#9B4D3A', text: 'text-ceramic-error', bg: 'bg-ceramic-error-bg' },
+  overtraining: { stroke: '#7F1D1D', text: 'text-red-900', bg: 'bg-red-900/15' },
 };
 
 const RISK_LABELS: Record<FatigueRisk, string> = {
@@ -60,6 +60,8 @@ export const ReadinessGauge: React.FC<ReadinessGaugeProps> = ({ readiness, class
             width={GAUGE_SIZE}
             height={GAUGE_SIZE}
             viewBox={`0 0 ${GAUGE_SIZE} ${GAUGE_SIZE}`}
+            role="img"
+            aria-label={`Readiness score: ${readinessScore}%`}
           >
             {/* Background circle */}
             <circle

--- a/src/modules/flux/components/athlete/ExerciseQuestionnaireSheet.tsx
+++ b/src/modules/flux/components/athlete/ExerciseQuestionnaireSheet.tsx
@@ -175,7 +175,7 @@ export function ExerciseQuestionnaireSheet({
         // Replace notes with transcript (not append) to prevent duplication on re-record
         setNotes(text);
       }
-    } catch (err: any) {
+    } catch (err) {
       log.error('Transcription error:', err);
       setError('Erro na transcricao. Use o campo de texto.');
     } finally {

--- a/src/modules/flux/components/canvas/WorkoutBlockEditor.tsx
+++ b/src/modules/flux/components/canvas/WorkoutBlockEditor.tsx
@@ -12,6 +12,9 @@ import { X, Save, Activity, Target, MessageSquare, Loader2, CheckCircle, Externa
 import { useNavigate } from 'react-router-dom';
 import type { WorkoutBlockData } from './WorkoutBlock';
 import type { WorkoutIntensity } from '../../types';
+import { createNamespacedLogger } from '@/lib/logger';
+
+const log = createNamespacedLogger('WorkoutBlockEditor');
 
 interface WorkoutBlockEditorProps {
   workout: WorkoutBlockData | null;
@@ -61,7 +64,7 @@ export const WorkoutBlockEditor: React.FC<WorkoutBlockEditorProps> = ({
         setSaveStatus('idle');
       }, 600);
     } catch (err) {
-      console.error('Error saving workout:', err);
+      log.error('Error saving workout:', err);
       setSaveStatus('error');
       errorTimerRef.current = setTimeout(() => setSaveStatus('idle'), 3000);
     } finally {

--- a/src/modules/flux/services/fluxScoring.ts
+++ b/src/modules/flux/services/fluxScoring.ts
@@ -80,18 +80,36 @@ async function computeFluxDomainScoreProvider(): Promise<DomainScore | null> {
     // Compute normalized score (0-1)
     const normalized = computeFluxDomainScore(avgReadiness, trainingConsistency, loadManagement);
 
-    // Determine trend by comparing current readiness against previous period
+    // Determine trend using snapshot heuristic.
+    // NOTE: This is a simplified heuristic comparing avgReadiness against absolute
+    // thresholds rather than a true temporal comparison (current vs previous period).
+    // A proper implementation would fetch readiness history from e.g. the last 7 vs
+    // prior 7 days and compare the means. Acceptable for MVP — revisit when
+    // life_score_history has enough Flux data points for temporal analysis.
     let trend: ScoreTrend = 'stable';
     if (readinessScores.length >= 2) {
-      // Use ACWR trend as a proxy: if most athletes have ACWR in sweet spot and improving, trend is improving
-      const avgAcwr = acwrValues.length > 0
+      // Only factor ACWR into trend when we actually have ACWR data;
+      // otherwise skip ACWR contribution to avoid the 1.0 default
+      // making trend appear "improving" with zero training data.
+      const hasAcwrData = acwrValues.length > 0;
+      const avgAcwr = hasAcwrData
         ? acwrValues.reduce((sum, v) => sum + v, 0) / acwrValues.length
-        : 1.0;
-      // Athletes with higher readiness + ACWR in sweet spot = improving
-      if (avgReadiness > 65 && avgAcwr >= 0.8 && avgAcwr <= 1.3) {
-        trend = 'improving';
-      } else if (avgReadiness < 40 || avgAcwr > 1.5) {
-        trend = 'declining';
+        : undefined;
+
+      if (hasAcwrData && avgAcwr !== undefined) {
+        // Athletes with higher readiness + ACWR in sweet spot = improving
+        if (avgReadiness > 65 && avgAcwr >= 0.8 && avgAcwr <= 1.3) {
+          trend = 'improving';
+        } else if (avgReadiness < 40 || avgAcwr > 1.5) {
+          trend = 'declining';
+        }
+      } else {
+        // No ACWR data — use readiness alone
+        if (avgReadiness > 65) {
+          trend = 'improving';
+        } else if (avgReadiness < 40) {
+          trend = 'declining';
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- Add ARIA attributes to ReadinessGauge SVG (`role="img"`, `aria-label`)
- Add `role="progressbar"` + `aria-valuenow/min/max` to MicrocycleProgressBar and ProgressionBar
- Differentiate FatigueRiskBadge "overtraining" (red-900) from "high" (ceramic-error) visually
- Fix ACWR default 1.0 misleading trend: skip ACWR when no data exists
- Replace `console.error` with namespaced logger in WorkoutBlockEditor
- Remove `catch (err: any)` type annotation in ExerciseQuestionnaireSheet

## Changed files
- `src/modules/flux/components/ReadinessGauge.tsx` — SVG ARIA
- `src/modules/flux/components/MicrocycleProgressBar.tsx` — progressbar ARIA
- `src/modules/flux/components/ProgressionBar.tsx` — progressbar ARIA
- `src/modules/flux/components/FatigueRiskBadge.tsx` — visual distinction
- `src/modules/flux/services/fluxScoring.ts` — trend computation fix
- `src/modules/flux/components/canvas/WorkoutBlockEditor.tsx` — logger
- `src/modules/flux/components/athlete/ExerciseQuestionnaireSheet.tsx` — cleanup

## Test plan
- [x] `npm run build` passes
- [x] `npm run typecheck` passes (no new errors)
- [ ] Screen reader testing for ARIA attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>