### PR TITLE
fix(finance): Wave 4 production readiness — Financas module

### DIFF
--- a/src/modules/finance/components/StatementUpload.tsx
+++ b/src/modules/finance/components/StatementUpload.tsx
@@ -602,7 +602,7 @@ export const StatementUpload: React.FC<StatementUploadProps> = ({
             );
             continue;
           } catch (err) {
-            console.error('CSV parse error:', err);
+            log.error('CSV parse error:', err);
             onError?.(`${fileWithMeta.file.name}: Erro ao processar CSV`);
             continue;
           }

--- a/src/modules/finance/services/financeDigestService.ts
+++ b/src/modules/finance/services/financeDigestService.ts
@@ -87,7 +87,7 @@ export async function getMonthlyDigest(
           detail = body?.error || detail
           log.error('Edge Function error detail:', body)
         }
-      } catch { /* ignore parse errors */ }
+      } catch (parseErr) { log.warn('Failed to parse Edge Function error context:', parseErr) }
       log.error('Edge Function invocation error:', detail)
       return {
         success: false,

--- a/src/modules/finance/services/financialHealthScoring.ts
+++ b/src/modules/finance/services/financialHealthScoring.ts
@@ -457,8 +457,8 @@ export async function storeFinancialHealth(
         borrow: result.finHealth.borrow,
         plan: result.finHealth.plan,
       },
-    }).catch(() => {
-      // Non-critical
+    }).catch((err) => {
+      log.warn('logAttribution failed (non-critical):', err);
     });
   } catch (err) {
     log.error('storeFinancialHealth failed:', err);

--- a/src/modules/finance/services/pdfProcessingService.ts
+++ b/src/modules/finance/services/pdfProcessingService.ts
@@ -219,7 +219,8 @@ export class PDFProcessingService {
     }
 
     const result = cleaned.join('\n')
-    log.debug(`[PDFProcessingService] Text preprocessed: ${rawText.length} → ${result.length} chars (${Math.round((1 - result.length / rawText.length) * 100)}% reduction)`)
+    const reductionPct = rawText.length > 0 ? Math.round((1 - result.length / rawText.length) * 100) : 0
+    log.debug(`[PDFProcessingService] Text preprocessed: ${rawText.length} → ${result.length} chars (${reductionPct}% reduction)`)
     return result
   }
 
@@ -352,7 +353,8 @@ export class PDFProcessingService {
               })),
             })
 
-            const categories = (catResult as any)?.categories
+            const catResultRecord = catResult as Record<string, unknown> | undefined
+            const categories = catResultRecord?.categories as string[] | undefined
             if (Array.isArray(categories) && categories.length === poorlyClassified.length) {
               // Build a map of description+amount → new category for lookup
               let improved = 0


### PR DESCRIPTION
## Summary
- Replace `as any` with typed `Record<string, unknown>` cast in pdfProcessingService
- Replace silent `.catch()` and catch blocks with logged warnings (financialHealthScoring, financeDigestService)
- Replace `console.error` with `log.error` in StatementUpload, guard division by zero in PDF debug log
- 4 files changed, 8 insertions, 6 deletions — all defensive hardening, zero behavioral changes

## Test plan
- [x] `npm run build` passes
- [x] Superpowers code review completed — approved with zero issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>