### PR TITLE
fix(connections): Wave 5 production readiness — Conexoes + Pessoas

### DIFF
--- a/src/modules/connections/components/whatsapp/ContactDossierCard.tsx
+++ b/src/modules/connections/components/whatsapp/ContactDossierCard.tsx
@@ -185,7 +185,7 @@ export const ContactDossierCard: React.FC<ContactDossierCardProps> = ({
         <div className="text-center py-6">
           <Brain className="w-10 h-10 text-ceramic-text-secondary/30 mx-auto mb-3" />
           <p className="text-sm text-ceramic-text-secondary mb-3">
-            Nenhum dossie gerado ainda. Sao necessarias pelo menos 3 mensagens com intencao extraida.
+            Nenhum dossiê gerado ainda. São necessárias pelo menos 3 mensagens com intenção extraída.
           </p>
           <button
             onClick={onRefresh}
@@ -197,7 +197,7 @@ export const ContactDossierCard: React.FC<ContactDossierCardProps> = ({
             ) : (
               <RefreshCw className="w-4 h-4" />
             )}
-            {isRefreshing ? 'Gerando...' : 'Gerar dossie'}
+            {isRefreshing ? 'Gerando...' : 'Gerar dossiê'}
           </button>
           {error && (
             <p className="mt-3 text-xs text-ceramic-error flex items-center justify-center gap-1">

--- a/src/modules/connections/hooks/useContactDossier.ts
+++ b/src/modules/connections/hooks/useContactDossier.ts
@@ -91,7 +91,7 @@ export function useContactDossier(contactId: string | null): UseContactDossierRe
       }
     } catch (err) {
       log.error('Failed to fetch dossier:', err)
-      setError(err instanceof Error ? err.message : 'Erro ao carregar dossie')
+      setError(err instanceof Error ? err.message : 'Erro ao carregar dossiê')
     } finally {
       setIsLoading(false)
     }
@@ -125,7 +125,7 @@ export function useContactDossier(contactId: string | null): UseContactDossierRe
       }
     } catch (err) {
       log.error('Failed to refresh dossier:', err)
-      setError(err instanceof Error ? err.message : 'Erro ao atualizar dossie')
+      setError(err instanceof Error ? err.message : 'Erro ao atualizar dossiê')
     } finally {
       setIsRefreshing(false)
     }
@@ -186,7 +186,7 @@ export function useContactDossierBatch() {
       })
     } catch (err) {
       log.error('Batch dossier build failed:', err)
-      setError(err instanceof Error ? err.message : 'Erro ao processar dossies em lote')
+      setError(err instanceof Error ? err.message : 'Erro ao processar dossiês em lote')
     } finally {
       setIsProcessing(false)
     }

--- a/src/modules/connections/hooks/useWhatsAppGamification.ts
+++ b/src/modules/connections/hooks/useWhatsAppGamification.ts
@@ -99,7 +99,7 @@ export function useWhatsAppGamification(): WhatsAppGamificationHook {
       // Show badge unlock modal
       const badge = BADGES_CATALOG.first_whatsapp_connect;
       if (badge) {
-        showBadgeUnlock(badge as any);
+        showBadgeUnlock(badge);
       }
 
       log.debug('[useWhatsAppGamification] Connection tracked:', {
@@ -136,7 +136,7 @@ export function useWhatsAppGamification(): WhatsAppGamificationHook {
         // Show badge unlock modal
         const badge = BADGES_CATALOG.consent_champion;
         if (badge) {
-          showBadgeUnlock(badge as any);
+          showBadgeUnlock(badge);
         }
 
         log.debug('[useWhatsAppGamification] Consent Champion badge unlocked!');
@@ -178,7 +178,7 @@ export function useWhatsAppGamification(): WhatsAppGamificationHook {
         // Show badge unlock modal
         const badge = BADGES_CATALOG.emotional_awareness_beginner;
         if (badge) {
-          showBadgeUnlock(badge as any);
+          showBadgeUnlock(badge);
         }
 
         log.debug('[useWhatsAppGamification] Emotional Awareness (Beginner) badge unlocked!');
@@ -188,7 +188,7 @@ export function useWhatsAppGamification(): WhatsAppGamificationHook {
         // Show badge unlock modal
         const badge = BADGES_CATALOG.emotional_awareness_master;
         if (badge) {
-          showBadgeUnlock(badge as any);
+          showBadgeUnlock(badge);
         }
 
         log.debug('[useWhatsAppGamification] Emotional Awareness (Master) badge unlocked!');
@@ -229,7 +229,7 @@ export function useWhatsAppGamification(): WhatsAppGamificationHook {
         // Show badge unlock modal
         const badge = BADGES_CATALOG.sentiment_explorer;
         if (badge) {
-          showBadgeUnlock(badge as any);
+          showBadgeUnlock(badge);
         }
 
         log.debug('[useWhatsAppGamification] Sentiment Explorer badge unlocked!');

--- a/src/modules/connections/services/invitationService.ts
+++ b/src/modules/connections/services/invitationService.ts
@@ -587,7 +587,7 @@ export async function cancelInvitation(invitationId: string): Promise<void> {
     }
 
     // Verify user owns the space
-    const space = invitation.connection_spaces as any;
+    const space = invitation.connection_spaces as Record<string, unknown>;
     if (space.owner_id !== user.id) {
       throw new Error('You do not have permission to cancel this invitation');
     }
@@ -641,7 +641,7 @@ export async function resendInvitation(invitationId: string): Promise<InviteResu
     }
 
     // Verify user owns the space or is admin
-    const space = originalInvitation.connection_spaces as any;
+    const space = originalInvitation.connection_spaces as Record<string, unknown>;
     const isOwner = space.owner_id === user.id;
 
     const { data: memberData } = await supabase

--- a/src/modules/connections/services/networkScoring.ts
+++ b/src/modules/connections/services/networkScoring.ts
@@ -678,7 +678,8 @@ export async function computeConnectionsDomainScore(): Promise<{
       confidence: Math.min(contacts.length / 10, 1),
       trend: 'stable',
     };
-  } catch {
+  } catch (err) {
+    log.warn('computeConnectionScore failed (non-critical):', err);
     return null;
   }
 }

--- a/src/modules/connections/views/ConnectionsWhatsAppTab.tsx
+++ b/src/modules/connections/views/ConnectionsWhatsAppTab.tsx
@@ -49,6 +49,7 @@ import { deleteContacts } from '@/services/contactNetworkService';
 import { useContactDossier } from '../hooks/useContactDossier';
 import { useConversationThreads } from '../hooks/useConversationThreads';
 import { useExtractedEntities } from '../hooks/useExtractedEntities';
+import type { ContactNetwork } from '@/types/memoryTypes';
 import whatsappAnalyticsService, {
   ContactSentimentScore,
   AnomalyAlert,
@@ -719,7 +720,7 @@ export const ConnectionsWhatsAppTab: React.FC<ConnectionsWhatsAppTabProps> = ({
 
       {/* Contact Detail Sheet */}
       <ContactDetailSheet
-        contact={detailContact as any}
+        contact={detailContact as unknown as ContactNetwork}
         isOpen={!!detailContact}
         onClose={() => {
           setDetailContact(null);


### PR DESCRIPTION
## Summary
- Replace 8 `as any` casts with typed alternatives across invitationService, useWhatsAppGamification, and ConnectionsWhatsAppTab
- Add logged warning on silent catch in networkScoring.ts
- Fix "dossie" → "dossiê" typos in 5 user-facing strings (useContactDossier + ContactDossierCard)

## Test plan
- [x] `npm run build` passes
- [x] Zero behavioral changes — defensive hardening only
- [x] Code review passed (superpowers:code-reviewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>