### PR TITLE
feat(flux): add Link Coringa — reusable coach invite links

### DIFF
--- a/src/modules/flux/components/forms/AthleteFormDrawer.tsx
+++ b/src/modules/flux/components/forms/AthleteFormDrawer.tsx
@@ -25,11 +25,13 @@ import {
   Copy,
   Link2,
   User as UserIcon,
+  Users,
   FileText,
   Loader2,
 } from 'lucide-react';
 import type { Athlete, ModalityLevel } from '../../types/flux';
 import { AthleteService } from '../../services/athleteService';
+import { CoachInviteLinkService, type CoachInviteLink } from '../../services/coachInviteLinkService';
 import {
   useAthleteForm,
   MODALITY_OPTIONS,
@@ -71,6 +73,22 @@ export default function AthleteFormDrawer({
   // Invite link state
   const [copyToast, setCopyToast] = useState(false);
   const createdAthleteId = lastCreatedId;
+  const [coringaLink, setCoringaLink] = useState<CoachInviteLink | null>(null);
+  const [coringaCopyToast, setCoringaCopyToast] = useState(false);
+
+  // Generate coringa link on success
+  React.useEffect(() => {
+    if (mode === 'create' && submitSuccess && !coringaLink) {
+      const healthConfig = {
+        requires_cardio_exam: formData.requires_cardio_exam,
+        requires_clearance_cert: formData.requires_clearance_cert,
+        allow_parq_onboarding: formData.allow_parq_onboarding,
+      };
+      CoachInviteLinkService.getOrCreateLink(healthConfig).then(({ data }) => {
+        if (data) setCoringaLink(data);
+      });
+    }
+  }, [submitSuccess, mode, coringaLink, formData.requires_cardio_exam, formData.requires_clearance_cert, formData.allow_parq_onboarding]);
 
   // Accordion state — in create mode, open health (only section); in edit mode, open basic info
   const [openSections, setOpenSections] = useState({
@@ -96,6 +114,18 @@ export default function AthleteFormDrawer({
       setTimeout(() => setCopyToast(false), 3000);
     } catch (err) {
       console.error('Failed to copy link:', err);
+    }
+  };
+
+  const getCoringaUrl = (token: string) => `https://aica.guru/join/${token}`;
+
+  const handleCopyCoringaLink = async (token: string) => {
+    try {
+      await navigator.clipboard.writeText(getCoringaUrl(token));
+      setCoringaCopyToast(true);
+      setTimeout(() => setCoringaCopyToast(false), 3000);
+    } catch (err) {
+      console.error('Failed to copy:', err);
     }
   };
 
@@ -205,38 +235,63 @@ export default function AthleteFormDrawer({
                   </div>
                 )}
 
-                {/* Create mode: Show invite link after success */}
+                {/* Create mode: Show invite links after success */}
                 {mode === 'create' && submitSuccess && createdAthleteId && (
-                  <div className="ceramic-card p-5 space-y-4">
-                    <div className="flex items-center gap-3">
-                      <div className="p-2.5 bg-ceramic-success/15 rounded-xl">
-                        <CheckCircle className="w-6 h-6 text-ceramic-success" />
-                      </div>
-                      <div>
-                        <p className="text-sm font-bold text-ceramic-text-primary">
-                          Atleta criado!
-                        </p>
-                        <p className="text-xs text-ceramic-text-secondary">
-                          Envie o link abaixo para seu atleta se cadastrar
+                  <div className="space-y-3">
+                    {/* Individual Link */}
+                    <div className="ceramic-card p-4 space-y-3">
+                      <div className="flex items-center gap-2">
+                        <UserIcon className="w-4 h-4 text-ceramic-text-secondary" />
+                        <p className="text-xs font-bold text-ceramic-text-secondary uppercase tracking-wider">
+                          Link Individual
                         </p>
                       </div>
+                      <div className="flex items-center gap-2">
+                        <input type="text" readOnly value={getInviteLink(createdAthleteId)}
+                          className="flex-1 ceramic-inset px-3 py-2 rounded-lg text-[10px] text-ceramic-text-secondary font-mono select-all" />
+                        <button type="button" onClick={() => handleCopyInviteLink(createdAthleteId)}
+                          className="px-3 py-2 bg-amber-500 hover:bg-amber-600 text-white rounded-lg text-xs font-bold transition-colors flex items-center gap-1.5">
+                          <Copy className="w-3.5 h-3.5" />
+                          {copyToast ? 'Copiado!' : 'Copiar'}
+                        </button>
+                      </div>
+                      <p className="text-[10px] text-ceramic-text-secondary">Para este atleta especifico</p>
                     </div>
 
-                    <div className="flex items-center gap-2">
-                      <input
-                        type="text"
-                        readOnly
-                        value={getInviteLink(createdAthleteId)}
-                        className="flex-1 ceramic-inset px-3 py-2.5 rounded-lg text-xs text-ceramic-text-secondary font-mono select-all"
-                      />
-                      <button
-                        type="button"
-                        onClick={() => handleCopyInviteLink(createdAthleteId)}
-                        className="px-4 py-2.5 bg-amber-500 hover:bg-amber-600 text-white rounded-lg text-sm font-bold transition-colors flex items-center gap-2"
-                      >
-                        <Copy className="w-4 h-4" />
-                        {copyToast ? 'Copiado!' : 'Copiar'}
-                      </button>
+                    {/* Link Coringa */}
+                    <div className="ceramic-card p-4 space-y-3 border-2 border-amber-300/50">
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-2">
+                          <Users className="w-4 h-4 text-amber-600" />
+                          <p className="text-xs font-bold text-amber-700 uppercase tracking-wider">Link Coringa</p>
+                        </div>
+                        {coringaLink && (
+                          <span className="text-[10px] font-bold px-2 py-0.5 rounded-md bg-amber-100 text-amber-700">
+                            {coringaLink.current_uses}/{coringaLink.max_uses} usos
+                          </span>
+                        )}
+                      </div>
+                      {coringaLink ? (
+                        <>
+                          <div className="flex items-center gap-2">
+                            <input type="text" readOnly value={getCoringaUrl(coringaLink.token)}
+                              className="flex-1 ceramic-inset px-3 py-2 rounded-lg text-[10px] text-ceramic-text-secondary font-mono select-all" />
+                            <button type="button" onClick={() => handleCopyCoringaLink(coringaLink.token)}
+                              className="px-3 py-2 bg-amber-500 hover:bg-amber-600 text-white rounded-lg text-xs font-bold transition-colors flex items-center gap-1.5">
+                              <Copy className="w-3.5 h-3.5" />
+                              {coringaCopyToast ? 'Copiado!' : 'Copiar'}
+                            </button>
+                          </div>
+                          <p className="text-[10px] text-ceramic-text-secondary">
+                            Reutilizavel — compartilhe em grupo (WhatsApp, email). Mesmas configs de saude.
+                          </p>
+                        </>
+                      ) : (
+                        <div className="flex items-center gap-2 py-2">
+                          <Loader2 className="w-4 h-4 text-amber-500 animate-spin" />
+                          <span className="text-xs text-ceramic-text-secondary">Gerando link...</span>
+                        </div>
+                      )}
                     </div>
                   </div>
                 )}

--- a/src/modules/flux/services/coachInviteLinkService.ts
+++ b/src/modules/flux/services/coachInviteLinkService.ts
@@ -1,0 +1,98 @@
+/**
+ * Coach Invite Link Service — manages reusable invite links ("Link Coringa")
+ */
+import { supabase } from '@/services/supabaseClient';
+
+export interface CoachInviteLink {
+  id: string;
+  user_id: string;
+  token: string;
+  max_uses: number;
+  current_uses: number;
+  health_config: {
+    requires_cardio_exam: boolean;
+    requires_clearance_cert: boolean;
+    allow_parq_onboarding: boolean;
+  };
+  expires_at: string | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+function generateToken(): string {
+  const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789';
+  let token = '';
+  const array = new Uint8Array(8);
+  crypto.getRandomValues(array);
+  for (const byte of array) {
+    token += chars[byte % chars.length];
+  }
+  return token;
+}
+
+export class CoachInviteLinkService {
+  static async findActiveLink(healthConfig: CoachInviteLink['health_config']): Promise<CoachInviteLink | null> {
+    const { data } = await supabase
+      .from('coach_invite_links')
+      .select('*')
+      .eq('is_active', true)
+      .order('created_at', { ascending: false });
+
+    if (!data || data.length === 0) return null;
+
+    // Find link with matching health config that's still usable
+    for (const row of data) {
+      const link = row as CoachInviteLink;
+      const cfg = link.health_config;
+      if (
+        cfg.requires_cardio_exam === healthConfig.requires_cardio_exam &&
+        cfg.requires_clearance_cert === healthConfig.requires_clearance_cert &&
+        cfg.allow_parq_onboarding === healthConfig.allow_parq_onboarding &&
+        link.current_uses < link.max_uses &&
+        (!link.expires_at || new Date(link.expires_at) > new Date())
+      ) {
+        return link;
+      }
+    }
+    return null;
+  }
+
+  static async createLink(healthConfig: CoachInviteLink['health_config'], maxUses = 10): Promise<{
+    data: CoachInviteLink | null;
+    error: any;
+  }> {
+    const token = generateToken();
+    const { data, error } = await supabase
+      .from('coach_invite_links')
+      .insert({ token, max_uses: maxUses, health_config: healthConfig })
+      .select()
+      .single();
+    return { data: data as CoachInviteLink | null, error };
+  }
+
+  static async getOrCreateLink(healthConfig: CoachInviteLink['health_config'], maxUses = 10): Promise<{
+    data: CoachInviteLink | null;
+    error: any;
+  }> {
+    const existing = await this.findActiveLink(healthConfig);
+    if (existing) return { data: existing, error: null };
+    return this.createLink(healthConfig, maxUses);
+  }
+
+  static async getMyLinks(): Promise<{ data: CoachInviteLink[]; error: any }> {
+    const { data, error } = await supabase
+      .from('coach_invite_links')
+      .select('*')
+      .order('created_at', { ascending: false });
+    return { data: (data || []) as CoachInviteLink[], error };
+  }
+
+  static async deactivateLink(linkId: string): Promise<{ error: any }> {
+    const { error } = await supabase
+      .from('coach_invite_links')
+      .update({ is_active: false, updated_at: new Date().toISOString() })
+      .eq('id', linkId);
+    return { error };
+  }
+}

--- a/src/modules/flux/views/CoachInviteView.tsx
+++ b/src/modules/flux/views/CoachInviteView.tsx
@@ -1,0 +1,439 @@
+/**
+ * CoachInviteView — Public page for reusable coach invite links ("Link Coringa")
+ *
+ * Route: /join/:token (public, no auth required)
+ *
+ * Flow:
+ * 1. Load link info via RPC (coach name, health config, usage)
+ * 2. Athlete fills name, email, phone
+ * 3. Submit creates athlete record atomically via RPC
+ * 4. Redirect to /onboarding/:athleteId for account creation
+ */
+
+import React, { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { motion } from 'framer-motion';
+import {
+  User,
+  Mail,
+  Phone,
+  Heart,
+  FileText,
+  CheckCircle,
+  AlertCircle,
+  Loader2,
+  ArrowRight,
+  Dumbbell,
+  Users,
+  Link2,
+} from 'lucide-react';
+import { supabase } from '@/services/supabaseClient';
+
+// ============================================
+// Types
+// ============================================
+
+interface LinkInfo {
+  coach_name: string;
+  health_config: {
+    requires_cardio_exam: boolean;
+    requires_clearance_cert: boolean;
+    allow_parq_onboarding: boolean;
+  };
+  max_uses: number;
+  current_uses: number;
+  is_active: boolean;
+  expires_at: string | null;
+}
+
+interface FormData {
+  name: string;
+  email: string;
+  phone: string;
+}
+
+interface FormErrors {
+  name?: string;
+  email?: string;
+  phone?: string;
+  general?: string;
+}
+
+type ViewStep = 'loading' | 'form' | 'submitting' | 'success' | 'error';
+
+// ============================================
+// Component
+// ============================================
+
+export default function CoachInviteView() {
+  const { token } = useParams<{ token: string }>();
+  const navigate = useNavigate();
+
+  const [step, setStep] = useState<ViewStep>('loading');
+  const [linkInfo, setLinkInfo] = useState<LinkInfo | null>(null);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [formData, setFormData] = useState<FormData>({ name: '', email: '', phone: '' });
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [createdAthleteId, setCreatedAthleteId] = useState<string | null>(null);
+
+  // Load link info
+  useEffect(() => {
+    if (!token) {
+      setStep('error');
+      setErrorMessage('Link invalido.');
+      return;
+    }
+
+    const loadLinkInfo = async () => {
+      try {
+        const { data, error } = await supabase.rpc('get_coach_invite_link', { p_token: token });
+
+        if (error || !data || (Array.isArray(data) && data.length === 0)) {
+          setStep('error');
+          setErrorMessage('Link nao encontrado. Verifique com seu treinador.');
+          return;
+        }
+
+        const info = (Array.isArray(data) ? data[0] : data) as LinkInfo;
+
+        // Check if link is still valid
+        if (!info.is_active) {
+          setStep('error');
+          setErrorMessage('Este link foi desativado pelo treinador.');
+          return;
+        }
+
+        if (info.current_uses >= info.max_uses) {
+          setStep('error');
+          setErrorMessage('Este link atingiu o limite de usos. Peca um novo link ao seu treinador.');
+          return;
+        }
+
+        if (info.expires_at && new Date(info.expires_at) < new Date()) {
+          setStep('error');
+          setErrorMessage('Este link expirou. Peca um novo link ao seu treinador.');
+          return;
+        }
+
+        setLinkInfo(info);
+        setStep('form');
+      } catch (err) {
+        console.error('[CoachInviteView] Error loading link:', err);
+        setStep('error');
+        setErrorMessage('Erro ao carregar dados. Tente novamente.');
+      }
+    };
+
+    loadLinkInfo();
+  }, [token]);
+
+  // Validation
+  const validate = (): boolean => {
+    const newErrors: FormErrors = {};
+
+    if (!formData.name || formData.name.trim().length < 2) {
+      newErrors.name = 'Nome e obrigatorio (min. 2 caracteres)';
+    }
+
+    if (!formData.email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.email)) {
+      newErrors.email = 'Email valido e obrigatorio';
+    }
+
+    if (!formData.phone || formData.phone.length < 10) {
+      newErrors.phone = 'Telefone invalido (formato: +5511987654321)';
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  // Submit form
+  const handleSubmit = async () => {
+    if (!validate() || !token) return;
+
+    setStep('submitting');
+    try {
+      const { data, error } = await supabase.rpc('use_coach_invite_link', {
+        p_token: token,
+        p_name: formData.name.trim(),
+        p_email: formData.email.trim(),
+        p_phone: formData.phone.trim(),
+      });
+
+      if (error) {
+        console.error('[CoachInviteView] RPC error:', error);
+        setStep('form');
+        setErrors({ general: error.message || 'Erro ao criar cadastro. Tente novamente.' });
+        return;
+      }
+
+      const athleteId = typeof data === 'string' ? data : (data as any)?.athlete_id;
+      if (!athleteId) {
+        setStep('form');
+        setErrors({ general: 'Erro inesperado. Tente novamente.' });
+        return;
+      }
+
+      setCreatedAthleteId(athleteId);
+      setStep('success');
+
+      // Redirect to existing onboarding flow for account creation
+      setTimeout(() => {
+        navigate(`/onboarding/${athleteId}`, { replace: true });
+      }, 2000);
+    } catch (err) {
+      console.error('[CoachInviteView] Error submitting:', err);
+      setStep('form');
+      setErrors({ general: 'Erro ao criar cadastro. Tente novamente.' });
+    }
+  };
+
+  // ============================================
+  // Health docs display
+  // ============================================
+
+  const healthDocs = linkInfo ? [
+    ...(linkInfo.health_config.requires_cardio_exam ? ['Exame Cardiologico'] : []),
+    ...(linkInfo.health_config.requires_clearance_cert ? ['Atestado de Liberacao Medica'] : []),
+    ...(linkInfo.health_config.allow_parq_onboarding ? ['Questionario PAR-Q+'] : []),
+  ] : [];
+
+  // ============================================
+  // Loading
+  // ============================================
+
+  if (step === 'loading') {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-screen bg-ceramic-base">
+        <Loader2 className="w-8 h-8 text-amber-500 animate-spin mb-4" />
+        <p className="text-sm text-ceramic-text-secondary">Carregando...</p>
+      </div>
+    );
+  }
+
+  // ============================================
+  // Error
+  // ============================================
+
+  if (step === 'error') {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-screen bg-ceramic-base px-6">
+        <div className="ceramic-card p-8 max-w-md text-center space-y-4">
+          <div className="w-16 h-16 rounded-full bg-ceramic-error/10 flex items-center justify-center mx-auto">
+            <AlertCircle className="w-8 h-8 text-ceramic-error" />
+          </div>
+          <h1 className="text-xl font-black text-ceramic-text-primary">Link Invalido</h1>
+          <p className="text-sm text-ceramic-text-secondary leading-relaxed">{errorMessage}</p>
+        </div>
+      </div>
+    );
+  }
+
+  // ============================================
+  // Success — redirecting to onboarding
+  // ============================================
+
+  if (step === 'success') {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-screen bg-ceramic-base px-6">
+        <div className="ceramic-card p-8 max-w-md text-center space-y-4">
+          <motion.div
+            initial={{ scale: 0 }}
+            animate={{ scale: 1 }}
+            transition={{ type: 'spring', damping: 10, stiffness: 200 }}
+          >
+            <div className="w-20 h-20 rounded-full bg-ceramic-success/15 flex items-center justify-center mx-auto">
+              <CheckCircle className="w-10 h-10 text-ceramic-success" />
+            </div>
+          </motion.div>
+          <h2 className="text-xl font-black text-ceramic-text-primary">Cadastro criado!</h2>
+          <p className="text-sm text-ceramic-text-secondary">
+            Redirecionando para completar seu perfil...
+          </p>
+          <Loader2 className="w-5 h-5 text-ceramic-text-secondary animate-spin mx-auto" />
+        </div>
+      </div>
+    );
+  }
+
+  // ============================================
+  // Main form (step === 'form' or 'submitting')
+  // ============================================
+
+  return (
+    <div className="min-h-screen bg-ceramic-base flex flex-col items-center px-4 py-8 sm:py-16">
+      {/* Header */}
+      <div className="text-center mb-8 max-w-md">
+        <div className="w-16 h-16 rounded-2xl bg-amber-500/10 flex items-center justify-center mx-auto mb-4">
+          <Dumbbell className="w-8 h-8 text-amber-600" />
+        </div>
+        <h1 className="text-2xl font-black text-ceramic-text-primary">
+          Bem-vindo ao Flux
+        </h1>
+        {linkInfo?.coach_name && (
+          <p className="text-sm text-ceramic-text-secondary mt-2">
+            Convite de <strong>{linkInfo.coach_name}</strong>
+          </p>
+        )}
+      </div>
+
+      {/* Link info badge */}
+      <div className="flex items-center gap-2 mb-6">
+        <div className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-100 text-amber-700">
+          <Users className="w-3.5 h-3.5" />
+          <span className="text-xs font-bold">
+            Link Coringa
+          </span>
+        </div>
+        {linkInfo && (
+          <span className="text-[10px] text-ceramic-text-secondary">
+            {linkInfo.current_uses}/{linkInfo.max_uses} usos
+          </span>
+        )}
+      </div>
+
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.3 }}
+        className="w-full max-w-md space-y-4"
+      >
+        {/* General error */}
+        {errors.general && (
+          <div className="flex items-start gap-3 p-4 bg-ceramic-error/10 border border-ceramic-error/20 rounded-lg">
+            <AlertCircle className="w-5 h-5 text-ceramic-error mt-0.5 flex-shrink-0" />
+            <p className="text-sm text-ceramic-error">{errors.general}</p>
+          </div>
+        )}
+
+        {/* Personal info form */}
+        <div className="ceramic-card p-6 space-y-5">
+          <div className="flex items-center gap-3 mb-2">
+            <div className="ceramic-inset p-2">
+              <User className="w-5 h-5 text-ceramic-text-primary" />
+            </div>
+            <div>
+              <h2 className="text-lg font-bold text-ceramic-text-primary">Seus Dados</h2>
+              <p className="text-xs text-ceramic-text-secondary">
+                Preencha suas informacoes para o treinador
+              </p>
+            </div>
+          </div>
+
+          {/* Name */}
+          <div>
+            <label className="block text-xs font-bold text-ceramic-text-secondary uppercase tracking-wider mb-2">
+              Nome Completo *
+            </label>
+            <input
+              type="text"
+              value={formData.name}
+              onChange={(e) => {
+                setFormData(prev => ({ ...prev, name: e.target.value }));
+                setErrors(prev => ({ ...prev, name: undefined }));
+              }}
+              className="w-full ceramic-inset px-4 py-3 rounded-lg text-sm text-ceramic-text-primary placeholder-ceramic-text-secondary/50 focus:outline-none focus:ring-2 focus:ring-amber-500/50"
+              placeholder="Seu nome completo"
+              autoFocus
+              disabled={step === 'submitting'}
+            />
+            {errors.name && <p className="text-xs text-ceramic-error mt-1">{errors.name}</p>}
+          </div>
+
+          {/* Email */}
+          <div>
+            <label className="block text-xs font-bold text-ceramic-text-secondary uppercase tracking-wider mb-2">
+              Email *
+            </label>
+            <input
+              type="email"
+              value={formData.email}
+              onChange={(e) => {
+                setFormData(prev => ({ ...prev, email: e.target.value }));
+                setErrors(prev => ({ ...prev, email: undefined }));
+              }}
+              className="w-full ceramic-inset px-4 py-3 rounded-lg text-sm text-ceramic-text-primary placeholder-ceramic-text-secondary/50 focus:outline-none focus:ring-2 focus:ring-amber-500/50"
+              placeholder="seu@email.com"
+              disabled={step === 'submitting'}
+            />
+            {errors.email && <p className="text-xs text-ceramic-error mt-1">{errors.email}</p>}
+          </div>
+
+          {/* Phone */}
+          <div>
+            <label className="block text-xs font-bold text-ceramic-text-secondary uppercase tracking-wider mb-2">
+              WhatsApp *
+            </label>
+            <input
+              type="tel"
+              value={formData.phone}
+              onChange={(e) => {
+                setFormData(prev => ({ ...prev, phone: e.target.value }));
+                setErrors(prev => ({ ...prev, phone: undefined }));
+              }}
+              className="w-full ceramic-inset px-4 py-3 rounded-lg text-sm text-ceramic-text-primary placeholder-ceramic-text-secondary/50 focus:outline-none focus:ring-2 focus:ring-amber-500/50"
+              placeholder="+5511987654321"
+              disabled={step === 'submitting'}
+            />
+            {errors.phone && <p className="text-xs text-ceramic-error mt-1">{errors.phone}</p>}
+          </div>
+        </div>
+
+        {/* Health requirements info */}
+        {healthDocs.length > 0 && (
+          <div className="ceramic-card p-5 space-y-3">
+            <div className="flex items-center gap-3">
+              <div className="ceramic-inset p-2">
+                <Heart className="w-5 h-5 text-ceramic-text-primary" />
+              </div>
+              <div>
+                <h3 className="text-sm font-bold text-ceramic-text-primary">Requisitos de Saude</h3>
+                <p className="text-xs text-ceramic-text-secondary">
+                  Documentos exigidos pelo treinador
+                </p>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              {healthDocs.map((doc) => (
+                <div
+                  key={doc}
+                  className="flex items-center gap-3 p-3 ceramic-inset rounded-lg"
+                >
+                  <FileText className="w-4 h-4 text-amber-600 flex-shrink-0" />
+                  <p className="text-xs font-medium text-ceramic-text-primary">{doc}</p>
+                </div>
+              ))}
+            </div>
+
+            <p className="text-[10px] text-ceramic-text-secondary leading-relaxed">
+              Voce podera enviar estes documentos apos criar sua conta.
+            </p>
+          </div>
+        )}
+
+        {/* Submit button */}
+        <button
+          type="button"
+          onClick={handleSubmit}
+          disabled={step === 'submitting'}
+          className="w-full py-3 bg-amber-500 hover:bg-amber-600 disabled:bg-ceramic-text-secondary/20 text-white rounded-xl font-bold text-sm transition-colors flex items-center justify-center gap-2"
+        >
+          {step === 'submitting' ? (
+            <Loader2 className="w-4 h-4 animate-spin" />
+          ) : (
+            <>
+              Comecar Cadastro
+              <ArrowRight className="w-4 h-4" />
+            </>
+          )}
+        </button>
+
+        {/* Footer info */}
+        <p className="text-[10px] text-ceramic-text-secondary text-center leading-relaxed">
+          Ao continuar, voce sera redirecionado para completar seu perfil e criar uma conta na plataforma AICA.
+        </p>
+      </motion.div>
+    </div>
+  );
+}

--- a/src/router/AppRouter.tsx
+++ b/src/router/AppRouter.tsx
@@ -72,6 +72,9 @@ const AthletePortalView = lazy(() => import('../modules/flux/views/AthletePortal
 // Athlete Onboarding - Public page for new athletes to complete their profile
 const AthleteOnboardingView = lazy(() => import('../modules/flux/views/AthleteOnboardingView').then(m => ({ default: m.default })));
 
+// Coach Invite Link - Public page for reusable invite links ("Link Coringa")
+const CoachInviteView = lazy(() => import('../modules/flux/views/CoachInviteView').then(m => ({ default: m.default })));
+
 // Guest Portal - Read-only episode view for podcast guests
 const GuestPortalView = lazy(() => import('../modules/studio/views/GuestPortalView').then(m => ({ default: m.default })));
 
@@ -770,6 +773,16 @@ export function AppRouter() {
                   element={
                     <Suspense fallback={<LoadingScreen message="Carregando..." />}>
                       <AthleteOnboardingView />
+                    </Suspense>
+                  }
+               />
+
+               {/* Coach Invite Link — Public route for reusable invite links */}
+               <Route
+                  path="/join/:token"
+                  element={
+                    <Suspense fallback={<LoadingScreen message="Carregando..." />}>
+                      <CoachInviteView />
                     </Suspense>
                   }
                />

--- a/supabase/migrations/20260317100004_add_coach_invite_links.sql
+++ b/supabase/migrations/20260317100004_add_coach_invite_links.sql
@@ -1,0 +1,188 @@
+-- ============================================
+-- Coach Invite Links ("Link Coringa")
+-- Reusable invite links for coaches to onboard multiple athletes
+-- ============================================
+
+-- Table
+CREATE TABLE IF NOT EXISTS public.coach_invite_links (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  token TEXT NOT NULL UNIQUE,
+  max_uses INTEGER NOT NULL DEFAULT 10,
+  current_uses INTEGER NOT NULL DEFAULT 0,
+  health_config JSONB NOT NULL DEFAULT '{
+    "requires_cardio_exam": false,
+    "requires_clearance_cert": false,
+    "allow_parq_onboarding": false
+  }'::jsonb,
+  expires_at TIMESTAMPTZ,
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_coach_invite_links_token ON public.coach_invite_links(token);
+CREATE INDEX IF NOT EXISTS idx_coach_invite_links_user_active ON public.coach_invite_links(user_id, is_active);
+
+-- RLS
+ALTER TABLE public.coach_invite_links ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Coaches can read own links"
+  ON public.coach_invite_links FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Coaches can insert own links"
+  ON public.coach_invite_links FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Coaches can update own links"
+  ON public.coach_invite_links FOR UPDATE
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Coaches can delete own links"
+  ON public.coach_invite_links FOR DELETE
+  USING (auth.uid() = user_id);
+
+-- Auto-set user_id on insert
+CREATE OR REPLACE FUNCTION public.set_coach_invite_link_user_id()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  NEW.user_id := auth.uid();
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_set_coach_invite_link_user_id
+  BEFORE INSERT ON public.coach_invite_links
+  FOR EACH ROW
+  EXECUTE FUNCTION public.set_coach_invite_link_user_id();
+
+-- ============================================
+-- RPC: use_coach_invite_link
+-- Atomically creates an athlete from a coach invite link
+-- Returns the new athlete_id
+-- ============================================
+CREATE OR REPLACE FUNCTION public.use_coach_invite_link(
+  p_token TEXT,
+  p_name TEXT,
+  p_email TEXT,
+  p_phone TEXT
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_link RECORD;
+  v_athlete_id UUID;
+BEGIN
+  -- Lock the link row for atomic update
+  SELECT * INTO v_link
+  FROM coach_invite_links
+  WHERE token = p_token
+    AND is_active = true
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Link invalido ou desativado';
+  END IF;
+
+  IF v_link.current_uses >= v_link.max_uses THEN
+    RAISE EXCEPTION 'Link atingiu o limite de usos';
+  END IF;
+
+  IF v_link.expires_at IS NOT NULL AND v_link.expires_at < now() THEN
+    RAISE EXCEPTION 'Link expirado';
+  END IF;
+
+  -- Create the athlete record
+  INSERT INTO athletes (
+    user_id,
+    name,
+    email,
+    phone,
+    status,
+    invitation_status,
+    requires_cardio_exam,
+    requires_clearance_cert,
+    allow_parq_onboarding,
+    invite_link_id
+  ) VALUES (
+    v_link.user_id,
+    p_name,
+    p_email,
+    p_phone,
+    'trial',
+    'pending',
+    COALESCE((v_link.health_config->>'requires_cardio_exam')::boolean, false),
+    COALESCE((v_link.health_config->>'requires_clearance_cert')::boolean, false),
+    COALESCE((v_link.health_config->>'allow_parq_onboarding')::boolean, false),
+    v_link.id
+  )
+  RETURNING id INTO v_athlete_id;
+
+  -- Increment usage counter
+  UPDATE coach_invite_links
+  SET current_uses = current_uses + 1,
+      updated_at = now()
+  WHERE id = v_link.id;
+
+  RETURN v_athlete_id;
+END;
+$$;
+
+-- ============================================
+-- RPC: get_coach_invite_link
+-- Public info about a coach invite link (no auth required)
+-- ============================================
+CREATE OR REPLACE FUNCTION public.get_coach_invite_link(p_token TEXT)
+RETURNS TABLE (
+  coach_name TEXT,
+  health_config JSONB,
+  max_uses INTEGER,
+  current_uses INTEGER,
+  is_active BOOLEAN,
+  expires_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    COALESCE(up.display_name, up.email, 'Treinador') AS coach_name,
+    cil.health_config,
+    cil.max_uses,
+    cil.current_uses,
+    cil.is_active,
+    cil.expires_at
+  FROM coach_invite_links cil
+  LEFT JOIN user_profiles up ON up.id = cil.user_id
+  WHERE cil.token = p_token;
+END;
+$$;
+
+-- Grant execute to authenticated and anon (public pages need anon access)
+GRANT EXECUTE ON FUNCTION public.use_coach_invite_link(TEXT, TEXT, TEXT, TEXT) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_coach_invite_link(TEXT) TO anon, authenticated;
+
+-- Add invite_link_id column to athletes if not exists
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'athletes'
+      AND column_name = 'invite_link_id'
+  ) THEN
+    ALTER TABLE public.athletes ADD COLUMN invite_link_id UUID REFERENCES public.coach_invite_links(id);
+  END IF;
+END;
+$$;


### PR DESCRIPTION
## Summary

- **coach_invite_links** table with RLS, usage limits, health config (JSONB)
- **use_coach_invite_link** RPC: atomic validate + create athlete + increment (row-level lock)
- **get_coach_invite_link** RPC: public info for /join/:token page
- **CoachInviteLinkService**: getOrCreate (reuses active link with same config), token generation
- **AthleteFormDrawer**: shows Individual + Coringa links after creation with copy buttons
- **CoachInviteView** (`/join/:token`): public page — athlete fills name/email/phone → creates via RPC → redirects to onboarding

## Test plan
- [ ] Coach creates athlete → sees both Individual and Coringa links
- [ ] Copy Coringa link → open in incognito → shows coach name + form
- [ ] Fill form → athlete created → redirected to onboarding
- [ ] Use link again (2nd athlete) → counter shows 1/10 → 2/10
- [ ] Same health config → reuses same coringa link
- [ ] Max uses reached → shows "Limite de vagas atingido"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Coaches can now generate reusable invite links with configurable usage limits and health document requirements.
  * Athletes can join organizations via public invite links by providing their details and are automatically directed to onboarding.
  * Coaches can view, copy, and manage multiple invite links directly from the athlete creation interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->