### PR TITLE
feat(chat): add observability — structured metrics + Sentry breadcrumbs (3.6)

### DIFF
--- a/src/hooks/useChatSession.ts
+++ b/src/hooks/useChatSession.ts
@@ -14,6 +14,7 @@ import { checkInteractionLimit, type InteractionLimitResult } from '@/services/b
 import { getUserAIContext } from '@/services/userAIContextService'
 import { streamChat, fetchChatNonStreaming, fetchReactChat, type InterviewMeta } from '@/services/chatStreamService'
 import type { ChatAction } from '@/types/chatActions'
+import { Sentry } from '@/lib/sentry'
 
 export interface DisplayMessage {
   id: string
@@ -164,6 +165,7 @@ export function useChatSession(): UseChatSessionReturn {
     setLimitReached(false)
     setSuggestedQuestions([])
     setIsLoading(true)
+    const sendStartMs = Date.now()
 
     try {
       // Check interaction limit before calling AI (fail-open)
@@ -347,12 +349,29 @@ export function useChatSession(): UseChatSessionReturn {
         }).catch(err => console.warn('[useChatSession] Title generation failed:', err))
       }
 
+      // Sentry breadcrumb: success
+      Sentry.addBreadcrumb({
+        category: 'chat',
+        message: 'message_sent',
+        level: 'info',
+        data: { modelUsed, latencyMs: Date.now() - sendStartMs, success: true },
+      })
+
       // Clear error and failed message on success
       setError(null)
       setLastFailedMessage(null)
     } catch (err) {
       console.error('[useChatSession] sendMessage failed:', err)
       const message = err instanceof Error ? err.message : 'Erro ao conectar com a Aica'
+
+      // Sentry breadcrumb: failure
+      Sentry.addBreadcrumb({
+        category: 'chat',
+        message: 'message_failed',
+        level: 'error',
+        data: { latencyMs: Date.now() - sendStartMs, error: message },
+      })
+
       setError(message)
       setLastFailedMessage(trimmed)
       setConnectionStatus('offline')

--- a/supabase/functions/gemini-chat/handlers/stream.ts
+++ b/supabase/functions/gemini-chat/handlers/stream.ts
@@ -15,6 +15,7 @@ export async function handleStreamChat(
   corsHeaders: Record<string, string>,
   apiKey: string
 ): Promise<Response> {
+  const requestStartMs = Date.now()
   const streamMessage = payload?.message
   if (!streamMessage) throw new Error('Mensagem e obrigatoria')
 
@@ -139,6 +140,8 @@ export async function handleStreamChat(
     const fallbackActions = generateSuggestedActions(streamMessage, streamRawData)
     const fallbackQuestions = generateSuggestedQuestions(streamMessage, nonStreamText, streamModule, streamRawData)
     const fallbackUsage = nonStreamResult.response.usageMetadata
+    const fallbackLatencyMs = Date.now() - requestStartMs
+    console.log(`[chat_aica_stream] METRIC user=${userId} module=${streamModule} latency=${fallbackLatencyMs}ms streaming=false fallback=true tokens_in=${fallbackUsage?.promptTokenCount || 0} tokens_out=${fallbackUsage?.candidatesTokenCount || 0}`)
     return new Response(JSON.stringify({
       success: true,
       text: nonStreamText,
@@ -195,6 +198,12 @@ export async function handleStreamChat(
           message: (streamError as Error).message || 'Erro no streaming',
         })}\n\n`))
       } finally {
+        const latencyMs = Date.now() - requestStartMs
+        const streamingSuccess = fullText.length > 0
+
+        // Structured metric log for observability
+        console.log(`[chat_aica_stream] METRIC user=${userId} module=${streamModule} latency=${latencyMs}ms streaming=${streamingSuccess} tokens_in=${usageMeta?.promptTokenCount || 0} tokens_out=${usageMeta?.candidatesTokenCount || 0}`)
+
         // Fire-and-forget: log interaction with real token counts from stream
         if (userId && supabaseAdmin) {
           supabaseAdmin.rpc('log_interaction', {


### PR DESCRIPTION
## Summary
- Backend: structured metric logs in Edge Function (`[chat_aica_stream] METRIC user=X module=Y latency=Zms streaming=T/F tokens_in=N tokens_out=M`)
- Frontend: Sentry breadcrumbs on chat success/failure with latencyMs, modelUsed, error details

## Files (2)
- `supabase/functions/gemini-chat/handlers/stream.ts` — timing + structured logs
- `src/hooks/useChatSession.ts` — Sentry breadcrumbs

## Test plan
- [x] Build passes, 11 tests pass
- [ ] Send chat message → verify structured log in Edge Function logs
- [ ] Check Sentry breadcrumbs after message send

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal monitoring and performance measurement capabilities for chat operations to improve system observability and debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->