### PR TITLE
feat(chat): add morning briefing — personalized bom dia with context (2.3)

### DIFF
--- a/src/hooks/useChatSession.ts
+++ b/src/hooks/useChatSession.ts
@@ -100,6 +100,42 @@ export function useChatSession(): UseChatSessionReturn {
     }
   }, [])
 
+  // Morning briefing: show once per day between 6-12h BRT
+  const fetchMorningBriefing = useCallback(async () => {
+    const now = new Date()
+    const brtHour = parseInt(now.toLocaleString('en-US', { hour: '2-digit', hour12: false, timeZone: 'America/Sao_Paulo' }))
+    if (brtHour < 6 || brtHour >= 12) return // Only 6-12h BRT
+
+    const todayKey = `aica_briefing_${now.toISOString().split('T')[0]}`
+    if (localStorage.getItem(todayKey)) return // Already shown today
+
+    try {
+      const resp = await supabase.functions.invoke('gemini-chat', {
+        body: { action: 'generate_morning_briefing', payload: {} },
+      })
+      if (resp.data?.success && resp.data?.briefing) {
+        localStorage.setItem(todayKey, '1')
+        const briefingMsg: DisplayMessage = {
+          id: `briefing-${Date.now()}`,
+          role: 'assistant',
+          content: resp.data.briefing,
+          created_at: new Date().toISOString(),
+          agent: 'aica_coordinator',
+        }
+        setMessages(prev => prev.length === 0 ? [briefingMsg] : prev)
+      }
+    } catch (err) {
+      console.warn('[useChatSession] Morning briefing failed:', err)
+    }
+  }, [])
+
+  // Trigger briefing when hook loads with no messages
+  useEffect(() => {
+    if (messages.length === 0 && !session) {
+      fetchMorningBriefing()
+    }
+  }, [messages.length, session, fetchMorningBriefing])
+
   const getUserId = useCallback(async (): Promise<string> => {
     const { session: authSession } = await getCachedSession()
     if (!authSession?.user?.id) throw new Error('Não autenticado')

--- a/supabase/functions/gemini-chat/index.ts
+++ b/supabase/functions/gemini-chat/index.ts
@@ -221,6 +221,44 @@ serve(async (req) => {
           )
           break
         }
+        case 'generate_morning_briefing': {
+          const briefingAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+            auth: { autoRefreshToken: false, persistSession: false },
+          })
+          const { buildUserContext } = await import('../_shared/context-builder.ts')
+          const ctx = await buildUserContext(briefingAdmin, userId!, 'coordinator')
+
+          const briefingModel = genAI.getGenerativeModel({
+            model: MODELS.fast,
+            generationConfig: { temperature: 0.7, maxOutputTokens: 4096 },
+          })
+
+          const now = new Date()
+          const hour = now.toLocaleString('pt-BR', { hour: '2-digit', timeZone: 'America/Sao_Paulo' })
+          const today = now.toISOString().split('T')[0]
+          const dow = ['domingo', 'segunda', 'terca', 'quarta', 'quinta', 'sexta', 'sabado'][now.getDay()]
+
+          const briefingPrompt = `Voce e a AICA, assistente pessoal do usuario. Gere um briefing matinal curto e motivacional em portugues.
+
+## Data: ${today} (${dow}), ${hour}h
+
+## Dados do usuario:
+${ctx.contextString}
+
+## Instrucoes:
+- Cumprimente pelo nome se disponivel
+- Mencione quantas tarefas tem para hoje e se alguma esta atrasada
+- Mencione eventos do dia se houver
+- Se tiver Life Score, comente brevemente
+- Maximo 3-4 frases, tom amigavel e energizante
+- Use emojis com moderacao (1-2 no maximo)
+- NAO liste tudo — seja conciso e destaque o mais importante`
+
+          const briefingResult = await briefingModel.generateContent(briefingPrompt)
+          const briefingText = briefingResult.response.text().trim()
+          result = { success: true, briefing: briefingText }
+          break
+        }
         case 'generate_title': {
           const titleMessage = payload?.message || ''
           const titleResponse = (payload?.response || '').substring(0, 200)


### PR DESCRIPTION
## Summary
- **Backend**: New `generate_morning_briefing` action in gemini-chat — fetches user context (tasks, events, Life Score) and generates a concise Portuguese morning greeting
- **Frontend**: `fetchMorningBriefing` in useChatSession — triggers between 6-12h BRT, shows once per day (localStorage dedup), displayed as first assistant message

## Files (2)
- `supabase/functions/gemini-chat/index.ts` — new action handler
- `src/hooks/useChatSession.ts` — briefing trigger + display

## Test plan
- [x] Build passes, 11 tests pass
- [ ] Open chat 6-12h BRT → see personalized briefing
- [ ] Open chat outside 6-12h → no briefing
- [ ] Open chat 2nd time same day → no repeat briefing

🤖 Generated with [Claude Code](https://claude.com/claude-code)